### PR TITLE
new: Support globs for `.moon/workspace.yml` `projects`.

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -8,8 +8,10 @@ node:
   addEnginesConstraint: false
 
 projects:
-  runtime: 'packages/runtime'
-  website: 'website'
+  - 'packages/*'
+  - 'website'
+  # runtime: 'packages/runtime'
+  # website: 'website'
 
 vcs:
   defaultBranch: 'master'

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -9,6 +9,7 @@ node:
 
 projects:
   - 'packages/*'
+  - '!packages/cli'
   - '!packages/core-*'
   - 'website'
   # runtime: 'packages/runtime'

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -9,6 +9,7 @@ node:
 
 projects:
   - 'packages/*'
+  - '!packages/core-*'
   - 'website'
   # runtime: 'packages/runtime'
   # website: 'website'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,11 +1310,9 @@ dependencies = [
  "moon_config",
  "moon_error",
  "moon_logger",
- "moon_project",
  "moon_utils",
  "serde",
  "serial_test",
- "sha2",
  "tokio",
 ]
 
@@ -1377,6 +1375,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "moon_hasher"
+version = "0.1.0"
+dependencies = [
+ "moon_config",
+ "moon_project",
+ "moon_utils",
+ "serde",
+ "sha2",
+]
+
+[[package]]
 name = "moon_lang"
 version = "0.1.0"
 dependencies = [
@@ -1408,6 +1417,7 @@ dependencies = [
  "common-path",
  "insta",
  "itertools",
+ "moon_cache",
  "moon_config",
  "moon_error",
  "moon_logger",
@@ -1490,6 +1500,7 @@ dependencies = [
  "moon_cache",
  "moon_config",
  "moon_error",
+ "moon_hasher",
  "moon_lang_node",
  "moon_logger",
  "moon_project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,6 +1307,7 @@ name = "moon_cache"
 version = "0.1.0"
 dependencies = [
  "assert_fs",
+ "filetime",
  "moon_config",
  "moon_error",
  "moon_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "brownstone"
-version = "1.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ea61398f34f1395ccbeb046fb68c87b631d1f34567fed0f0f11fa35d18d8d"
+checksum = "c5839ee4f953e811bfdcf223f509cb2c6a3e1447959b0bff459405575bc17f22"
 dependencies = [
  "arrayvec",
 ]
@@ -1544,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "nom-supreme"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadc66631948f6b65da03be4c4cd8bd104d481697ecbb9bbd65719b1ec60bc9f"
+checksum = "2bd3ae6c901f1959588759ff51c95d24b491ecb9ff91aa9c2ef4acc5b1dcab27"
 dependencies = [
  "brownstone",
  "indent_write",
@@ -2947,9 +2947,9 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wax"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a4ecdf7da7e42385f844503bac3e9a2a066838e3cb66c5f28ce03bafb2f90d"
+checksum = "06c7a3bac6110ac062b7b422a442b7ee23e07209e2784a036654cab1e71bbafc"
 dependencies = [
  "bstr",
  "const_format",

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -7,10 +7,8 @@ edition = "2021"
 moon_config = { path = "../config"}
 moon_error = { path = "../error"}
 moon_logger = { path = "../logger"}
-moon_project = { path = "../project"}
 moon_utils = { path = "../utils"}
 serde = { version = "1.0.137", features = ["derive"] }
-sha2 = "0.10.2"
 
 [dev-dependencies]
 assert_fs = "1.0.7"

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -12,5 +12,6 @@ serde = { version = "1.0.137", features = ["derive"] }
 
 [dev-dependencies]
 assert_fs = "1.0.7"
+filetime = "0.2.16"
 tokio = { version = "1.18.2", features = ["test-util"] }
 serial_test = "0.6.0"

--- a/crates/cache/src/engine.rs
+++ b/crates/cache/src/engine.rs
@@ -177,7 +177,7 @@ impl CacheEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::helpers::run_with_env;
+    use crate::helpers::{run_with_env, to_millis};
     use assert_fs::prelude::*;
     use serial_test::serial;
     use std::fs;
@@ -587,6 +587,140 @@ mod tests {
             assert_eq!(
                 fs::read_to_string(item.path).unwrap(),
                 r#"{"lastNodeInstallTime":123,"lastVersionCheckTime":0}"#
+            );
+
+            dir.close().unwrap();
+        }
+    }
+
+    mod cache_projects_state {
+        use super::*;
+        use filetime::{set_file_mtime, FileTime};
+        use moon_utils::string_vec;
+        use std::collections::HashMap;
+        use std::time::SystemTime;
+
+        #[tokio::test]
+        #[serial]
+        async fn creates_parent_dir_on_call() {
+            let dir = assert_fs::TempDir::new().unwrap();
+            let cache = CacheEngine::create(dir.path()).await.unwrap();
+            let item = cache.cache_projects_state().await.unwrap();
+
+            assert!(!item.path.exists());
+            assert!(item.path.parent().unwrap().exists());
+
+            dir.close().unwrap();
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn loads_cache_if_it_exists() {
+            let dir = assert_fs::TempDir::new().unwrap();
+
+            dir.child(".moon/cache/projectsState.json")
+                .write_str(r#"{"globs":["**/*"],"projects":{"foo":"bar"}}"#)
+                .unwrap();
+
+            let cache = CacheEngine::create(dir.path()).await.unwrap();
+            let item = cache.cache_projects_state().await.unwrap();
+
+            assert_eq!(
+                item.item,
+                ProjectsState {
+                    globs: string_vec!["**/*"],
+                    projects: HashMap::from([("foo".to_owned(), "bar".to_owned())]),
+                }
+            );
+
+            dir.close().unwrap();
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn loads_cache_if_it_exists_and_cache_is_readonly() {
+            let dir = assert_fs::TempDir::new().unwrap();
+
+            dir.child(".moon/cache/projectsState.json")
+                .write_str(r#"{"globs":["**/*"],"projects":{"foo":"bar"}}"#)
+                .unwrap();
+
+            let cache = CacheEngine::create(dir.path()).await.unwrap();
+            let item = run_with_env("read", || cache.cache_projects_state())
+                .await
+                .unwrap();
+
+            assert_eq!(
+                item.item,
+                ProjectsState {
+                    globs: string_vec!["**/*"],
+                    projects: HashMap::from([("foo".to_owned(), "bar".to_owned())]),
+                }
+            );
+
+            dir.close().unwrap();
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn doesnt_load_if_it_exists_but_cache_is_off() {
+            let dir = assert_fs::TempDir::new().unwrap();
+
+            dir.child(".moon/cache/projectsState.json")
+                .write_str(r#"{"globs":[],"projects":{"foo":"bar"}}"#)
+                .unwrap();
+
+            let cache = CacheEngine::create(dir.path()).await.unwrap();
+            let item = run_with_env("off", || cache.cache_projects_state())
+                .await
+                .unwrap();
+
+            assert_eq!(item.item, ProjectsState::default());
+
+            dir.close().unwrap();
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn doesnt_load_if_it_exists_but_cache_is_stale() {
+            let dir = assert_fs::TempDir::new().unwrap();
+
+            dir.child(".moon/cache/projectsState.json")
+                .write_str(r#"{"globs":[],"projects":{"foo":"bar"}}"#)
+                .unwrap();
+
+            let now = to_millis(SystemTime::now()) - 100000;
+
+            set_file_mtime(
+                dir.path().join(".moon/cache/projectsState.json"),
+                FileTime::from_unix_time((now / 1000) as i64, 0),
+            )
+            .unwrap();
+
+            let cache = CacheEngine::create(dir.path()).await.unwrap();
+            let item = cache.cache_projects_state().await.unwrap();
+
+            assert_eq!(item.item, ProjectsState::default());
+
+            dir.close().unwrap();
+        }
+
+        #[tokio::test]
+        #[serial]
+        async fn saves_to_cache() {
+            let dir = assert_fs::TempDir::new().unwrap();
+            let cache = CacheEngine::create(dir.path()).await.unwrap();
+            let mut item = cache.cache_projects_state().await.unwrap();
+
+            item.item
+                .projects
+                .insert("foo".to_owned(), "bar".to_owned());
+
+            run_with_env("", || item.save()).await.unwrap();
+
+            assert_eq!(
+                fs::read_to_string(item.path).unwrap(),
+                r#"{"globs":[],"projects":{"foo":"bar"}}"#
             );
 
             dir.close().unwrap();

--- a/crates/cache/src/engine.rs
+++ b/crates/cache/src/engine.rs
@@ -63,6 +63,7 @@ impl CacheEngine {
                 target: String::from(target_id),
                 ..RunTargetState::default()
             },
+            0,
         )
         .await
     }
@@ -71,6 +72,7 @@ impl CacheEngine {
         CacheItem::load(
             self.dir.join("projectsState.json"),
             ProjectsState::default(),
+            90000, // Cache for 3 minutes
         )
         .await
     }
@@ -79,6 +81,7 @@ impl CacheEngine {
         CacheItem::load(
             self.dir.join("workspaceState.json"),
             WorkspaceState::default(),
+            0,
         )
         .await
     }

--- a/crates/cache/src/engine.rs
+++ b/crates/cache/src/engine.rs
@@ -165,7 +165,7 @@ impl CacheEngine {
         if is_writable() {
             let path = self.hashes_dir.join(format!("{}.json", hash));
 
-            trace!(target: "moon:cache:hash", "Creating hash {}", color::path(&path));
+            trace!(target: "moon:cache:hash", "Writing hash {}", color::path(&path));
 
             fs::write_json(&path, &hasher, true).await?;
         }

--- a/crates/cache/src/engine.rs
+++ b/crates/cache/src/engine.rs
@@ -1,6 +1,6 @@
 use crate::hasher::Hasher;
 use crate::helpers::{is_writable, LOG_TARGET};
-use crate::items::{CacheItem, RunTargetState, WorkspaceState};
+use crate::items::{CacheItem, ProjectsState, RunTargetState, WorkspaceState};
 use crate::runfiles::CacheRunfile;
 use moon_config::constants::CONFIG_DIRNAME;
 use moon_error::MoonError;
@@ -64,6 +64,14 @@ impl CacheEngine {
                 target: String::from(target_id),
                 ..RunTargetState::default()
             },
+        )
+        .await
+    }
+
+    pub async fn cache_projects_state(&self) -> Result<CacheItem<ProjectsState>, MoonError> {
+        CacheItem::load(
+            self.dir.join("projectsState.json"),
+            ProjectsState::default(),
         )
         .await
     }

--- a/crates/cache/src/helpers.rs
+++ b/crates/cache/src/helpers.rs
@@ -1,5 +1,6 @@
 use moon_logger::warn;
 use std::env;
+use std::time::SystemTime;
 
 pub const LOG_TARGET: &str = "moon:cache";
 
@@ -34,6 +35,13 @@ pub fn is_readable() -> bool {
 
 pub fn is_writable() -> bool {
     get_cache_env_var() == "write"
+}
+
+pub fn to_millis(time: SystemTime) -> u128 {
+    match time.duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(d) => d.as_millis(),
+        Err(_) => 0,
+    }
 }
 
 #[cfg(test)]

--- a/crates/cache/src/items.rs
+++ b/crates/cache/src/items.rs
@@ -4,6 +4,7 @@ use moon_logger::{color, trace};
 use moon_utils::fs;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -69,6 +70,13 @@ pub struct RunTargetState {
     pub stdout: String,
 
     pub target: String,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectsState {
+    #[serde(default)]
+    pub projects: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Serialize)]

--- a/crates/cache/src/items.rs
+++ b/crates/cache/src/items.rs
@@ -1,4 +1,4 @@
-use crate::helpers::{is_readable, is_writable};
+use crate::helpers::{is_readable, is_writable, to_millis};
 use moon_error::MoonError;
 use moon_logger::{color, trace};
 use moon_utils::fs;
@@ -9,13 +9,6 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 const LOG_TARGET: &str = "moon:cache:item";
-
-fn to_millis(time: SystemTime) -> u128 {
-    match time.duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(d) => d.as_millis(),
-        Err(_) => 0,
-    }
-}
 
 #[derive(Debug)]
 pub struct CacheItem<T: DeserializeOwned + Serialize> {

--- a/crates/cache/src/items.rs
+++ b/crates/cache/src/items.rs
@@ -4,7 +4,7 @@ use moon_logger::{color, trace};
 use moon_utils::fs;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -76,7 +76,7 @@ pub struct RunTargetState {
 #[serde(rename_all = "camelCase")]
 pub struct ProjectsState {
     #[serde(default)]
-    pub projects: BTreeMap<String, String>,
+    pub projects: HashMap<String, String>,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Serialize)]

--- a/crates/cache/src/items.rs
+++ b/crates/cache/src/items.rs
@@ -111,6 +111,9 @@ pub struct RunTargetState {
 #[serde(rename_all = "camelCase")]
 pub struct ProjectsState {
     #[serde(default)]
+    pub globs: Vec<String>,
+
+    #[serde(default)]
     pub projects: HashMap<String, String>,
 }
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -1,10 +1,8 @@
 mod engine;
-mod hasher;
 mod helpers;
 mod items;
 mod runfiles;
 
 pub use engine::CacheEngine;
-pub use hasher::Hasher;
 pub use helpers::*;
 pub use items::*;

--- a/crates/cache/src/runfiles.rs
+++ b/crates/cache/src/runfiles.rs
@@ -14,7 +14,7 @@ impl CacheRunfile {
         path: PathBuf,
         data: &T,
     ) -> Result<CacheRunfile, MoonError> {
-        trace!(target: "moon:cache:runfile", "Creating runfile {}", color::path(&path));
+        trace!(target: "moon:cache:runfile", "Writing runfile {}", color::path(&path));
 
         fs::create_dir_all(path.parent().unwrap()).await?;
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,7 +29,7 @@ indicatif = "0.16.2"
 itertools = "0.10.3"
 strum = "0.24.0"
 strum_macros = "0.24.0"
-tera = "1.15.0"
+tera = { version = "1.15.0", features = ["preserve_order"] }
 tokio = { version = "1.18.2", features = ["full"] }
 
 [dev-dependencies]

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -1,6 +1,7 @@
 // https://github.com/clap-rs/clap/tree/master/examples/derive_ref#app-attributes
 
 use crate::commands::bin::BinTools;
+use crate::commands::init::{InheritProjectsAs, PackageManager};
 use crate::commands::run::RunStatus;
 use crate::enums::{CacheMode, LogLevel};
 use clap::{Parser, Subcommand};
@@ -19,7 +20,8 @@ pub enum Commands {
     // moon init
     #[clap(
         name = "init",
-        about = "Initialize a new moon repository and scaffold config files."
+        about = "Initialize a new moon repository and scaffold config files.",
+        rename_all = "camelCase"
     )]
     Init {
         #[clap(help = "Destination to initialize in", default_value = ".")]
@@ -30,6 +32,22 @@ pub enum Commands {
 
         #[clap(long, help = "Skip prompts and use default values")]
         yes: bool,
+
+        #[clap(
+            arg_enum,
+            long,
+            help = "Inherit projects from `package.json` workspaces as",
+            default_value_t
+        )]
+        inherit_projects: InheritProjectsAs,
+
+        #[clap(
+            arg_enum,
+            long,
+            help = "Package manager to configure and use",
+            default_value_t
+        )]
+        package_manager: PackageManager,
     },
 
     // moon bin <tool>

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -30,13 +30,10 @@ pub enum Commands {
         #[clap(long, help = "Overwrite existing configurations")]
         force: bool,
 
-        #[clap(long, help = "Skip prompts and use default values")]
-        yes: bool,
-
         #[clap(
             arg_enum,
             long,
-            help = "Inherit projects from `package.json` workspaces as",
+            help = "Inherit projects from `package.json` workspaces",
             default_value_t
         )]
         inherit_projects: InheritProjectsAs,
@@ -48,6 +45,9 @@ pub enum Commands {
             default_value_t
         )]
         package_manager: PackageManager,
+
+        #[clap(long, help = "Skip prompts and use default values")]
+        yes: bool,
     },
 
     // moon bin <tool>

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -1,3 +1,4 @@
+use clap::ArgEnum;
 use dialoguer::{Confirm, Select};
 use moon_config::constants::{CONFIG_DIRNAME, CONFIG_PROJECT_FILENAME, CONFIG_WORKSPACE_FILENAME};
 use moon_config::package::{PackageJson, Workspaces};
@@ -8,31 +9,84 @@ use moon_config::{
 use moon_lang::is_using_package_manager;
 use moon_lang_node::{NODENV, NPM, NVMRC, PNPM, YARN};
 use moon_logger::color;
-use moon_project::{detect_projects_with_globs, ProjectsSourceMap};
+use moon_project::detect_projects_with_globs;
 use moon_terminal::create_theme;
 use moon_utils::{fs, path};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::fs::{read_to_string, OpenOptions};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use tera::{Context, Tera};
 
+#[derive(ArgEnum, Clone, Debug)]
+pub enum PackageManager {
+    Npm,
+    Pnpm,
+    Yarn,
+}
+
+impl PackageManager {
+    fn get_option_index(&self) -> usize {
+        match self {
+            PackageManager::Npm => 0,
+            PackageManager::Pnpm => 1,
+            PackageManager::Yarn => 2,
+        }
+    }
+}
+
+impl Default for PackageManager {
+    fn default() -> Self {
+        PackageManager::Npm
+    }
+}
+
+#[derive(ArgEnum, Clone, Debug)]
+pub enum InheritProjectsAs {
+    None,
+    GlobsList,
+    ProjectsMap,
+}
+
+impl InheritProjectsAs {
+    fn get_option_index(&self) -> usize {
+        match self {
+            InheritProjectsAs::None => 0,
+            InheritProjectsAs::GlobsList => 1,
+            InheritProjectsAs::ProjectsMap => 2,
+        }
+    }
+}
+
+impl Default for InheritProjectsAs {
+    fn default() -> Self {
+        InheritProjectsAs::None
+    }
+}
+
+pub struct InitOptions {
+    pub force: bool,
+    pub inherit_projects: InheritProjectsAs,
+    pub package_manager: PackageManager,
+    pub yes: bool,
+}
+
 type AnyError = Box<dyn std::error::Error>;
 
 /// Verify the destination and return a path to the `.moon` folder
 /// if all questions have passed.
-fn verify_dest_dir(dest_dir: &Path, yes: bool, force: bool) -> Result<Option<PathBuf>, AnyError> {
+fn verify_dest_dir(dest_dir: &Path, options: &InitOptions) -> Result<Option<PathBuf>, AnyError> {
     let theme = create_theme();
 
-    if yes
+    if options.yes
         || Confirm::with_theme(&theme)
             .with_prompt(format!("Initialize moon into {}?", color::path(dest_dir)))
             .interact()?
     {
         let moon_dir = dest_dir.join(CONFIG_DIRNAME);
 
-        if !force
+        if !options.force
             && moon_dir.exists()
             && !Confirm::with_theme(&theme)
                 .with_prompt("Moon has already been initialized, overwrite it?")
@@ -49,7 +103,10 @@ fn verify_dest_dir(dest_dir: &Path, yes: bool, force: bool) -> Result<Option<Pat
 
 /// Verify the package manager to use. If a `package.json` exists,
 /// and the `packageManager` field is defined, use that.
-async fn detect_package_manager(dest_dir: &Path, yes: bool) -> Result<(String, String), AnyError> {
+async fn detect_package_manager(
+    dest_dir: &Path,
+    options: &InitOptions,
+) -> Result<(String, String), AnyError> {
     let pkg_path = dest_dir.join("package.json");
     let mut pm_type = String::new();
     let mut pm_version = String::new();
@@ -83,19 +140,21 @@ async fn detect_package_manager(dest_dir: &Path, yes: bool) -> Result<(String, S
 
     // If no value again, ask for explicit input
     if pm_type.is_empty() {
-        if yes {
-            pm_type = String::from("npm");
+        let items = vec!["npm", "pnpm", "yarn"];
+        let default_index = options.package_manager.get_option_index();
+
+        let index = if options.yes {
+            default_index
         } else {
-            let items = vec!["npm", "pnpm", "yarn"];
-            let index = Select::with_theme(&create_theme())
+            Select::with_theme(&create_theme())
                 .with_prompt("Which package manager?")
                 .items(&items)
-                .default(0)
+                .default(default_index)
                 .interact_opt()?
-                .unwrap_or(0);
+                .unwrap_or(default_index)
+        };
 
-            pm_type = String::from(items[index]);
-        }
+        pm_type = String::from(items[index]);
     }
 
     // If no version, fallback to configuration default
@@ -132,40 +191,67 @@ fn detect_node_version(dest_dir: &Path) -> Result<String, AnyError> {
 
 /// Detect potential projects (for existing repos only) by
 /// inspecting the `workspaces` field in a root `package.json`.
-async fn detect_projects(dest_dir: &Path, yes: bool) -> Result<ProjectsSourceMap, AnyError> {
+async fn detect_projects(
+    dest_dir: &Path,
+    options: &InitOptions,
+) -> Result<(BTreeMap<String, String>, Vec<String>), AnyError> {
     let pkg_path = dest_dir.join("package.json");
     let mut projects = HashMap::new();
+    let mut project_globs = vec![];
 
     if pkg_path.exists() {
         if let Ok(pkg) = PackageJson::load(&pkg_path).await {
             if let Some(workspaces) = pkg.workspaces {
-                if yes
-                    || Confirm::with_theme(&create_theme())
+                let items = vec![
+                    "Don't inherit",
+                    "As a list of globs",
+                    "As a map of project locations",
+                ];
+                let default_index = options.inherit_projects.get_option_index();
+
+                let index = if options.yes {
+                    default_index
+                } else {
+                    Select::with_theme(&create_theme())
                         .with_prompt(format!(
                             "Inherit projects from {} workspaces?",
                             color::file("package.json")
                         ))
-                        .interact()?
-                {
-                    let globs = match workspaces {
-                        Workspaces::Array(list) => list,
-                        Workspaces::Object(object) => object.packages.unwrap_or_default(),
-                    };
+                        .items(&items)
+                        .default(default_index)
+                        .interact_opt()?
+                        .unwrap_or(default_index)
+                };
 
+                let globs = match workspaces {
+                    Workspaces::Array(list) => list,
+                    Workspaces::Object(object) => object.packages.unwrap_or_default(),
+                };
+
+                if index == 1 {
+                    project_globs.extend(globs);
+                } else if index == 2 {
                     detect_projects_with_globs(dest_dir, &globs, &mut projects)?;
                 }
             }
         }
     }
 
-    if projects.is_empty() {
+    if projects.is_empty() && project_globs.is_empty() {
         projects.insert("example".to_owned(), "apps/example".to_owned());
     }
 
-    Ok(projects)
+    // Sort the projects for template rendering
+    let mut sorted_projects = BTreeMap::new();
+
+    for (key, value) in projects {
+        sorted_projects.insert(key, value);
+    }
+
+    Ok((sorted_projects, project_globs))
 }
 
-pub async fn init(dest: &str, yes: bool, force: bool) -> Result<(), AnyError> {
+pub async fn init(dest: &str, options: InitOptions) -> Result<(), AnyError> {
     let working_dir = env::current_dir().unwrap();
     let dest_path = PathBuf::from(dest);
     let dest_dir = if dest == "." {
@@ -178,13 +264,13 @@ pub async fn init(dest: &str, yes: bool, force: bool) -> Result<(), AnyError> {
 
     // Extract template variables
     let dest_dir = path::normalize(&dest_dir);
-    let moon_dir = match verify_dest_dir(&dest_dir, yes, force)? {
+    let moon_dir = match verify_dest_dir(&dest_dir, &options)? {
         Some(dir) => dir,
         None => return Ok(()),
     };
-    let package_manager = detect_package_manager(&dest_dir, yes).await?;
+    let package_manager = detect_package_manager(&dest_dir, &options).await?;
     let node_version = detect_node_version(&dest_dir)?;
-    let projects = detect_projects(&dest_dir, yes).await?;
+    let (projects, project_globs) = detect_projects(&dest_dir, &options).await?;
 
     // Generate a template
     let mut context = Context::new();
@@ -192,6 +278,7 @@ pub async fn init(dest: &str, yes: bool, force: bool) -> Result<(), AnyError> {
     context.insert("package_manager_version", &package_manager.1);
     context.insert("node_version", &node_version);
     context.insert("projects", &projects);
+    context.insert("project_globs", &project_globs);
 
     let mut tera = Tera::default();
     tera.add_raw_template("workspace", load_workspace_config_template())?;

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -147,12 +147,12 @@ async fn detect_projects(dest_dir: &Path, yes: bool) -> Result<ProjectsSourceMap
                         ))
                         .interact()?
                 {
-                    let packages = match workspaces {
+                    let globs = match workspaces {
                         Workspaces::Array(list) => list,
                         Workspaces::Object(object) => object.packages.unwrap_or_default(),
                     };
 
-                    detect_projects_with_globs(dest_dir, packages, &mut projects)?;
+                    detect_projects_with_globs(dest_dir, &globs, &mut projects)?;
                 }
             }
         }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -76,10 +76,10 @@ pub async fn run_cli() {
             init(
                 dest,
                 InitOptions {
-                    yes: *yes,
                     force: *force,
                     inherit_projects: inherit_projects.clone(),
                     package_manager: package_manager.clone(),
+                    yes: *yes,
                 },
             )
             .await

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4,7 +4,7 @@ mod enums;
 
 use crate::commands::bin::bin;
 use crate::commands::ci::{ci, CiOptions};
-use crate::commands::init::init;
+use crate::commands::init::{init, InitOptions};
 use crate::commands::project::project;
 use crate::commands::project_graph::project_graph;
 use crate::commands::run::{run, RunOptions};
@@ -66,7 +66,24 @@ pub async fn run_cli() {
             })
             .await
         }
-        Commands::Init { dest, force, yes } => init(dest, *yes, *force).await,
+        Commands::Init {
+            dest,
+            force,
+            inherit_projects,
+            package_manager,
+            yes,
+        } => {
+            init(
+                dest,
+                InitOptions {
+                    yes: *yes,
+                    force: *force,
+                    inherit_projects: inherit_projects.clone(),
+                    package_manager: package_manager.clone(),
+                },
+            )
+            .await
+        }
         Commands::Project { id, json } => project(id, *json).await,
         Commands::ProjectGraph { id } => project_graph(id).await,
         Commands::Run {

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -156,7 +156,7 @@ mod caching {
 
         assert!(cache_path.exists());
 
-        let state = CacheItem::load(cache_path, RunTargetState::default())
+        let state = CacheItem::load(cache_path, RunTargetState::default(), 0)
             .await
             .unwrap();
 

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
@@ -1,3 +1,8 @@
+---
+source: crates/cli/tests/init_test.rs
+assertion_line: 266
+expression: "fs::read_to_string(workspace_config).unwrap()"
+---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # A map of all projects found within the workspace. Each entry requires a unique project ID
@@ -5,12 +10,8 @@ $schema: 'https://moonrepo.dev/schemas/workspace.json'
 # are relative from the workspace root, and cannot reference projects located outside the
 # workspace boundary.
 projects:
-  {%- for glob in project_globs | sort %}
-  - '{{ glob }}'
-  {%- endfor %}
-  {%- for id, source in projects %}
-  {{ id }}: '{{ source }}'
-  {%- endfor %}
+  - 'app'
+  - 'packages/*'
 
 # OPTIONAL: Configures Node.js within the toolchain. moon manages its own version of Node.js
 # instead of relying on a version found on the host machine. This ensures deterministic
@@ -18,21 +19,13 @@ projects:
 node:
   # The version to use. Must be a semantic version that includes major, minor, and patch.
   # We suggest using the latest active LTS version: https://nodejs.org/en/about/releases
-  version: '{{ node_version }}'
+  version: '16.15.0'
 
   # OPTIONAL: The package manager to use when managing dependencies.
   # Accepts "npm", "pnpm", or "yarn". Defaults to "npm".
-  packageManager: '{{ package_manager }}'
+  packageManager: 'npm'
 
-  {% if package_manager != "npm" -%}
-  # OPTIONAL: The version of the package manager (above) to use.
-  {{ package_manager }}:
-    version: '{{ package_manager_version }}'
-  {%- elif package_manager == "npm" and package_manager_version != "inherit" -%}
-  # OPTIONAL: The version of the package manager (above) to use.
-  npm:
-    version: '{{ package_manager_version }}'
-  {%- endif %}
+  
 
   # OPTIONAL: Add `node.version` as a constaint in the root `package.json` `engines`.
   addEnginesConstraint: true
@@ -72,3 +65,4 @@ vcs:
   # local branch against. For git, this is is typically "master" or "main",
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
+

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
@@ -1,3 +1,8 @@
+---
+source: crates/cli/tests/init_test.rs
+assertion_line: 296
+expression: "fs::read_to_string(workspace_config).unwrap()"
+---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # A map of all projects found within the workspace. Each entry requires a unique project ID
@@ -5,12 +10,8 @@ $schema: 'https://moonrepo.dev/schemas/workspace.json'
 # are relative from the workspace root, and cannot reference projects located outside the
 # workspace boundary.
 projects:
-  {%- for glob in project_globs | sort %}
-  - '{{ glob }}'
-  {%- endfor %}
-  {%- for id, source in projects %}
-  {{ id }}: '{{ source }}'
-  {%- endfor %}
+  - 'app'
+  - 'packages/*'
 
 # OPTIONAL: Configures Node.js within the toolchain. moon manages its own version of Node.js
 # instead of relying on a version found on the host machine. This ensures deterministic
@@ -18,21 +19,13 @@ projects:
 node:
   # The version to use. Must be a semantic version that includes major, minor, and patch.
   # We suggest using the latest active LTS version: https://nodejs.org/en/about/releases
-  version: '{{ node_version }}'
+  version: '16.15.0'
 
   # OPTIONAL: The package manager to use when managing dependencies.
   # Accepts "npm", "pnpm", or "yarn". Defaults to "npm".
-  packageManager: '{{ package_manager }}'
+  packageManager: 'npm'
 
-  {% if package_manager != "npm" -%}
-  # OPTIONAL: The version of the package manager (above) to use.
-  {{ package_manager }}:
-    version: '{{ package_manager_version }}'
-  {%- elif package_manager == "npm" and package_manager_version != "inherit" -%}
-  # OPTIONAL: The version of the package manager (above) to use.
-  npm:
-    version: '{{ package_manager_version }}'
-  {%- endif %}
+  
 
   # OPTIONAL: Add `node.version` as a constaint in the root `package.json` `engines`.
   addEnginesConstraint: true
@@ -72,3 +65,4 @@ vcs:
   # local branch against. For git, this is is typically "master" or "main",
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
+

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
@@ -1,3 +1,8 @@
+---
+source: crates/cli/tests/init_test.rs
+assertion_line: 231
+expression: "fs::read_to_string(workspace_config).unwrap()"
+---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # A map of all projects found within the workspace. Each entry requires a unique project ID
@@ -5,12 +10,8 @@ $schema: 'https://moonrepo.dev/schemas/workspace.json'
 # are relative from the workspace root, and cannot reference projects located outside the
 # workspace boundary.
 projects:
-  {%- for glob in project_globs | sort %}
-  - '{{ glob }}'
-  {%- endfor %}
-  {%- for id, source in projects %}
-  {{ id }}: '{{ source }}'
-  {%- endfor %}
+  app: 'app'
+  foo: 'packages/foo'
 
 # OPTIONAL: Configures Node.js within the toolchain. moon manages its own version of Node.js
 # instead of relying on a version found on the host machine. This ensures deterministic
@@ -18,21 +19,13 @@ projects:
 node:
   # The version to use. Must be a semantic version that includes major, minor, and patch.
   # We suggest using the latest active LTS version: https://nodejs.org/en/about/releases
-  version: '{{ node_version }}'
+  version: '16.15.0'
 
   # OPTIONAL: The package manager to use when managing dependencies.
   # Accepts "npm", "pnpm", or "yarn". Defaults to "npm".
-  packageManager: '{{ package_manager }}'
+  packageManager: 'npm'
 
-  {% if package_manager != "npm" -%}
-  # OPTIONAL: The version of the package manager (above) to use.
-  {{ package_manager }}:
-    version: '{{ package_manager_version }}'
-  {%- elif package_manager == "npm" and package_manager_version != "inherit" -%}
-  # OPTIONAL: The version of the package manager (above) to use.
-  npm:
-    version: '{{ package_manager_version }}'
-  {%- endif %}
+  
 
   # OPTIONAL: Add `node.version` as a constaint in the root `package.json` `engines`.
   addEnginesConstraint: true
@@ -72,3 +65,4 @@ vcs:
   # local branch against. For git, this is is typically "master" or "main",
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
+

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
@@ -1,3 +1,8 @@
+---
+source: crates/cli/tests/init_test.rs
+assertion_line: 261
+expression: "fs::read_to_string(workspace_config).unwrap()"
+---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # A map of all projects found within the workspace. Each entry requires a unique project ID
@@ -5,12 +10,8 @@ $schema: 'https://moonrepo.dev/schemas/workspace.json'
 # are relative from the workspace root, and cannot reference projects located outside the
 # workspace boundary.
 projects:
-  {%- for glob in project_globs | sort %}
-  - '{{ glob }}'
-  {%- endfor %}
-  {%- for id, source in projects %}
-  {{ id }}: '{{ source }}'
-  {%- endfor %}
+  app: 'app'
+  bar: 'packages/bar'
 
 # OPTIONAL: Configures Node.js within the toolchain. moon manages its own version of Node.js
 # instead of relying on a version found on the host machine. This ensures deterministic
@@ -18,21 +19,13 @@ projects:
 node:
   # The version to use. Must be a semantic version that includes major, minor, and patch.
   # We suggest using the latest active LTS version: https://nodejs.org/en/about/releases
-  version: '{{ node_version }}'
+  version: '16.15.0'
 
   # OPTIONAL: The package manager to use when managing dependencies.
   # Accepts "npm", "pnpm", or "yarn". Defaults to "npm".
-  packageManager: '{{ package_manager }}'
+  packageManager: 'npm'
 
-  {% if package_manager != "npm" -%}
-  # OPTIONAL: The version of the package manager (above) to use.
-  {{ package_manager }}:
-    version: '{{ package_manager_version }}'
-  {%- elif package_manager == "npm" and package_manager_version != "inherit" -%}
-  # OPTIONAL: The version of the package manager (above) to use.
-  npm:
-    version: '{{ package_manager_version }}'
-  {%- endif %}
+  
 
   # OPTIONAL: Add `node.version` as a constaint in the root `package.json` `engines`.
   addEnginesConstraint: true
@@ -72,3 +65,4 @@ vcs:
   # local branch against. For git, this is is typically "master" or "main",
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
+

--- a/crates/cli/tests/snapshots/run_test__configs__bubbles_up_invalid_workspace_config.snap
+++ b/crates/cli/tests/snapshots/run_test__configs__bubbles_up_invalid_workspace_config.snap
@@ -8,6 +8,6 @@ expression: get_assert_output(&assert)
 
 Failed to validate .moon/workspace.yml configuration file.
 
-  ▪ Invalid field projects: Expected a sequence of project globs or a map of projects type, received bool true.
+  ▪ Invalid field projects: Expected a sequence of globs or a map of projects type, received bool true.
 
 

--- a/crates/cli/tests/snapshots/run_test__configs__bubbles_up_invalid_workspace_config.snap
+++ b/crates/cli/tests/snapshots/run_test__configs__bubbles_up_invalid_workspace_config.snap
@@ -8,6 +8,6 @@ expression: get_assert_output(&assert)
 
 Failed to validate .moon/workspace.yml configuration file.
 
-  ▪ Invalid field projects: Expected a map type, received bool true.
+  ▪ Invalid field projects: Expected a sequence of project globs or a map of projects type, received bool true.
 
 

--- a/crates/config/src/constants.rs
+++ b/crates/config/src/constants.rs
@@ -3,3 +3,5 @@ pub const CONFIG_DIRNAME: &str = ".moon";
 pub const CONFIG_WORKSPACE_FILENAME: &str = "workspace.yml";
 
 pub const CONFIG_PROJECT_FILENAME: &str = "project.yml";
+
+pub const FLAG_PROJECTS_USING_GLOB: &str = "MOON_PROJECTS_USING_GLOBS";

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -11,7 +11,7 @@ pub use errors::format_errors;
 pub use project::global::GlobalProjectConfig;
 pub use project::task::{TaskConfig, TaskMergeStrategy, TaskOptionsConfig, TaskType};
 pub use project::{ProjectConfig, ProjectMetadataConfig, ProjectType};
-pub use types::{FilePath, FilePathOrGlob, ProjectID, TargetID, TaskID};
+pub use types::{FileGlob, FilePath, FilePathOrGlob, ProjectID, TargetID, TaskID};
 pub use validator::ValidationErrors;
 pub use workspace::node::{
     default_node_version, default_npm_version, default_pnpm_version, default_yarn_version,

--- a/crates/config/src/package.rs
+++ b/crates/config/src/package.rs
@@ -257,7 +257,7 @@ pub enum StringArrayOrObject<T> {
     Object(T),
 }
 
-pub type Bin = StringOrArray<BinSet>;
+pub type Bin = StringOrObject<BinSet>;
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Bug {

--- a/crates/config/src/project/global.rs
+++ b/crates/config/src/project/global.rs
@@ -1,5 +1,4 @@
 // .moon/project.yml
-#![allow(rustdoc::bare_urls)]
 
 use crate::constants;
 use crate::errors::{create_validation_error, map_figment_error_to_validation_errors};

--- a/crates/config/src/project/mod.rs
+++ b/crates/config/src/project/mod.rs
@@ -1,5 +1,4 @@
 // <project path>/project.yml
-#![allow(rustdoc::bare_urls)]
 
 pub mod global;
 pub mod task;

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -130,15 +130,6 @@ pub struct TaskConfig {
 
 // SERDE
 
-#[derive(JsonSchema)]
-#[serde(untagged)]
-enum Args {
-    #[allow(dead_code)]
-    Str(String),
-    #[allow(dead_code)]
-    Vec(Vec<String>),
-}
-
 struct DeserializeArgs;
 
 impl<'de> de::Visitor<'de> for DeserializeArgs {
@@ -179,38 +170,21 @@ where
     Ok(Some(deserializer.deserialize_any(DeserializeArgs)?))
 }
 
+// JSON SCHEMA
+
+#[derive(JsonSchema)]
+#[serde(untagged)]
+enum ArgsField {
+    #[allow(dead_code)]
+    Str(String),
+    #[allow(dead_code)]
+    Vec(Vec<String>),
+}
+
 fn make_args_schema(_gen: &mut SchemaGenerator) -> Schema {
-    let root = schema_for!(Args);
+    let root = schema_for!(ArgsField);
 
     Schema::Object(root.schema)
-
-    // let mut schema: SchemaObject = <String>::json_schema(gen).into();
-    // schema.instance_type = None;
-    // schema.subschemas = Some(Box::new(SubschemaValidation {
-    //     one_of: Some(vec![
-    //         Schema::Object(SchemaObject {
-    //             instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::String))),
-    //             ..SchemaObject::default()
-    //         }),
-    //         Schema::Object(SchemaObject {
-    //             instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::Array))),
-    //             array: Some(Box::new(ArrayValidation {
-    //                 items: Some(SingleOrVec::Single(Box::new(Schema::Object(
-    //                     SchemaObject {
-    //                         instance_type: Some(SingleOrVec::Single(Box::new(
-    //                             InstanceType::String,
-    //                         ))),
-    //                         ..SchemaObject::default()
-    //                     },
-    //                 )))),
-    //                 ..ArrayValidation::default()
-    //             })),
-    //             ..SchemaObject::default()
-    //         }),
-    //     ]),
-    //     ..SubschemaValidation::default()
-    // }));
-    // schema.into()
 }
 
 #[cfg(test)]

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+pub type FileGlob = String;
+
 pub type FilePath = String;
 
 pub type FilePathOrGlob = String;

--- a/crates/config/src/workspace/mod.rs
+++ b/crates/config/src/workspace/mod.rs
@@ -627,7 +627,7 @@ projects: {}"#,
 
         #[test]
         #[should_panic(
-            expected = "Invalid field <id>projects</id>: Expected a sequence of project globs or a map of projects type, received string \"apps/*\"."
+            expected = "Invalid field <id>projects</id>: Expected a sequence of globs or a map of projects type, received string \"apps/*\"."
         )]
         fn invalid_type() {
             figment::Jail::expect_with(|jail| {

--- a/crates/hasher/Cargo.toml
+++ b/crates/hasher/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "moon_hasher"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+moon_config = { path = "../config"}
+moon_project = { path = "../project"}
+moon_utils = { path = "../utils"}
+serde = { version = "1.0.137", features = ["derive"] }
+sha2 = "0.10.2"

--- a/crates/hasher/src/hasher.rs
+++ b/crates/hasher/src/hasher.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 
 #[derive(Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Hasher {
+pub struct TargetHasher {
     // Task `command`
     command: String,
 
@@ -50,12 +50,12 @@ pub struct Hasher {
     version: String,
 }
 
-impl Hasher {
+impl TargetHasher {
     pub fn new(node_version: String) -> Self {
-        Hasher {
+        TargetHasher {
             node_version,
             version: String::from("1"),
-            ..Hasher::default()
+            ..TargetHasher::default()
         }
     }
 
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn returns_default_hash() {
-        let hasher = Hasher::new(String::from("0.0.0"));
+        let hasher = TargetHasher::new(String::from("0.0.0"));
 
         assert_eq!(
             hasher.to_hash(),
@@ -187,15 +187,15 @@ mod tests {
 
     #[test]
     fn returns_same_hash_if_called_again() {
-        let hasher = Hasher::new(String::from("0.0.0"));
+        let hasher = TargetHasher::new(String::from("0.0.0"));
 
         assert_eq!(hasher.to_hash(), hasher.to_hash());
     }
 
     #[test]
     fn returns_different_hash_for_diff_contents() {
-        let hasher1 = Hasher::new(String::from("0.0.0"));
-        let hasher2 = Hasher::new(String::from("1.0.0"));
+        let hasher1 = TargetHasher::new(String::from("0.0.0"));
+        let hasher2 = TargetHasher::new(String::from("1.0.0"));
 
         assert_ne!(hasher1.to_hash(), hasher2.to_hash());
     }
@@ -208,10 +208,10 @@ mod tests {
             let mut package1 = PackageJson::default();
             package1.add_dependency("react".to_owned(), "17.0.0".to_owned(), true);
 
-            let mut hasher1 = Hasher::new(String::from("0.0.0"));
+            let mut hasher1 = TargetHasher::new(String::from("0.0.0"));
             hasher1.hash_package_json(&package1);
 
-            let mut hasher2 = Hasher::new(String::from("0.0.0"));
+            let mut hasher2 = TargetHasher::new(String::from("0.0.0"));
             hasher2.hash_package_json(&package1);
             hasher2.hash_package_json(&package1);
 
@@ -226,11 +226,11 @@ mod tests {
             let mut package2 = PackageJson::default();
             package2.add_dependency("react-dom".to_owned(), "17.0.0".to_owned(), true);
 
-            let mut hasher1 = Hasher::new(String::from("0.0.0"));
+            let mut hasher1 = TargetHasher::new(String::from("0.0.0"));
             hasher1.hash_package_json(&package2);
             hasher1.hash_package_json(&package1);
 
-            let mut hasher2 = Hasher::new(String::from("0.0.0"));
+            let mut hasher2 = TargetHasher::new(String::from("0.0.0"));
             hasher2.hash_package_json(&package1);
             hasher2.hash_package_json(&package2);
 
@@ -245,7 +245,7 @@ mod tests {
             let mut package2 = PackageJson::default();
             package2.add_dependency("react".to_owned(), "18.0.0".to_owned(), true);
 
-            let mut hasher1 = Hasher::new(String::from("0.0.0"));
+            let mut hasher1 = TargetHasher::new(String::from("0.0.0"));
             hasher1.hash_package_json(&package1);
 
             let hash1 = hasher1.to_hash();

--- a/crates/hasher/src/lib.rs
+++ b/crates/hasher/src/lib.rs
@@ -1,0 +1,3 @@
+mod hasher;
+
+pub use hasher::TargetHasher;

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+moon_cache = { path = "../cache" }
 moon_config = { path = "../config" }
 moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }

--- a/crates/project/src/errors.rs
+++ b/crates/project/src/errors.rs
@@ -15,12 +15,6 @@ pub enum ProjectError {
     )]
     InvalidConfigFile(String, String),
 
-    #[error("Failed to parse and open <file>{0}/package.json</file>: {1}")]
-    InvalidPackageJson(String, String),
-
-    #[error("Failed to parse and open <file>{0}/{1}</file>: {2}")]
-    InvalidTsConfigJson(String, String, String),
-
     #[error("No project exists at path <file>{0}</file>.")]
     MissingProject(String),
 

--- a/crates/project/src/helpers.rs
+++ b/crates/project/src/helpers.rs
@@ -21,10 +21,10 @@ pub fn infer_project_name_and_source(source: &str) -> (String, String) {
 /// for potential projects, and infer their name and source.
 pub fn detect_projects_with_globs(
     workspace_root: &Path,
-    globs: Vec<String>,
+    globs: &[String],
     projects: &mut ProjectsSourceMap,
 ) -> Result<(), ProjectError> {
-    for project_root in glob::walk(workspace_root, &globs)? {
+    for project_root in glob::walk(workspace_root, globs)? {
         if project_root.is_dir() {
             let project_source = project_root
                 .strip_prefix(workspace_root)

--- a/crates/project/src/helpers.rs
+++ b/crates/project/src/helpers.rs
@@ -1,0 +1,51 @@
+use crate::errors::ProjectError;
+use crate::types::ProjectsSourceMap;
+use moon_logger::{color, warn};
+use moon_utils::{glob, path, regex};
+use std::path::Path;
+
+/// Infer a project name from a source path, by using the name of
+/// the project folder.
+pub fn infer_project_name_and_source(source: &str) -> (String, String) {
+    let source = path::standardize_separators(source);
+
+    if source.contains('/') {
+        (source.split('/').last().unwrap().to_owned(), source)
+    } else {
+        (source.clone(), source)
+    }
+}
+
+/// For each pattern in the workspaces list, glob the file system
+/// for potential projects, and infer their name and source.
+pub fn detect_projects_with_globs(
+    workspace_root: &Path,
+    globs: Vec<String>,
+    projects: &mut ProjectsSourceMap,
+) -> Result<(), ProjectError> {
+    for project_root in glob::walk(workspace_root, &globs)? {
+        if project_root.is_dir() {
+            let (id, source) = infer_project_name_and_source(
+                &project_root
+                    .strip_prefix(workspace_root)
+                    .unwrap()
+                    .to_string_lossy(),
+            );
+            let id = regex::clean_id(&id);
+
+            if let Some(existing_source) = projects.get(&id) {
+                warn!(
+                    target: "moon:project",
+                    "A project already exists for {} at source {}. Skipping conflicting source {}. Try renaming the project folder to make it unique.",
+                    color::id(&id),
+                    color::file(existing_source),
+                    color::file(&source)
+                );
+            } else {
+                projects.insert(id, source);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -1,6 +1,7 @@
 mod constants;
 mod errors;
 mod file_group;
+mod helpers;
 mod project;
 mod project_graph;
 mod target;
@@ -11,6 +12,7 @@ mod types;
 
 pub use constants::ROOT_NODE_ID;
 pub use errors::{ProjectError, TargetError};
+pub use helpers::*;
 pub use types::*;
 
 // Projects

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -373,11 +373,8 @@ impl Project {
 
         if package_path.exists() {
             return match PackageJson::load(&package_path).await {
-                Ok(json) => Ok(Some(json)),
-                Err(error) => Err(ProjectError::InvalidPackageJson(
-                    String::from(&self.source),
-                    error.to_string(),
-                )),
+                Ok(cfg) => Ok(Some(cfg)),
+                Err(error) => Err(ProjectError::Moon(error)),
             };
         }
 
@@ -401,11 +398,7 @@ impl Project {
         if tsconfig_path.exists() {
             return match TsConfigJson::load(&tsconfig_path).await {
                 Ok(cfg) => Ok(Some(cfg)),
-                Err(error) => Err(ProjectError::InvalidTsConfigJson(
-                    String::from(&self.source),
-                    String::from(tsconfig_name),
-                    error.to_string(),
-                )),
+                Err(error) => Err(ProjectError::Moon(error)),
             };
         }
 

--- a/crates/project/src/project_graph.rs
+++ b/crates/project/src/project_graph.rs
@@ -64,9 +64,10 @@ async fn load_projects_from_cache(
     // Generate a new projects map by globbing the filesystem
     let mut map = HashMap::new();
 
-    detect_projects_with_globs(workspace_root, globs, &mut map)?;
+    detect_projects_with_globs(workspace_root, &globs, &mut map)?;
 
     // Update the cache
+    cache.item.globs = globs;
     cache.item.projects = map.clone();
     cache.save().await?;
 

--- a/crates/project/src/project_graph.rs
+++ b/crates/project/src/project_graph.rs
@@ -2,6 +2,7 @@ use crate::constants::ROOT_NODE_ID;
 use crate::errors::ProjectError;
 use crate::project::Project;
 use crate::types::TouchedFilePaths;
+use moon_cache::CacheEngine;
 use moon_config::constants::{CONFIG_DIRNAME, CONFIG_PROJECT_FILENAME, CONFIG_WORKSPACE_FILENAME};
 use moon_config::{GlobalProjectConfig, ProjectID};
 use moon_logger::{color, debug, map_list, trace};
@@ -45,6 +46,7 @@ impl ProjectGraph {
         workspace_root: &Path,
         global_config: GlobalProjectConfig,
         projects_config: &HashMap<ProjectID, String>,
+        // cache: &CacheEngine,
     ) -> ProjectGraph {
         debug!(
             target: LOG_TARGET,

--- a/crates/project/src/project_graph.rs
+++ b/crates/project/src/project_graph.rs
@@ -1,9 +1,12 @@
 use crate::constants::ROOT_NODE_ID;
 use crate::errors::ProjectError;
+use crate::helpers::detect_projects_with_globs;
 use crate::project::Project;
-use crate::types::TouchedFilePaths;
+use crate::types::{ProjectsSourceMap, TouchedFilePaths};
 use moon_cache::CacheEngine;
-use moon_config::constants::{CONFIG_DIRNAME, CONFIG_PROJECT_FILENAME, CONFIG_WORKSPACE_FILENAME};
+use moon_config::constants::{
+    CONFIG_DIRNAME, CONFIG_PROJECT_FILENAME, CONFIG_WORKSPACE_FILENAME, FLAG_PROJECTS_USING_GLOB,
+};
 use moon_config::{GlobalProjectConfig, ProjectID};
 use moon_logger::{color, debug, map_list, trace};
 use petgraph::dot::{Config, Dot};
@@ -20,6 +23,47 @@ type IndicesType = HashMap<ProjectID, NodeIndex>;
 const LOG_TARGET: &str = "moon:project-graph";
 const READ_ERROR: &str = "Failed to acquire a read lock";
 const WRITE_ERROR: &str = "Failed to acquire a write lock";
+
+async fn load_projects_from_cache(
+    workspace_root: &Path,
+    projects: &ProjectsSourceMap,
+    engine: &CacheEngine,
+) -> Result<ProjectsSourceMap, ProjectError> {
+    // Projects were mapped manually and are not using globs
+    if !projects.contains_key(FLAG_PROJECTS_USING_GLOB) {
+        return Ok(projects.clone());
+    }
+
+    let mut cache = engine.cache_projects_state().await?;
+
+    // Return the values from the cache
+    if !cache.item.projects.is_empty() {
+        return Ok(cache.item.projects);
+    }
+
+    // Extract globs from our fake projects map
+    let globs = projects
+        .iter()
+        .filter_map(|(key, value)| {
+            if key == FLAG_PROJECTS_USING_GLOB {
+                None
+            } else {
+                Some(value.clone())
+            }
+        })
+        .collect::<Vec<String>>();
+
+    // Generate a new projects map by globbing the filesystem
+    let mut map = HashMap::new();
+
+    detect_projects_with_globs(workspace_root, globs, &mut map)?;
+
+    // Update the cache
+    cache.item.projects = map.clone();
+    cache.save().await?;
+
+    Ok(map)
+}
 
 pub struct ProjectGraph {
     /// The global project configuration that all projects inherit from.
@@ -42,12 +86,12 @@ pub struct ProjectGraph {
 }
 
 impl ProjectGraph {
-    pub fn new(
+    pub async fn create(
         workspace_root: &Path,
         global_config: GlobalProjectConfig,
-        projects_config: &HashMap<ProjectID, String>,
-        // cache: &CacheEngine,
-    ) -> ProjectGraph {
+        projects_config: &ProjectsSourceMap,
+        cache: &CacheEngine,
+    ) -> Result<ProjectGraph, ProjectError> {
         debug!(
             target: LOG_TARGET,
             "Creating project graph with {} projects",
@@ -64,13 +108,14 @@ impl ProjectGraph {
             ..Project::default()
         });
 
-        ProjectGraph {
+        Ok(ProjectGraph {
             global_config,
             graph: Arc::new(RwLock::new(graph)),
             indices: Arc::new(RwLock::new(HashMap::new())),
-            projects_config: projects_config.clone(),
+            projects_config: load_projects_from_cache(workspace_root, projects_config, cache)
+                .await?,
             workspace_root: workspace_root.to_path_buf(),
-        }
+        })
     }
 
     /// Return a list of all configured project IDs in ascending order.

--- a/crates/project/src/project_graph.rs
+++ b/crates/project/src/project_graph.rs
@@ -38,6 +38,8 @@ async fn load_projects_from_cache(
 
     // Return the values from the cache
     if !cache.item.projects.is_empty() {
+        debug!(target: LOG_TARGET, "Loading projects from cache");
+
         return Ok(cache.item.projects);
     }
 
@@ -52,6 +54,12 @@ async fn load_projects_from_cache(
             }
         })
         .collect::<Vec<String>>();
+
+    debug!(
+        target: LOG_TARGET,
+        "Finding projects with globs: {}",
+        map_list(&globs, |g| color::file(g))
+    );
 
     // Generate a new projects map by globbing the filesystem
     let mut map = HashMap::new();

--- a/crates/project/src/types.rs
+++ b/crates/project/src/types.rs
@@ -1,3 +1,4 @@
+use moon_config::ProjectID;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
@@ -6,3 +7,5 @@ pub type TouchedFilePaths = HashSet<PathBuf>;
 pub type ExpandedFiles = HashSet<PathBuf>;
 
 pub type EnvVars = HashMap<String, String>;
+
+pub type ProjectsSourceMap = HashMap<ProjectID, String>;

--- a/crates/project/tests/project_graph_test.rs
+++ b/crates/project/tests/project_graph_test.rs
@@ -1,14 +1,15 @@
 use insta::assert_snapshot;
+use moon_cache::CacheEngine;
 use moon_config::GlobalProjectConfig;
 use moon_project::ProjectGraph;
 use moon_utils::string_vec;
 use moon_utils::test::get_fixtures_dir;
 use std::collections::HashMap;
 
-fn get_dependencies_graph() -> ProjectGraph {
+async fn get_dependencies_graph() -> ProjectGraph {
     let workspace_root = get_fixtures_dir("project-graph/dependencies");
 
-    ProjectGraph::new(
+    ProjectGraph::create(
         &workspace_root,
         GlobalProjectConfig::default(),
         &HashMap::from([
@@ -17,13 +18,16 @@ fn get_dependencies_graph() -> ProjectGraph {
             ("c".to_owned(), "c".to_owned()),
             ("d".to_owned(), "d".to_owned()),
         ]),
+        &CacheEngine::create(&workspace_root).await.unwrap(),
     )
+    .await
+    .unwrap()
 }
 
-fn get_dependents_graph() -> ProjectGraph {
+async fn get_dependents_graph() -> ProjectGraph {
     let workspace_root = get_fixtures_dir("project-graph/dependents");
 
-    ProjectGraph::new(
+    ProjectGraph::create(
         &workspace_root,
         GlobalProjectConfig::default(),
         &HashMap::from([
@@ -32,15 +36,18 @@ fn get_dependents_graph() -> ProjectGraph {
             ("c".to_owned(), "c".to_owned()),
             ("d".to_owned(), "d".to_owned()),
         ]),
+        &CacheEngine::create(&workspace_root).await.unwrap(),
     )
+    .await
+    .unwrap()
 }
 
 mod get_dependencies_of {
     use super::*;
 
-    #[test]
-    fn returns_dep_list() {
-        let graph = get_dependencies_graph();
+    #[tokio::test]
+    async fn returns_dep_list() {
+        let graph = get_dependencies_graph().await;
 
         let a = graph.load("a").unwrap();
         let b = graph.load("b").unwrap();
@@ -60,9 +67,9 @@ mod get_dependencies_of {
 mod get_dependents_of {
     use super::*;
 
-    #[test]
-    fn returns_dep_list() {
-        let graph = get_dependents_graph();
+    #[tokio::test]
+    async fn returns_dep_list() {
+        let graph = get_dependents_graph().await;
 
         let a = graph.load("a").unwrap();
         let b = graph.load("b").unwrap();
@@ -82,9 +89,9 @@ mod get_dependents_of {
 mod to_dot {
     use super::*;
 
-    #[test]
-    fn renders_tree() {
-        let graph = get_dependencies_graph();
+    #[tokio::test]
+    async fn renders_tree() {
+        let graph = get_dependencies_graph().await;
 
         graph.load("a").unwrap();
         graph.load("b").unwrap();

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -20,5 +20,5 @@ regex = "1.5.6"
 serde = "1.0.137"
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
 tokio = { version = "1.18.2", features = ["full"] }
-wax = "0.4.0"
+wax = "0.5.0"
 

--- a/crates/utils/src/glob.rs
+++ b/crates/utils/src/glob.rs
@@ -4,7 +4,7 @@ use moon_error::MoonError;
 use regex::Regex;
 use std::path::{Path, PathBuf};
 pub use wax::Glob;
-use wax::{Any, GlobError as WaxGlobError, LinkBehavior, Pattern};
+use wax::{Any, GlobError as WaxGlobError, LinkBehavior, Negation, Pattern};
 
 lazy_static! {
     pub static ref WINDOWS_PREFIX: Regex = Regex::new(r"(//\?/)?[A-Z]:").unwrap();
@@ -21,7 +21,7 @@ impl<'t> GlobSet<'t> {
         let mut globs = vec![];
 
         for pattern in patterns {
-            globs.push(Glob::new(pattern).map_err(|e| e.into_owned())?);
+            globs.push(create_glob(pattern)?);
         }
 
         Ok(GlobSet {
@@ -32,6 +32,10 @@ impl<'t> GlobSet<'t> {
     pub fn matches(&self, path: &Path) -> Result<bool, MoonError> {
         Ok(self.any.is_match(path))
     }
+}
+
+pub fn create_glob(pattern: &str) -> Result<Glob, GlobError> {
+    Ok(Glob::new(pattern).map_err(|e| e.into_owned())?)
 }
 
 // This is not very exhaustive and may be inaccurate.
@@ -96,40 +100,39 @@ pub fn normalize(path: &Path) -> Result<String, MoonError> {
 
 /// Wax currently doesn't support negated globs (starts with !),
 /// so we must extract them manually.
-pub fn split_patterns(patterns: &[String]) -> (Vec<String>, Vec<String>) {
+pub fn split_patterns(patterns: &[String]) -> Result<(Vec<Glob>, Vec<Glob>), GlobError> {
     let mut expressions = vec![];
     let mut negations = vec![];
 
     for pattern in patterns {
         if pattern.starts_with('!') {
-            negations.push(pattern.strip_prefix('!').unwrap().to_owned());
+            negations.push(create_glob(pattern.strip_prefix('!').unwrap())?);
         } else if pattern.starts_with('/') {
-            expressions.push(pattern.strip_prefix('/').unwrap().to_owned());
+            expressions.push(create_glob(pattern.strip_prefix('/').unwrap())?);
         } else {
-            expressions.push(pattern.clone());
+            expressions.push(create_glob(pattern)?);
         }
     }
 
-    (expressions, negations)
+    Ok((expressions, negations))
 }
 
 pub fn walk(base_dir: &Path, patterns: &[String]) -> Result<Vec<PathBuf>, GlobError> {
-    let (expressions, _negations) = split_patterns(patterns);
+    let (globs, negations) = split_patterns(patterns)?;
+    let negation = Negation::try_from_patterns(negations).unwrap();
     let mut paths = vec![];
 
-    for expression in expressions {
-        let glob = Glob::new(&expression).map_err(|e| e.into_owned())?;
-        // let negs = negations.clone();
-
-        for entry in glob.walk_with_behavior(base_dir, LinkBehavior::ReadFile)
-        // .not(
-        //     negs.into_iter()
-        //         .map(|n| Glob::new(&n).unwrap())
-        //         .collect::<Vec<Glob>>(),
-        // )?
-        {
+    for glob in globs {
+        for entry in glob.walk_with_behavior(base_dir, LinkBehavior::ReadFile) {
             match entry {
-                Ok(e) => paths.push(e.into_path()),
+                Ok(e) => {
+                    // Filter out negated results
+                    if negation.target(&e).is_some() {
+                        continue;
+                    }
+
+                    paths.push(e.into_path());
+                }
                 Err(_) => {
                     // Will crash if the file doesnt exist
                     continue;

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 moon_cache = { path = "../cache" }
 moon_config = { path = "../config" }
 moon_error = { path = "../error" }
+moon_hasher = { path = "../hasher" }
 moon_lang_node = { path = "../lang-node" }
 moon_logger = { path = "../logger" }
 moon_project = { path = "../project" }

--- a/crates/workspace/src/actions/hashing/target.rs
+++ b/crates/workspace/src/actions/hashing/target.rs
@@ -1,5 +1,5 @@
 use crate::{Workspace, WorkspaceError};
-use moon_cache::Hasher;
+use moon_hasher::TargetHasher;
 use moon_project::{ExpandedFiles, Project, Task};
 use moon_utils::path::path_to_string;
 use std::path::Path;
@@ -33,10 +33,10 @@ pub async fn create_target_hasher(
     project: &Project,
     task: &Task,
     passthrough_args: &[String],
-) -> Result<Hasher, WorkspaceError> {
+) -> Result<TargetHasher, WorkspaceError> {
     let vcs = workspace.detect_vcs()?;
     let globset = task.create_globset()?;
-    let mut hasher = Hasher::new(workspace.config.node.version.clone());
+    let mut hasher = TargetHasher::new(workspace.config.node.version.clone());
 
     hasher.hash_project(project);
     hasher.hash_task(task);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -176,7 +176,8 @@ impl Workspace {
         // Setup components
         let cache = CacheEngine::create(&root_dir).await?;
         let toolchain = Toolchain::create(&root_dir, &config).await?;
-        let projects = ProjectGraph::new(&root_dir, project_config, &config.projects); // , &cache);
+        let projects =
+            ProjectGraph::create(&root_dir, project_config, &config.projects, &cache).await?;
 
         Ok(Workspace {
             cache,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -56,10 +56,7 @@ fn load_global_project_config(root_dir: &Path) -> Result<GlobalProjectConfig, Wo
 }
 
 // workspace.yml
-fn load_workspace_config(
-    root_dir: &Path,
-    cache: &CacheEngine,
-) -> Result<WorkspaceConfig, WorkspaceError> {
+fn load_workspace_config(root_dir: &Path) -> Result<WorkspaceConfig, WorkspaceError> {
     let config_path = root_dir
         .join(constants::CONFIG_DIRNAME)
         .join(constants::CONFIG_WORKSPACE_FILENAME);
@@ -169,19 +166,17 @@ impl Workspace {
             color::path(&working_dir)
         );
 
-        // Setup cache first
-        let cache = CacheEngine::create(&root_dir).await?;
-
         // Load configs
-        let config = load_workspace_config(&root_dir, &cache)?;
+        let config = load_workspace_config(&root_dir)?;
         let project_config = load_global_project_config(&root_dir)?;
         let package_json = load_package_json(&root_dir).await?;
         let tsconfig_json =
             load_tsconfig_json(&root_dir, &config.typescript.root_config_file_name).await?;
 
         // Setup components
+        let cache = CacheEngine::create(&root_dir).await?;
         let toolchain = Toolchain::create(&root_dir, &config).await?;
-        let projects = ProjectGraph::new(&root_dir, project_config, &config.projects);
+        let projects = ProjectGraph::new(&root_dir, project_config, &config.projects); // , &cache);
 
         Ok(Workspace {
             cache,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -56,7 +56,10 @@ fn load_global_project_config(root_dir: &Path) -> Result<GlobalProjectConfig, Wo
 }
 
 // workspace.yml
-fn load_workspace_config(root_dir: &Path) -> Result<WorkspaceConfig, WorkspaceError> {
+fn load_workspace_config(
+    root_dir: &Path,
+    cache: &CacheEngine,
+) -> Result<WorkspaceConfig, WorkspaceError> {
     let config_path = root_dir
         .join(constants::CONFIG_DIRNAME)
         .join(constants::CONFIG_WORKSPACE_FILENAME);
@@ -166,15 +169,17 @@ impl Workspace {
             color::path(&working_dir)
         );
 
+        // Setup cache first
+        let cache = CacheEngine::create(&root_dir).await?;
+
         // Load configs
-        let config = load_workspace_config(&root_dir)?;
+        let config = load_workspace_config(&root_dir, &cache)?;
         let project_config = load_global_project_config(&root_dir)?;
         let package_json = load_package_json(&root_dir).await?;
         let tsconfig_json =
             load_tsconfig_json(&root_dir, &config.typescript.root_config_file_name).await?;
 
         // Setup components
-        let cache = CacheEngine::create(&root_dir).await?;
         let toolchain = Toolchain::create(&root_dir, &config).await?;
         let projects = ProjectGraph::new(&root_dir, project_config, &config.projects);
 

--- a/website/docs/commands/init.mdx
+++ b/website/docs/commands/init.mdx
@@ -21,4 +21,12 @@ $ moon init ./app
 ### Options
 
 - `--force` - Overwrite existing config files if they exist.
+- `--inheritProjects <as>` - Sets the default value on whether to inherit projects from
+  `package.json` workspaces. Supports:
+  - `none` - Do not inherit projects.
+  - `globs-list` - Inherit globs as-is and configure as a list.
+  - `projects-map` - Glob the file system for projects and configure as a map.
+- `--packageManager <type>` - Sets the default value for which package manager to use, if none were
+  detected.
+  - Types: `npm`, `pnpm`, `yarn`
 - `--yes` - Skip all prompts and use default values.

--- a/website/docs/commands/run.mdx
+++ b/website/docs/commands/run.mdx
@@ -30,6 +30,6 @@ $ moon run :lint
 
 - `--affected` - Only run target if affected by changed files, _otherwise_ will always run.
 - `--status <type>` - Filter affected based on a change status.
-  - Types: all (default), added, deleted, modified, staged, unstaged, untracked
+  - Types: `all` (default), `added`, `deleted`, `modified`, `staged`, `unstaged`, `untracked`
 - `--upstream` - Determine affected against upstream by comparing `HEAD` against a base revision
   (default branch), _otherwise_ uses local changes.

--- a/website/docs/concepts/cache.mdx
+++ b/website/docs/concepts/cache.mdx
@@ -32,6 +32,10 @@ The following diagram outlines our cache folder structure and why each piece exi
 
 ```shell
 .moon/cache/
+	# List of projects located on the file system. Will only exists when
+	# projects are configured using globs.
+	projectsState.json
+
 	# State of the workspace. Mainly for tracking install times.
 	workspaceState.json
 

--- a/website/docs/concepts/project.mdx
+++ b/website/docs/concepts/project.mdx
@@ -10,8 +10,8 @@ files, assets, resources, and more. A project must exist and be configured withi
 
 A project identifier is a unique resource for locating a project. The ID is explicitly configured
 within [`.moon/workspace.yml`](../config/workspace), as a key within the
-[`projects`](../config/workspace#projects) setting, and can be written in camelCase, kebab-case, or
-snake_case.
+[`projects`](../config/workspace#projects) setting, and can be written in camel/kebab/snake case.
+IDs support `a-z`, `A-Z`, `0-9`, `_`, `-`, and must start with a character.
 
 IDs are used heavily by configuration and the command line to link and reference everything. They're
 also a much easier concept for remembering projects than file system paths, and they typically can

--- a/website/docs/concepts/task.mdx
+++ b/website/docs/concepts/task.mdx
@@ -10,7 +10,7 @@ in a parallel thread pool within moon's orchestration layer.
 
 A task identifier is a unique resource for locating a task _within_ a project. The ID is explicitly
 configured as a key within the [`tasks`](../config/project#tasks) setting, and can be written in
-camelCase, kebab-case, or snake_case.
+camel/kebab/snake case. IDs support `a-z`, `A-Z`, `0-9`, `_`, `-`, and must start with a character.
 
 A task ID can be paired with a project ID to create a [target](./target).
 

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -3,6 +3,8 @@ title: .moon/workspace.yml
 toc_max_heading_level: 6
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import RequiredLabel from '@site/src/components/Docs/RequiredLabel';
 
 The `.moon/workspace.yml` file configures available projects and their locations, the toolchain, and
@@ -10,13 +12,26 @@ the workspace development environment.
 
 ## `projects`<RequiredLabel />
 
-> `Record<string, string>`
+> `Record<string, string> | string[]`
 
-Defines the location of all [projects](../concepts/project) within the workspace. Each project
-requires a unique ID as the map key, where this ID is used heavily on the command line and within
-the project graph for uniquely identifying the project amongst all projects. The map value (known as
-the project source) is a file system path to the project folder, relative from the workspace root,
-and must be contained within the workspace boundary.
+Defines the location of all [projects](../concepts/project) within the workspace. Supports either a
+manual map of projects (default), _or_ a list of globs in which to automatically locate projects.
+
+<Tabs
+  groupId="projects-type"
+  defaultValue="manual"
+  values={[
+    { label: 'Manual', value: 'manual' },
+    { label: 'Automatic', value: 'auto' },
+  ]}
+>
+<TabItem value="manual">
+
+When using a map, each project must be _manually_ configured and requires a unique
+[ID](../concepts/project#id) as the map key, where this ID is used heavily on the command line and
+within the project graph for uniquely identifying the project amongst all projects. The map value
+(known as the project source) is a file system path to the project folder, relative from the
+workspace root, and must be contained within the workspace boundary.
 
 ```yaml title=".moon/workspace.yml"
 projects:
@@ -26,15 +41,29 @@ projects:
   web: 'apps/web'
 ```
 
-Unlike packages in the JavaScript ecosystem, a moon project _does not_ require a `package.json`, and
-is not coupled to Yarn workspaces (or similar architectures).
+</TabItem>
+<TabItem value="auto">
 
-> **Why doesn't moon auto-detect projects?** moon _does not_ automatically detect projects using
-> file system globs for the following reasons:
->
-> - Depth-first scans are expensive, especially when the workspace continues to grow.
-> - CI and other machines may inadvertently detect more projects because of left over artifacts.
-> - Centralizing a manifest of projects allows for an easy review and approval process.
+If manually mapping projects is too tedious or cumbersome, you may provide a list of
+[globs](../concepts/file-pattern#globs) to automatically locate all project folders, relative from
+the workspace root.
+
+When using this approach, the project ID is derived from the project folder name, and is cleaned to
+our [supported characters](../concepts/project#id) . Furthermore, globbing **does risk the chance of
+collision**, and when that happens, we log a warning and skip the conflicting project from being
+configured in the project graph.
+
+```yaml title=".moon/workspace.yml"
+projects:
+  - 'apps/*'
+  - 'packages/*'
+```
+
+</TabItem>
+</Tabs>
+
+> Unlike packages in the JavaScript ecosystem, a moon project _does not_ require a `package.json`,
+> and is not coupled to Yarn workspaces (or similar architectures).
 
 ## `node`
 

--- a/website/docs/create-project.mdx
+++ b/website/docs/create-project.mdx
@@ -35,6 +35,13 @@ We can now run [`moon project client`](./commands/project) and
 [`moon project server`](./commands/project) to display information about each project. If these
 projects were not mapped, or were pointing to an invalid source, the command would throw an error.
 
+:::success
+
+The [`projects`](./config/workspace#projects) setting also supports a list of globs, if you'd prefer
+to not manually curate the projects list!
+
+:::
+
 ## Configuring a project
 
 A project can be configured in 1 of 2 ways:

--- a/website/static/schemas/global-project.json
+++ b/website/static/schemas/global-project.json
@@ -27,7 +27,7 @@
       "type": "object",
       "properties": {
         "args": {
-          "title": "Args",
+          "title": "ArgsField",
           "default": null,
           "anyOf": [
             {

--- a/website/static/schemas/project.json
+++ b/website/static/schemas/project.json
@@ -147,7 +147,7 @@
       "type": "object",
       "properties": {
         "args": {
-          "title": "Args",
+          "title": "ArgsField",
           "default": null,
           "anyOf": [
             {

--- a/website/static/schemas/workspace.json
+++ b/website/static/schemas/workspace.json
@@ -25,11 +25,22 @@
       ]
     },
     "projects": {
+      "title": "ProjectsField",
       "default": {},
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     },
     "typescript": {
       "default": {


### PR DESCRIPTION
Right now, `projects` support a map of name to source. This works really well, but is also a bit tedious to manage. For open source projects, it's actually more of a burden.

So this PR updates the `projects` setting to also support an array of globs, but this has a few caveats:

- Project IDs use the name of the folder, and are cleaned to our valid list of characters. These IDs run the risk of collision, so instead of overwriting an existing one, we skip the new one and log a warning (this is the same code as `init`).
- Globbing can be a heavy process, especially if there are hundreds of projects. So we're also going to cache the results of the glob with a small lifetime to avoid the glob cost.