### PR TITLE
new: Add language crates.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,6 @@ dependencies = [
 name = "moon_lang"
 version = "0.1.0"
 dependencies = [
- "serde_json",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,7 @@ dependencies = [
  "itertools",
  "moon_cache",
  "moon_config",
+ "moon_lang_node",
  "moon_logger",
  "moon_project",
  "moon_terminal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,6 +1492,7 @@ dependencies = [
  "moon_cache",
  "moon_config",
  "moon_error",
+ "moon_lang_node",
  "moon_logger",
  "moon_project",
  "moon_terminal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,6 +1354,7 @@ dependencies = [
  "figment",
  "json",
  "moon_error",
+ "moon_lang_node",
  "moon_utils",
  "regex",
  "schemars",
@@ -1372,6 +1373,21 @@ version = "0.1.0"
 dependencies = [
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "moon_lang"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "moon_lang_node"
+version = "0.1.0"
+dependencies = [
+ "moon_lang",
 ]
 
 [[package]]
@@ -1427,6 +1443,8 @@ dependencies = [
  "mockito",
  "moon_config",
  "moon_error",
+ "moon_lang",
+ "moon_lang_node",
  "moon_logger",
  "moon_utils",
  "predicates",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,7 @@ dependencies = [
  "itertools",
  "moon_cache",
  "moon_config",
+ "moon_lang",
  "moon_lang_node",
  "moon_logger",
  "moon_project",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 moon_config = { path = "../config" }
+moon_lang = { path = "../lang" }
 moon_lang_node = { path = "../lang-node" }
 moon_logger = { path = "../logger" }
 moon_project = { path = "../project" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 moon_config = { path = "../config" }
+moon_lang_node = { path = "../lang-node" }
 moon_logger = { path = "../logger" }
 moon_project = { path = "../project" }
 moon_terminal = { path = "../terminal" }

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -5,6 +5,7 @@ use moon_config::{
     default_node_version, default_npm_version, default_pnpm_version, default_yarn_version,
     load_global_project_config_template, load_workspace_config_template,
 };
+use moon_lang_node::{NODENV, NVMRC};
 use moon_logger::color;
 use moon_terminal::create_theme;
 use moon_utils::fs;
@@ -126,13 +127,13 @@ async fn detect_package_manager(dest_dir: &Path, yes: bool) -> Result<(String, S
 /// Detect the Node.js version from local configuration files,
 /// otherwise fallback to the configuration default.
 fn detect_node_version(dest_dir: &Path) -> Result<String, AnyError> {
-    let nvmrc_path = dest_dir.join(".nvmrc");
+    let nvmrc_path = dest_dir.join(NVMRC.version_filename);
 
     if nvmrc_path.exists() {
         return Ok(read_to_string(nvmrc_path)?.trim().to_owned());
     }
 
-    let node_version_path = dest_dir.join(".node-version");
+    let node_version_path = dest_dir.join(NODENV.version_filename);
 
     if node_version_path.exists() {
         return Ok(read_to_string(node_version_path)?.trim().to_owned());

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -5,7 +5,8 @@ use moon_config::{
     default_node_version, default_npm_version, default_pnpm_version, default_yarn_version,
     load_global_project_config_template, load_workspace_config_template,
 };
-use moon_lang_node::{NODENV, NVMRC};
+use moon_lang::is_using_package_manager;
+use moon_lang_node::{NODENV, NPM, NVMRC, PNPM, YARN};
 use moon_logger::color;
 use moon_terminal::create_theme;
 use moon_utils::fs;
@@ -72,23 +73,11 @@ async fn detect_package_manager(dest_dir: &Path, yes: bool) -> Result<(String, S
 
     // If no value, detect based on files
     if pm_type.is_empty() {
-        // yarn
-        if dest_dir.join("yarn.lock").exists()
-            || dest_dir.join(".yarn").exists()
-            || dest_dir.join(".yarnrc").exists()
-            || dest_dir.join(".yarnrc.yml").exists()
-        {
+        if is_using_package_manager(dest_dir, &YARN) {
             pm_type = String::from("yarn");
-
-            // pnpm
-        } else if dest_dir.join("pnpm-lock.yaml").exists()
-            || dest_dir.join("pnpm-workspace.yaml").exists()
-            || dest_dir.join(".pnpmfile.cjs").exists()
-        {
+        } else if is_using_package_manager(dest_dir, &PNPM) {
             pm_type = String::from("pnpm");
-
-            // npm
-        } else if dest_dir.join("package-lock.json").exists() {
+        } else if is_using_package_manager(dest_dir, &NPM) {
             pm_type = String::from("npm");
         }
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,6 @@
 use moon_cli::run_cli;
 use moon_config::constants;
+use moon_lang_node::NODE;
 use std::env;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
@@ -84,7 +85,7 @@ async fn main() {
             // locally installed `moon` binary in node modules
             if let Some(workspace_root) = find_workspace_root(&current_dir) {
                 let moon_bin = workspace_root
-                    .join("node_modules")
+                    .join(NODE.vendor_dir)
                     .join("@moonrepo")
                     .join("cli")
                     .join("moon");

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 moon_error = { path = "../error"}
+moon_lang_node = { path = "../lang-node" }
 moon_utils = { path = "../utils"}
 figment = { version = "0.10.6", features = ["test", "yaml"] }
 json = "0.12.4"

--- a/crates/config/src/workspace/node.rs
+++ b/crates/config/src/workspace/node.rs
@@ -1,4 +1,5 @@
 use crate::validators::validate_semver_version;
+use moon_lang_node::NPM;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -14,7 +15,7 @@ pub fn default_npm_version() -> String {
 }
 
 pub fn default_pnpm_version() -> String {
-    env::var("MOON_PNPM_VERSION").unwrap_or_else(|_| String::from("6.32.2"))
+    env::var("MOON_PNPM_VERSION").unwrap_or_else(|_| NPM.default_version.to_string())
 }
 
 pub fn default_yarn_version() -> String {

--- a/crates/config/src/workspace/node.rs
+++ b/crates/config/src/workspace/node.rs
@@ -1,5 +1,5 @@
 use crate::validators::validate_semver_version;
-use moon_lang_node::NPM;
+use moon_lang_node::{NODENV, NVMRC, PNPM, YARN};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -15,11 +15,11 @@ pub fn default_npm_version() -> String {
 }
 
 pub fn default_pnpm_version() -> String {
-    env::var("MOON_PNPM_VERSION").unwrap_or_else(|_| NPM.default_version.to_string())
+    env::var("MOON_PNPM_VERSION").unwrap_or_else(|_| PNPM.default_version.to_string())
 }
 
 pub fn default_yarn_version() -> String {
-    env::var("MOON_YARN_VERSION").unwrap_or_else(|_| String::from("3.2.0"))
+    env::var("MOON_YARN_VERSION").unwrap_or_else(|_| YARN.default_version.to_string())
 }
 
 fn default_bool_true() -> bool {
@@ -70,8 +70,8 @@ pub enum VersionManager {
 impl VersionManager {
     pub fn get_config_file_name(&self) -> String {
         match self {
-            VersionManager::Nodenv => String::from(".node-version"),
-            VersionManager::Nvm => String::from(".nvmrc"),
+            VersionManager::Nodenv => String::from(NODENV.version_filename),
+            VersionManager::Nvm => String::from(NVMRC.version_filename),
         }
     }
 }

--- a/crates/config/src/workspace/node.rs
+++ b/crates/config/src/workspace/node.rs
@@ -1,12 +1,12 @@
 use crate::validators::validate_semver_version;
-use moon_lang_node::{NODENV, NVMRC, PNPM, YARN};
+use moon_lang_node::{NODE, NODENV, NVMRC, PNPM, YARN};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::env;
 use validator::{Validate, ValidationError};
 
 pub fn default_node_version() -> String {
-    env::var("MOON_NODE_VERSION").unwrap_or_else(|_| String::from("16.15.0"))
+    env::var("MOON_NODE_VERSION").unwrap_or_else(|_| NODE.default_version.to_string())
 }
 
 pub fn default_npm_version() -> String {

--- a/crates/config/src/workspace/node.rs
+++ b/crates/config/src/workspace/node.rs
@@ -68,7 +68,7 @@ pub enum VersionManager {
 }
 
 impl VersionManager {
-    pub fn get_config_file_name(&self) -> String {
+    pub fn get_config_filename(&self) -> String {
         match self {
             VersionManager::Nodenv => String::from(NODENV.version_filename),
             VersionManager::Nvm => String::from(NVMRC.version_filename),

--- a/crates/lang-node/Cargo.toml
+++ b/crates/lang-node/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "moon_lang_node"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+moon_lang = { path = "../lang" }

--- a/crates/lang-node/src/lib.rs
+++ b/crates/lang-node/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod node;
+
 use moon_lang::{Language, PackageManager, VersionManager};
 
 pub const NODE: Language = Language {

--- a/crates/lang-node/src/lib.rs
+++ b/crates/lang-node/src/lib.rs
@@ -1,0 +1,36 @@
+use moon_lang::{PackageManager, VersionManager};
+
+// Package managers
+
+pub const NPM: PackageManager = PackageManager {
+    config_filenames: &[".npmrc"],
+    default_version: "8.10.0",
+    lock_filenames: &["package-lock.json", "npm-shrinkwrap.json"],
+    manifest_filename: "package.json",
+};
+
+pub const PNPM: PackageManager = PackageManager {
+    config_filenames: &["pnpm-workspace.yaml", ".pnpmfile.cjs"],
+    default_version: "7.1.5",
+    lock_filenames: &["pnpm-lock.yaml"],
+    manifest_filename: "package.json",
+};
+
+pub const YARN: PackageManager = PackageManager {
+    config_filenames: &[".yarn", ".yarnrc", ".yarnrc.yml"],
+    default_version: "3.2.1",
+    lock_filenames: &["yarn.lock"],
+    manifest_filename: "package.json",
+};
+
+// Version managers
+
+pub const NVMRC: VersionManager = VersionManager {
+    config_filename: None,
+    version_filename: ".nvmrc",
+};
+
+pub const NODENV: VersionManager = VersionManager {
+    config_filename: None,
+    version_filename: ".node-version",
+};

--- a/crates/lang-node/src/lib.rs
+++ b/crates/lang-node/src/lib.rs
@@ -1,4 +1,10 @@
-use moon_lang::{PackageManager, VersionManager};
+use moon_lang::{Language, PackageManager, VersionManager};
+
+pub const NODE: Language = Language {
+    default_version: "16.15.0",
+    vendor_bins_dir: "node_modules/.bin",
+    vendor_dir: "node_modules",
+};
 
 // Package managers
 

--- a/crates/lang-node/src/node.rs
+++ b/crates/lang-node/src/node.rs
@@ -1,0 +1,9 @@
+pub fn get_bin_name_suffix(name: &str, windows_ext: &str, flat: bool) -> String {
+    if cfg!(windows) {
+        format!("{}.{}", name, windows_ext)
+    } else if flat {
+        name.to_owned()
+    } else {
+        format!("bin/{}", name)
+    }
+}

--- a/crates/lang-node/src/node.rs
+++ b/crates/lang-node/src/node.rs
@@ -1,7 +1,14 @@
 use crate::NODE;
 use moon_lang::LangError;
-use std::env::consts;
+use std::env::{self, consts};
 use std::path::{Path, PathBuf};
+
+pub fn extend_node_options_env_var(next: String) -> String {
+    match env::var("NODE_OPTIONS") {
+        Ok(prev) => format!("{} {}", prev, next),
+        Err(_) => next,
+    }
+}
 
 pub fn find_package(starting_dir: &Path, package_name: &str) -> Option<PathBuf> {
     let pkg_path = starting_dir.join(NODE.vendor_dir).join(package_name);

--- a/crates/lang-node/src/node.rs
+++ b/crates/lang-node/src/node.rs
@@ -1,3 +1,6 @@
+use moon_lang::LangError;
+use std::env::consts;
+
 pub fn get_bin_name_suffix(name: &str, windows_ext: &str, flat: bool) -> String {
     if cfg!(windows) {
         format!("{}.{}", name, windows_ext)
@@ -6,4 +9,73 @@ pub fn get_bin_name_suffix(name: &str, windows_ext: &str, flat: bool) -> String 
     } else {
         format!("bin/{}", name)
     }
+}
+
+pub fn get_download_file_ext() -> &'static str {
+    if consts::OS == "windows" {
+        "zip"
+    } else {
+        "tar.gz"
+    }
+}
+
+// #[allow(unused_assignments)]
+pub fn get_download_file_name(version: &str) -> Result<String, LangError> {
+    let platform;
+
+    if consts::OS == "linux" {
+        platform = "linux"
+    } else if consts::OS == "windows" {
+        platform = "win";
+    } else if consts::OS == "macos" {
+        platform = "darwin"
+    } else {
+        return Err(LangError::UnsupportedPlatform(
+            consts::OS.to_string(),
+            String::from("Node.js"),
+        ));
+    }
+
+    let arch;
+
+    if consts::ARCH == "x86" {
+        arch = "x86"
+    } else if consts::ARCH == "x86_64" {
+        arch = "x64"
+    } else if consts::ARCH == "arm" {
+        arch = "arm64"
+    } else if consts::ARCH == "powerpc64" {
+        arch = "ppc64le"
+    } else if consts::ARCH == "s390x" {
+        arch = "s390x"
+    } else {
+        return Err(LangError::UnsupportedArchitecture(
+            consts::ARCH.to_string(),
+            String::from("Node.js"),
+        ));
+    }
+
+    Ok(format!(
+        "node-v{version}-{platform}-{arch}",
+        version = version,
+        platform = platform,
+        arch = arch,
+    ))
+}
+
+pub fn get_download_file(version: &str) -> Result<String, LangError> {
+    Ok(format!(
+        "{}.{}",
+        get_download_file_name(version)?,
+        get_download_file_ext()
+    ))
+}
+
+pub fn get_nodejs_url(version: &str, host: &str, path: &str) -> String {
+    format!(
+        "{host}/dist/v{version}/{path}",
+        host = host,
+        version = version,
+        path = path,
+    )
 }

--- a/crates/lang-node/src/node.rs
+++ b/crates/lang-node/src/node.rs
@@ -1,5 +1,35 @@
+use crate::NODE;
 use moon_lang::LangError;
 use std::env::consts;
+use std::path::{Path, PathBuf};
+
+pub fn find_package(starting_dir: &Path, package_name: &str) -> Option<PathBuf> {
+    let pkg_path = starting_dir.join(NODE.vendor_dir).join(package_name);
+
+    if pkg_path.exists() {
+        return Some(pkg_path);
+    }
+
+    match starting_dir.parent() {
+        Some(dir) => find_package_bin(dir, package_name),
+        None => None,
+    }
+}
+
+pub fn find_package_bin(starting_dir: &Path, package_name: &str) -> Option<PathBuf> {
+    let bin_path = starting_dir
+        .join(NODE.vendor_bins_dir)
+        .join(get_bin_name_suffix(package_name, "cmd", true));
+
+    if bin_path.exists() {
+        return Some(bin_path);
+    }
+
+    match starting_dir.parent() {
+        Some(dir) => find_package_bin(dir, package_name),
+        None => None,
+    }
+}
 
 pub fn get_bin_name_suffix(name: &str, windows_ext: &str, flat: bool) -> String {
     if cfg!(windows) {

--- a/crates/lang/Cargo.toml
+++ b/crates/lang/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "moon_lang"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde_json = { version = "1.0.81", default-features = false }
+thiserror = "1.0.31"

--- a/crates/lang/Cargo.toml
+++ b/crates/lang/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde_json = { version = "1.0.81", default-features = false }
 thiserror = "1.0.31"

--- a/crates/lang/src/error.rs
+++ b/crates/lang/src/error.rs
@@ -1,0 +1,26 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LangError {
+    #[error(
+        "Shashum check has failed for <file>{0}</file>, which was downloaded from <url>{1}</url>."
+    )]
+    InvalidShasum(
+        String, // Download path
+        String, // URL
+    ),
+
+    #[error(
+        "Unsupported architecture <symbol>{0}</symbol>. Unable to install <symbol>{1}</symbol>."
+    )]
+    UnsupportedArchitecture(
+        String, // Arch
+        String, // Tool name
+    ),
+
+    #[error("Unsupported platform <symbol>{0}</symbol>. Unable to install <symbol>{1}</symbol>.")]
+    UnsupportedPlatform(
+        String, // Platform
+        String, // Tool name
+    ),
+}

--- a/crates/lang/src/lib.rs
+++ b/crates/lang/src/lib.rs
@@ -1,3 +1,6 @@
+mod error;
+
+pub use error::LangError;
 use std::path::Path;
 
 pub type StaticString = &'static str;

--- a/crates/lang/src/lib.rs
+++ b/crates/lang/src/lib.rs
@@ -1,0 +1,19 @@
+pub type StaticString = &'static str;
+
+pub type StaticStringList = &'static [StaticString];
+
+pub struct PackageManager {
+    pub config_filenames: StaticStringList,
+
+    pub default_version: StaticString,
+
+    pub lock_filenames: StaticStringList,
+
+    pub manifest_filename: StaticString,
+}
+
+pub struct VersionManager {
+    pub config_filename: Option<StaticString>,
+
+    pub version_filename: StaticString,
+}

--- a/crates/lang/src/lib.rs
+++ b/crates/lang/src/lib.rs
@@ -1,6 +1,16 @@
+use std::path::Path;
+
 pub type StaticString = &'static str;
 
 pub type StaticStringList = &'static [StaticString];
+
+pub struct Language {
+    pub default_version: StaticString,
+
+    pub vendor_bins_dir: StaticString,
+
+    pub vendor_dir: StaticString,
+}
 
 pub struct PackageManager {
     pub config_filenames: StaticStringList,
@@ -16,4 +26,34 @@ pub struct VersionManager {
     pub config_filename: Option<StaticString>,
 
     pub version_filename: StaticString,
+}
+
+pub fn is_using_package_manager(base_dir: &Path, pm: &PackageManager) -> bool {
+    for lockfile in pm.lock_filenames {
+        if base_dir.join(lockfile).exists() {
+            return true;
+        }
+    }
+
+    for config in pm.config_filenames {
+        if base_dir.join(config).exists() {
+            return true;
+        }
+    }
+
+    false
+}
+
+pub fn is_using_version_manager(base_dir: &Path, vm: &VersionManager) -> bool {
+    if base_dir.join(vm.version_filename).exists() {
+        return true;
+    }
+
+    if let Some(config) = vm.config_filename {
+        if base_dir.join(config).exists() {
+            return true;
+        }
+    }
+
+    false
 }

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [dependencies]
 moon_config = { path = "../config" }
 moon_error = { path = "../error" }
+moon_lang = { path = "../lang" }
+moon_lang_node = { path = "../lang-node" }
 moon_logger = { path = "../logger" }
 moon_utils = { path = "../utils" }
 async-trait = "0.1.53"

--- a/crates/toolchain/src/errors.rs
+++ b/crates/toolchain/src/errors.rs
@@ -1,4 +1,5 @@
 use moon_error::MoonError;
+use moon_lang::LangError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -6,33 +7,14 @@ pub enum ToolchainError {
     #[error("Internet connection required, unable to download and install tools.")]
     InternetConnectionRequired,
 
-    #[error(
-        "Shashum check has failed for <file>{0}</file>, which was downloaded from <url>{1}</url>."
-    )]
-    InvalidShasum(
-        String, // Download path
-        String, // URL
-    ),
-
     #[error("Unable to determine your home directory.")]
     MissingHomeDir,
 
     #[error("Unable to find a node module binary for <symbol>{0}</symbol>. Have you installed the corresponding package?")]
     MissingNodeModuleBin(String), // bin name
 
-    #[error(
-        "Unsupported architecture <symbol>{0}</symbol>. Unable to install <symbol>{1}</symbol>."
-    )]
-    UnsupportedArchitecture(
-        String, // Arch
-        String, // Tool name
-    ),
-
-    #[error("Unsupported platform <symbol>{0}</symbol>. Unable to install <symbol>{1}</symbol>.")]
-    UnsupportedPlatform(
-        String, // Platform
-        String, // Tool name
-    ),
+    #[error(transparent)]
+    Lang(#[from] LangError),
 
     #[error(transparent)]
     Moon(#[from] MoonError),

--- a/crates/toolchain/src/helpers.rs
+++ b/crates/toolchain/src/helpers.rs
@@ -12,16 +12,6 @@ use std::path::Path;
 use tar::Archive;
 use zip::ZipArchive;
 
-pub fn get_bin_name_suffix(name: &str, windows_ext: &str, flat: bool) -> String {
-    if cfg!(windows) {
-        format!("{}.{}", name, windows_ext)
-    } else if flat {
-        name.to_owned()
-    } else {
-        format!("bin/{}", name)
-    }
-}
-
 pub async fn get_bin_version(bin: &Path) -> Result<String, ToolchainError> {
     let output = Command::new(bin)
         .arg("--version")

--- a/crates/toolchain/src/pms/npm.rs
+++ b/crates/toolchain/src/pms/npm.rs
@@ -221,7 +221,7 @@ impl PackageManager<NodeTool> for NpmTool {
         exec_args.extend(args);
 
         let bin_dir = toolchain.get_node().get_install_dir()?;
-        let npx_path = bin_dir.join(node::get_bin_name_suffix("npx", "exe", false));
+        let npx_path = bin_dir.join(node::get_bin_name_suffix("npx", "cmd", false));
 
         Command::new(&npx_path)
             .args(exec_args)

--- a/crates/toolchain/src/pms/npm.rs
+++ b/crates/toolchain/src/pms/npm.rs
@@ -233,11 +233,11 @@ impl PackageManager<NodeTool> for NpmTool {
         Ok(())
     }
 
-    fn get_lockfile_name(&self) -> String {
+    fn get_lock_filename(&self) -> String {
         String::from(NPM.lock_filenames[0])
     }
 
-    fn get_manifest_name(&self) -> String {
+    fn get_manifest_filename(&self) -> String {
         String::from(NPM.manifest_filename)
     }
 
@@ -249,7 +249,7 @@ impl PackageManager<NodeTool> for NpmTool {
         let mut args = vec!["install"];
 
         if is_ci() {
-            let lockfile = toolchain.workspace_root.join(self.get_lockfile_name());
+            let lockfile = toolchain.workspace_root.join(self.get_lock_filename());
 
             // npm will error if using `ci` and a lockfile does not exist!
             if lockfile.exists() {

--- a/crates/toolchain/src/pms/npm.rs
+++ b/crates/toolchain/src/pms/npm.rs
@@ -1,11 +1,11 @@
 use crate::errors::ToolchainError;
-use crate::helpers::{get_bin_name_suffix, get_bin_version, get_path_env_var};
+use crate::helpers::{get_bin_version, get_path_env_var};
 use crate::tools::node::NodeTool;
 use crate::traits::{Executable, Installable, Lifecycle, PackageManager};
 use crate::Toolchain;
 use async_trait::async_trait;
 use moon_config::NpmConfig;
-use moon_lang_node::NPM;
+use moon_lang_node::{node, NPM};
 use moon_logger::{color, debug, Logable};
 use moon_utils::is_ci;
 use moon_utils::process::{output_to_trimmed_string, Command};
@@ -28,7 +28,7 @@ impl NpmTool {
         let install_dir = node.get_install_dir()?.clone();
 
         Ok(NpmTool {
-            bin_path: install_dir.join(get_bin_name_suffix("npm", "cmd", false)),
+            bin_path: install_dir.join(node::get_bin_name_suffix("npm", "cmd", false)),
             config: config.to_owned(),
             global_install_dir: None,
             install_dir,
@@ -180,7 +180,7 @@ impl Executable<NodeTool> for NpmTool {
         // If the global has moved, be sure to reference it
         let bin_path = self
             .get_global_dir()?
-            .join(get_bin_name_suffix("npm", "cmd", false));
+            .join(node::get_bin_name_suffix("npm", "cmd", false));
 
         if bin_path.exists() {
             self.bin_path = bin_path;
@@ -221,7 +221,7 @@ impl PackageManager<NodeTool> for NpmTool {
         exec_args.extend(args);
 
         let bin_dir = toolchain.get_node().get_install_dir()?;
-        let npx_path = bin_dir.join(get_bin_name_suffix("npx", "exe", false));
+        let npx_path = bin_dir.join(node::get_bin_name_suffix("npx", "exe", false));
 
         Command::new(&npx_path)
             .args(exec_args)

--- a/crates/toolchain/src/pms/npm.rs
+++ b/crates/toolchain/src/pms/npm.rs
@@ -5,6 +5,7 @@ use crate::traits::{Executable, Installable, Lifecycle, PackageManager};
 use crate::Toolchain;
 use async_trait::async_trait;
 use moon_config::NpmConfig;
+use moon_lang_node::NPM;
 use moon_logger::{color, debug, Logable};
 use moon_utils::is_ci;
 use moon_utils::process::{output_to_trimmed_string, Command};
@@ -233,7 +234,11 @@ impl PackageManager<NodeTool> for NpmTool {
     }
 
     fn get_lockfile_name(&self) -> String {
-        String::from("package-lock.json")
+        String::from(NPM.lock_filenames[0])
+    }
+
+    fn get_manifest_name(&self) -> String {
+        String::from(NPM.manifest_filename)
     }
 
     fn get_workspace_dependency_range(&self) -> String {

--- a/crates/toolchain/src/pms/pnpm.rs
+++ b/crates/toolchain/src/pms/pnpm.rs
@@ -1,11 +1,11 @@
 use crate::errors::ToolchainError;
-use crate::helpers::{get_bin_name_suffix, get_bin_version};
+use crate::helpers::get_bin_version;
 use crate::tools::node::NodeTool;
 use crate::traits::{Executable, Installable, Lifecycle, PackageManager};
 use crate::Toolchain;
 use async_trait::async_trait;
 use moon_config::PnpmConfig;
-use moon_lang_node::PNPM;
+use moon_lang_node::{node, PNPM};
 use moon_logger::{color, debug, Logable};
 use moon_utils::is_ci;
 use std::env;
@@ -25,7 +25,7 @@ impl PnpmTool {
         let install_dir = node.get_install_dir()?.clone();
 
         Ok(PnpmTool {
-            bin_path: install_dir.join(get_bin_name_suffix("pnpm", "cmd", false)),
+            bin_path: install_dir.join(node::get_bin_name_suffix("pnpm", "cmd", false)),
             config: config.to_owned(),
             install_dir,
         })
@@ -122,7 +122,7 @@ impl Executable<NodeTool> for PnpmTool {
         let bin_path = node
             .get_npm()
             .get_global_dir()?
-            .join(get_bin_name_suffix("pnpm", "cmd", false));
+            .join(node::get_bin_name_suffix("pnpm", "cmd", false));
 
         if bin_path.exists() {
             self.bin_path = bin_path;

--- a/crates/toolchain/src/pms/pnpm.rs
+++ b/crates/toolchain/src/pms/pnpm.rs
@@ -5,6 +5,7 @@ use crate::traits::{Executable, Installable, Lifecycle, PackageManager};
 use crate::Toolchain;
 use async_trait::async_trait;
 use moon_config::PnpmConfig;
+use moon_lang_node::PNPM;
 use moon_logger::{color, debug, Logable};
 use moon_utils::is_ci;
 use std::env;
@@ -173,7 +174,11 @@ impl PackageManager<NodeTool> for PnpmTool {
     }
 
     fn get_lockfile_name(&self) -> String {
-        String::from("pnpm-lock.yaml")
+        String::from(PNPM.lock_filenames[0])
+    }
+
+    fn get_manifest_name(&self) -> String {
+        String::from(PNPM.manifest_filename)
     }
 
     fn get_workspace_dependency_range(&self) -> String {

--- a/crates/toolchain/src/pms/pnpm.rs
+++ b/crates/toolchain/src/pms/pnpm.rs
@@ -173,11 +173,11 @@ impl PackageManager<NodeTool> for PnpmTool {
         Ok(())
     }
 
-    fn get_lockfile_name(&self) -> String {
+    fn get_lock_filename(&self) -> String {
         String::from(PNPM.lock_filenames[0])
     }
 
-    fn get_manifest_name(&self) -> String {
+    fn get_manifest_filename(&self) -> String {
         String::from(PNPM.manifest_filename)
     }
 

--- a/crates/toolchain/src/pms/yarn.rs
+++ b/crates/toolchain/src/pms/yarn.rs
@@ -5,6 +5,7 @@ use crate::traits::{Executable, Installable, Lifecycle, PackageManager};
 use crate::Toolchain;
 use async_trait::async_trait;
 use moon_config::YarnConfig;
+use moon_lang_node::YARN;
 use moon_logger::{color, debug, Logable};
 use moon_utils::is_ci;
 use std::env;
@@ -200,7 +201,7 @@ impl PackageManager<NodeTool> for YarnTool {
                     .exec_package(
                         toolchain,
                         "yarn-deduplicate",
-                        vec!["yarn-deduplicate", "yarn.lock"],
+                        vec!["yarn-deduplicate", YARN.lock_filenames[0]],
                     )
                     .await?;
             }
@@ -237,7 +238,11 @@ impl PackageManager<NodeTool> for YarnTool {
     }
 
     fn get_lockfile_name(&self) -> String {
-        String::from("yarn.lock")
+        String::from(YARN.lock_filenames[0])
+    }
+
+    fn get_manifest_name(&self) -> String {
+        String::from(YARN.manifest_filename)
     }
 
     fn get_workspace_dependency_range(&self) -> String {

--- a/crates/toolchain/src/pms/yarn.rs
+++ b/crates/toolchain/src/pms/yarn.rs
@@ -191,7 +191,7 @@ impl PackageManager<NodeTool> for YarnTool {
         if self.is_v1() {
             if toolchain
                 .workspace_root
-                .join(self.get_lockfile_name())
+                .join(self.get_lock_filename())
                 .exists()
             {
                 // Will error if the lockfile does not exist!
@@ -237,11 +237,11 @@ impl PackageManager<NodeTool> for YarnTool {
         Ok(())
     }
 
-    fn get_lockfile_name(&self) -> String {
+    fn get_lock_filename(&self) -> String {
         String::from(YARN.lock_filenames[0])
     }
 
-    fn get_manifest_name(&self) -> String {
+    fn get_manifest_filename(&self) -> String {
         String::from(YARN.manifest_filename)
     }
 

--- a/crates/toolchain/src/pms/yarn.rs
+++ b/crates/toolchain/src/pms/yarn.rs
@@ -1,11 +1,11 @@
 use crate::errors::ToolchainError;
-use crate::helpers::{get_bin_name_suffix, get_bin_version};
+use crate::helpers::get_bin_version;
 use crate::tools::node::NodeTool;
 use crate::traits::{Executable, Installable, Lifecycle, PackageManager};
 use crate::Toolchain;
 use async_trait::async_trait;
 use moon_config::YarnConfig;
-use moon_lang_node::YARN;
+use moon_lang_node::{node, YARN};
 use moon_logger::{color, debug, Logable};
 use moon_utils::is_ci;
 use std::env;
@@ -25,7 +25,7 @@ impl YarnTool {
         let install_dir = node.get_install_dir()?.clone();
 
         Ok(YarnTool {
-            bin_path: install_dir.join(get_bin_name_suffix("yarn", "cmd", false)),
+            bin_path: install_dir.join(node::get_bin_name_suffix("yarn", "cmd", false)),
             config: config.to_owned(),
             install_dir,
         })
@@ -165,7 +165,7 @@ impl Executable<NodeTool> for YarnTool {
         let bin_path = node
             .get_npm()
             .get_global_dir()?
-            .join(get_bin_name_suffix("yarn", "cmd", false));
+            .join(node::get_bin_name_suffix("yarn", "cmd", false));
 
         if bin_path.exists() {
             self.bin_path = bin_path;

--- a/crates/toolchain/src/tools/node.rs
+++ b/crates/toolchain/src/tools/node.rs
@@ -1,7 +1,6 @@
 use crate::errors::ToolchainError;
 use crate::helpers::{
-    download_file_from_url, get_bin_name_suffix, get_bin_version, get_file_sha256_hash,
-    get_path_env_var, unpack,
+    download_file_from_url, get_bin_version, get_file_sha256_hash, get_path_env_var, unpack,
 };
 use crate::pms::npm::NpmTool;
 use crate::pms::pnpm::PnpmTool;
@@ -12,7 +11,7 @@ use async_trait::async_trait;
 use moon_config::constants::CONFIG_DIRNAME;
 use moon_config::NodeConfig;
 use moon_error::map_io_to_fs_error;
-use moon_lang_node::NODE;
+use moon_lang_node::{node, NODE};
 use moon_logger::{color, debug, error, Logable};
 use moon_utils::fs;
 use moon_utils::process::Command;
@@ -138,7 +137,7 @@ impl NodeTool {
         let install_dir = toolchain.tools_dir.join("node").join(&config.version);
 
         let mut node = NodeTool {
-            bin_path: install_dir.join(get_bin_name_suffix("node", "exe", false)),
+            bin_path: install_dir.join(node::get_bin_name_suffix("node", "cmd", false)),
             config: config.to_owned(),
             download_path: toolchain
                 .temp_dir
@@ -170,7 +169,7 @@ impl NodeTool {
     {
         let corepack_path = self
             .install_dir
-            .join(get_bin_name_suffix("corepack", "cmd", false));
+            .join(node::get_bin_name_suffix("corepack", "cmd", false));
 
         Command::new(&corepack_path)
             .args(args)
@@ -188,7 +187,7 @@ impl NodeTool {
     ) -> Result<PathBuf, ToolchainError> {
         let bin_path = starting_dir
             .join(NODE.vendor_bins_dir)
-            .join(get_bin_name_suffix(package_name, "cmd", true));
+            .join(node::get_bin_name_suffix(package_name, "cmd", true));
 
         if bin_path.exists() {
             return Ok(bin_path);

--- a/crates/toolchain/src/tools/node.rs
+++ b/crates/toolchain/src/tools/node.rs
@@ -67,7 +67,7 @@ impl NodeTool {
         let install_dir = toolchain.tools_dir.join("node").join(&config.version);
 
         let mut node = NodeTool {
-            bin_path: install_dir.join(node::get_bin_name_suffix("node", "cmd", false)),
+            bin_path: install_dir.join(node::get_bin_name_suffix("node", "exe", false)),
             config: config.to_owned(),
             download_path: toolchain
                 .temp_dir

--- a/crates/toolchain/src/tools/node.rs
+++ b/crates/toolchain/src/tools/node.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use moon_config::constants::CONFIG_DIRNAME;
 use moon_config::NodeConfig;
 use moon_error::map_io_to_fs_error;
+use moon_lang_node::NODE;
 use moon_logger::{color, debug, error, Logable};
 use moon_utils::fs;
 use moon_utils::process::Command;
@@ -186,8 +187,7 @@ impl NodeTool {
         starting_dir: &Path,
     ) -> Result<PathBuf, ToolchainError> {
         let bin_path = starting_dir
-            .join("node_modules")
-            .join(".bin")
+            .join(NODE.vendor_bins_dir)
             .join(get_bin_name_suffix(package_name, "cmd", true));
 
         if bin_path.exists() {

--- a/crates/toolchain/src/traits.rs
+++ b/crates/toolchain/src/traits.rs
@@ -226,10 +226,10 @@ pub trait PackageManager<T: Send + Sync>:
     ) -> Result<(), ToolchainError>;
 
     /// Return the name of the lockfile.
-    fn get_lockfile_name(&self) -> String;
+    fn get_lock_filename(&self) -> String;
 
     /// Return the name of the manifest.
-    fn get_manifest_name(&self) -> String;
+    fn get_manifest_filename(&self) -> String;
 
     /// Return the dependency range to use when linking local workspace packages.
     fn get_workspace_dependency_range(&self) -> String;

--- a/crates/toolchain/src/traits.rs
+++ b/crates/toolchain/src/traits.rs
@@ -229,9 +229,7 @@ pub trait PackageManager<T: Send + Sync>:
     fn get_lockfile_name(&self) -> String;
 
     /// Return the name of the manifest.
-    fn get_manifest_name(&self) -> String {
-        String::from("package.json")
-    }
+    fn get_manifest_name(&self) -> String;
 
     /// Return the dependency range to use when linking local workspace packages.
     fn get_workspace_dependency_range(&self) -> String;

--- a/crates/toolchain/tests/node_test.rs
+++ b/crates/toolchain/tests/node_test.rs
@@ -1,5 +1,5 @@
 use moon_config::WorkspaceConfig;
-use moon_toolchain::helpers::get_bin_name_suffix;
+use moon_lang_node::node;
 use moon_toolchain::{Downloadable, Executable, Installable, Toolchain};
 use predicates::prelude::*;
 use std::env;
@@ -49,7 +49,7 @@ async fn generates_paths() {
         .join("tools")
         .join("node")
         .join("1.0.0")
-        .join(get_bin_name_suffix("node", "exe", false));
+        .join(node::get_bin_name_suffix("node", "exe", false));
 
     assert!(predicates::str::ends_with(bin_path.to_str().unwrap())
         .eval(node.get_bin_path().to_str().unwrap()));

--- a/crates/toolchain/tests/npm_test.rs
+++ b/crates/toolchain/tests/npm_test.rs
@@ -1,5 +1,5 @@
 use moon_config::WorkspaceConfig;
-use moon_toolchain::helpers::get_bin_name_suffix;
+use moon_lang_node::node;
 use moon_toolchain::{Executable, Installable, Toolchain};
 use predicates::prelude::*;
 use std::env;
@@ -39,7 +39,7 @@ async fn generates_paths() {
         .join("tools")
         .join("node")
         .join("1.0.0")
-        .join(get_bin_name_suffix("npm", "cmd", false));
+        .join(node::get_bin_name_suffix("npm", "cmd", false));
 
     assert!(predicates::str::ends_with(bin_path.to_str().unwrap())
         .eval(npm.get_bin_path().to_str().unwrap()));

--- a/crates/toolchain/tests/pnpm_test.rs
+++ b/crates/toolchain/tests/pnpm_test.rs
@@ -1,5 +1,5 @@
 use moon_config::{PackageManager, PnpmConfig, WorkspaceConfig};
-use moon_toolchain::helpers::get_bin_name_suffix;
+use moon_lang_node::node;
 use moon_toolchain::{Executable, Installable, Toolchain};
 use predicates::prelude::*;
 use std::env;
@@ -42,7 +42,7 @@ async fn generates_paths() {
         .join("tools")
         .join("node")
         .join("1.0.0")
-        .join(get_bin_name_suffix("pnpm", "cmd", false));
+        .join(node::get_bin_name_suffix("pnpm", "cmd", false));
 
     assert!(predicates::str::ends_with(bin_path.to_str().unwrap())
         .eval(pnpm.get_bin_path().to_str().unwrap()));

--- a/crates/toolchain/tests/yarn_test.rs
+++ b/crates/toolchain/tests/yarn_test.rs
@@ -1,5 +1,5 @@
 use moon_config::{PackageManager, WorkspaceConfig, YarnConfig};
-use moon_toolchain::helpers::get_bin_name_suffix;
+use moon_lang_node::node;
 use moon_toolchain::{Executable, Installable, Toolchain};
 use predicates::prelude::*;
 use std::env;
@@ -42,7 +42,7 @@ async fn generates_paths() {
         .join("tools")
         .join("node")
         .join("1.0.0")
-        .join(get_bin_name_suffix("yarn", "cmd", false));
+        .join(node::get_bin_name_suffix("yarn", "cmd", false));
 
     assert!(predicates::str::ends_with(bin_path.to_str().unwrap())
         .eval(yarn.get_bin_path().to_str().unwrap()));

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 moon_cache = { path = "../cache" }
 moon_config = { path = "../config" }
 moon_error = { path = "../error" }
+moon_lang_node = { path = "../lang-node" }
 moon_logger = { path = "../logger" }
 moon_project = { path = "../project" }
 moon_terminal = { path = "../terminal" }

--- a/crates/workspace/src/actions/install_node_deps.rs
+++ b/crates/workspace/src/actions/install_node_deps.rs
@@ -82,7 +82,7 @@ pub async fn install_node_deps(
 
         // Create nvm/nodenv config file
         if let Some(version_manager) = &node_config.sync_version_manager_config {
-            let rc_name = version_manager.get_config_file_name();
+            let rc_name = version_manager.get_config_filename();
             let rc_path = workspace.root.join(&rc_name);
 
             fs::write(&rc_path, &node_config.version).await?;
@@ -95,7 +95,7 @@ pub async fn install_node_deps(
         }
 
         // Get the last modified time of the root lockfile
-        let lockfile = workspace.root.join(manager.get_lockfile_name());
+        let lockfile = workspace.root.join(manager.get_lock_filename());
         let mut last_modified = 0;
 
         if lockfile.exists() {

--- a/crates/workspace/src/actions/run_target.rs
+++ b/crates/workspace/src/actions/run_target.rs
@@ -131,6 +131,8 @@ fn create_node_target_command(
     project: &Project,
     task: &Task,
 ) -> Result<Command, WorkspaceError> {
+    use moon_lang_node::node;
+
     let node = workspace.toolchain.get_node();
 
     let cmd = match task.command.as_str() {
@@ -151,7 +153,10 @@ fn create_node_target_command(
             "PATH",
             get_path_env_var(node.get_bin_path().parent().unwrap()),
         )
-        .env("NODE_OPTIONS", create_node_options(task).join(" "));
+        .env(
+            "NODE_OPTIONS",
+            node::extend_node_options_env_var(create_node_options(task).join(" ")),
+        );
 
     Ok(command)
 }

--- a/crates/workspace/src/actions/run_target.rs
+++ b/crates/workspace/src/actions/run_target.rs
@@ -103,7 +103,7 @@ fn create_node_target_command(
             cmd = node.get_yarn().unwrap().get_bin_path();
         }
         bin => {
-            let bin_path = node.find_package_bin_path(bin, &project.root)?;
+            let bin_path = node.find_package_bin(bin, &project.root)?;
 
             args.extend(create_node_options(task));
             args.push(path::path_to_string(&bin_path)?);
@@ -138,7 +138,7 @@ fn create_node_target_command(
         "npm" => node.get_npm().get_bin_path().clone(),
         "pnpm" => node.get_pnpm().unwrap().get_bin_path().clone(),
         "yarn" => node.get_yarn().unwrap().get_bin_path().clone(),
-        bin => node.find_package_bin_path(bin, &project.root)?,
+        bin => node.find_package_bin(bin, &project.root)?,
     };
 
     // Create the command


### PR DESCRIPTION
This PR adds language based crates, starting with Node.js. I wanted a place that stored all metadata and utils unique to the language, its package managers, and any version managers.

The other crates like toolchain and config then utilize this.