### PR TITLE
fix: Remove os/arch/etc from CLI package.

### DIFF
--- a/.yarn/versions/cb91120d.yml
+++ b/.yarn/versions/cb91120d.yml
@@ -1,0 +1,7 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,19 +8,6 @@
     "cli",
     "core"
   ],
-  "os": [
-    "linux",
-    "win32",
-    "darwin"
-  ],
-  "cpu": [
-    "arm64",
-    "x64"
-  ],
-  "libc": [
-    "glibc",
-    "musl"
-  ],
   "files": [
     "moon",
     "postinstall.js"


### PR DESCRIPTION
While this worked for npm, this breaks Yarn 2 since it filters packages that don't align.