### PR TITLE
ci: Switch to manual releases.

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,14 +1,11 @@
 name: Release
 
 on:
-  push:
-    # Release packages when a tag is created
-    tags:
-      - '*'
+  # Manually release packages
+  workflow_dispatch:
 
 jobs:
   publish:
-    if: ${{ startsWith(github.ref, 'refs/tags/@moonrepo') }}
     name: Publish
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
           TARGET: ${{ matrix.target }}
 
   publish:
-    if: ${{ startsWith(github.ref, 'refs/tags/@moonrepo/cli') }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     name: Publish
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,12 @@ env:
   MACOSX_DEPLOYMENT_TARGET: '10.13'
 
 on:
+  # Manually release cli/core packages
+  workflow_dispatch:
+  # Test on master to ensure PRs are good
   push:
-    # Test on master to ensure PRs are good
     branches:
       - master
-    # Release cli/core packages when a tag is created
-    tags:
-      - '*'
-  schedule:
-    # Test every night to ensure builds are good
-    - cron: '0 10 * * *' # 2am PT, 10am UTC
   # Uncomment to test in PRs (its safe)
   # pull_request:
 

--- a/scripts/release-workflow.md
+++ b/scripts/release-workflow.md
@@ -54,6 +54,8 @@ At this point, the actual "publishing to npm" is done through two GitHub workflo
 - [release-npm.yml](https://github.com/moonrepo/moon/blob/master/.github/workflows/release-npm.yml) -
   This workflow publishes all other npm packages.
 
+Both of these workflows _must be manually triggered_ through GitHub's UI.
+
 ### Handling failed publishes
 
 This hasn't happened yet, so nothing to document. At minimum, re-running the workflows should be our


### PR DESCRIPTION
My last few attempts to release have failed, as the workflow never runs. It turns out that pushing more than 3 tags _does not_ trigger the workflow, wtf! https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push

Moving this to manual dispatches.