### PR TITLE
ci: Upload code coverage as a batch.

### DIFF
--- a/.github/workflows/rust-stub.yml
+++ b/.github/workflows/rust-stub.yml
@@ -3,6 +3,7 @@ name: Rust
 on:
   pull_request:
     paths-ignore:
+      - .github/workflows/rust.yml
       - crates/**
       - tests/**
       - Cargo.lock
@@ -29,5 +30,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - run: 'echo "Not affected, skipping"'
+  coverage:
+    name: Code coverage
+    runs-on: ubuntu-latest
+    needs:
+      - test
     steps:
       - run: 'echo "Not affected, skipping"'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,14 +113,14 @@ jobs:
       - name: Generate code coverage
         run:
           grcov . -s . --binary-path ./target/debug -t lcov --branch --ignore-not-existing -o
-          ./report.info
+          ./report.txt
       - uses: actions/upload-artifact@v2
         # Windows fails to compile right now...
         if: ${{ matrix.os != 'windows-latest' }}
         name: Upload coverage report
         with:
           name: coverage-${{ matrix.os }}
-          path: ./report.info
+          path: ./report.txt
           if-no-files-found: error
   coverage:
     name: Code coverage
@@ -137,3 +137,4 @@ jobs:
         with:
           directory: coverage
           flags: rust
+          verbose: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,7 +114,7 @@ jobs:
         name: Upload coverage report
         with:
           name: coverage-${{ matrix.os }}
-          path: ./coverage/report.txt
+          path: ./coverage/report.xml
           if-no-files-found: error
   coverage:
     name: Code coverage
@@ -129,6 +129,6 @@ jobs:
       - uses: codecov/codecov-action@v3
         name: Upload to Codecov
         with:
-          files: ./coverage/coverage-ubuntu-latest/report.txt,./coverage/coverage-macos-latest/report.txt
+          files: ./coverage/coverage-ubuntu-latest/report.xml,./coverage/coverage-macos-latest/report.xml
           flags: rust
           verbose: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,28 +100,21 @@ jobs:
           args: --force cargo-make grcov
       - uses: actions-rs/cargo@v1
         with:
-          command: build
-        env:
-          RUSTFLAGS: '-Cinstrument-coverage'
-      - uses: actions-rs/cargo@v1
-        with:
           command: make
-          args: test
-        env:
-          RUSTFLAGS: '-Cinstrument-coverage'
-          LLVM_PROFILE_FILE: 'moon-%p-%m.profraw'
+          args: test-coverage
       # Windows fails to compile right now...
       - name: Generate code coverage
         if: ${{ matrix.os != 'windows-latest' }}
-        run:
-          grcov . -s . --binary-path ./target/debug -t cobertura --branch --ignore-not-existing -o
-          ./report.xml
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: generate-report
       - uses: actions/upload-artifact@v2
         if: ${{ matrix.os != 'windows-latest' }}
         name: Upload coverage report
         with:
           name: coverage-${{ matrix.os }}
-          path: ./report.xml
+          path: ./coverage/report.txt
           if-no-files-found: error
   coverage:
     name: Code coverage
@@ -136,6 +129,6 @@ jobs:
       - uses: codecov/codecov-action@v3
         name: Upload to Codecov
         with:
-          directory: ./coverage
+          files: ./coverage/coverage-ubuntu-latest/report.txt,./coverage/coverage-macos-latest/report.txt
           flags: rust
           verbose: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,12 +109,28 @@ jobs:
         env:
           RUSTFLAGS: '-Cinstrument-coverage'
           LLVM_PROFILE_FILE: 'moon-%p-%m.profraw'
-      - name: Generating code coverage
+      - name: Generate code coverage
         run:
           grcov . -s . --binary-path ./target/debug -t cobertura --branch --ignore-not-existing -o
-          ./coverage.xml
-      - name: Uploading code coverage
-        uses: codecov/codecov-action@v3.1.0
+          ./report.xml
+      - uses: actions/upload-artifact@v2
+        name: Upload coverage report
         with:
-          files: ./coverage.xml
-          flags: rust,${{ matrix.os }}
+          name: report-${{ matrix.os }}.xml
+          path: ./report.xml
+          if-no-files-found: error
+  coverage:
+    name: Code coverage
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    steps:
+      - uses: actions/download-artifact@v2
+        name: Download coverage reports
+        with:
+          path: coverage
+      - uses: codecov/codecov-action@v3
+        name: Upload to Codecov
+        with:
+          directory: coverage
+          flags: rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
       - master
   pull_request:
     paths:
+      - .github/workflows/rust.yml
       - crates/**
       - tests/**
       - Cargo.lock

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -110,12 +110,13 @@ jobs:
         env:
           RUSTFLAGS: '-Cinstrument-coverage'
           LLVM_PROFILE_FILE: 'moon-%p-%m.profraw'
+      # Windows fails to compile right now...
       - name: Generate code coverage
+        if: ${{ matrix.os != 'windows-latest' }}
         run:
           grcov . -s . --binary-path ./target/debug -t lcov --branch --ignore-not-existing -o
           ./report.txt
       - uses: actions/upload-artifact@v2
-        # Windows fails to compile right now...
         if: ${{ matrix.os != 'windows-latest' }}
         name: Upload coverage report
         with:
@@ -135,6 +136,6 @@ jobs:
       - uses: codecov/codecov-action@v3
         name: Upload to Codecov
         with:
-          directory: coverage
+          directory: ./coverage
           flags: rust
           verbose: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,6 +115,8 @@ jobs:
           grcov . -s . --binary-path ./target/debug -t lcov --branch --ignore-not-existing -o
           ./report.info
       - uses: actions/upload-artifact@v2
+        # Windows fails to compile right now...
+        if: ${{ matrix.os != 'windows-latest' }}
         name: Upload coverage report
         with:
           name: coverage-${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,14 +114,14 @@ jobs:
       - name: Generate code coverage
         if: ${{ matrix.os != 'windows-latest' }}
         run:
-          grcov . -s . --binary-path ./target/debug -t lcov --branch --ignore-not-existing -o
-          ./report.txt
+          grcov . -s . --binary-path ./target/debug -t cobertura --branch --ignore-not-existing -o
+          ./report.xml
       - uses: actions/upload-artifact@v2
         if: ${{ matrix.os != 'windows-latest' }}
         name: Upload coverage report
         with:
           name: coverage-${{ matrix.os }}
-          path: ./report.txt
+          path: ./report.xml
           if-no-files-found: error
   coverage:
     name: Code coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         name: Upload coverage report
         with:
-          name: report-${{ matrix.os }}.xml
+          name: coverage-${{ matrix.os }}
           path: ./report.xml
           if-no-files-found: error
   coverage:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,13 +112,13 @@ jobs:
           LLVM_PROFILE_FILE: 'moon-%p-%m.profraw'
       - name: Generate code coverage
         run:
-          grcov . -s . --binary-path ./target/debug -t cobertura --branch --ignore-not-existing -o
-          ./report.xml
+          grcov . -s . --binary-path ./target/debug -t lcov --branch --ignore-not-existing -o
+          ./report.info
       - uses: actions/upload-artifact@v2
         name: Upload coverage report
         with:
           name: coverage-${{ matrix.os }}
-          path: ./report.xml
+          path: ./report.info
           if-no-files-found: error
   coverage:
     name: Code coverage

--- a/.yarn/versions/005acb02.yml
+++ b/.yarn/versions/005acb02.yml
@@ -1,0 +1,7 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,26 @@ common tasks.
 - `cargo make format` - Formats code.
 - `cargo make lint` - Runs the linter.
 - `cargo make test` - Runs unit and integration tests.
+- `cargo make test-coverage` - Run tests and also generate code coverage reports.
+
+#### Code coverage
+
+We support source based code coverage with [grcov](https://github.com/mozilla/grcov) via unit and
+integration testing. To begin, install the necessary tooling:
+
+```
+rustup component add llvm-tools-preview
+cargo install --force grcov
+```
+
+Once installed, run `cargo make test-coverage`, which is a lengthy and time consuming process. This
+will build the binary in debug mode with instrumentation enabled, run all unit and integration
+tests, and generate _a ton_ of `*.profraw` files in the repository (do not commit these!).
+
+From here you can generate an LCOV HTML coverage report to `./coverage` with
+`cargo make generate-html`. Open the `index.html` file to browse line-by-line coverage.
+
+Once done, run `cargo make clean-profraw` to cleanup and remove all the `*.profraw` files.
 
 ### Node.js
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,8 +116,8 @@ Once installed, run `cargo make test-coverage`, which is a lengthy and time cons
 will build the binary in debug mode with instrumentation enabled, run all unit and integration
 tests, and generate _a ton_ of `*.profraw` files in the repository (do not commit these!).
 
-From here you can generate an LCOV HTML coverage report to `./coverage` with
-`cargo make generate-html`. Open the `index.html` file to browse line-by-line coverage.
+From here you can generate an HTML coverage report to `./coverage` with `cargo make generate-html`.
+Open the `index.html` file to browse line-by-line coverage.
 
 Once done, run `cargo make clean-profraw` to cleanup and remove all the `*.profraw` files.
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -27,7 +27,7 @@ args = ["clippy", "--workspace", "--all-targets"]
 
 # TESTING
 
-[tasks.pre-test]
+[tasks.setup-test]
 command = "cargo"
 args = ["run", "--", "--log", "debug", "setup"]
 cwd = "./tests/fixtures/cases"
@@ -36,13 +36,12 @@ cwd = "./tests/fixtures/cases"
 command = "cargo"
 args = ["test", "--workspace"]
 
-[tasks.post-test]
-command = "rm"
-args = ["-rf", "./tests/fixtures/cases/.moon/cache"]
+[tasks.clean-test]
+script = "rm -rf ./tests/fixtures/cases/.moon/cache"
 condition = { platforms = ["mac", "linux"] }
 
 [tasks.test]
-run_task = { name = ["pre-test", "run-test"], fork = true, cleanup_task = "post-test" }
+run_task = { name = ["clean-test", "setup-test", "run-test", "clean-test"] }
 
 [tasks.test-output]
 command = "cargo"
@@ -50,9 +49,12 @@ args = ["test", "--workspace", "--", "--nocapture", "--show-output"]
 
 # CODE COVERAGE
 
+[tasks.create-coverage-dir]
+script = "mkdir ./coverage"
+
 [tasks.test-coverage]
 env = { RUSTFLAGS = "-Cinstrument-coverage", LLVM_PROFILE_FILE = "moon-%p-%m.profraw" }
-run_task = { name = ["build", "test"] }
+run_task = { name = ["build", "test", "create-coverage-dir"] }
 
 [tasks.generate-report]
 command = "grcov"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -48,6 +48,23 @@ run_task = { name = ["pre-test", "run-test"], fork = true, cleanup_task = "post-
 command = "cargo"
 args = ["test", "--workspace", "--", "--nocapture", "--show-output"]
 
+# CODE COVERAGE
+
+[tasks.test-coverage]
+env = { RUSTFLAGS = "-Cinstrument-coverage", LLVM_PROFILE_FILE = "moon-%p-%m.profraw" }
+run_task = { name = ["build", "test"] }
+
+[tasks.generate-report]
+command = "grcov"
+args = [".", "-s", "./crates", "--binary-path", "./target/debug", "-t", "lcov", "--branch", "--ignore-not-existing", "-o", "./coverage/report.txt"]
+
+[tasks.generate-html]
+command = "grcov"
+args = [".", "-s", "./crates", "--binary-path", "./target/debug", "-t", "html", "--branch", "--ignore-not-existing", "-o", "./coverage"]
+
+[tasks.clean-profraw]
+script = "rm -rf *.profraw crates/**/*.profraw tests/fixtures/**/*.profraw"
+
 ## OTHER
 
 [tasks.gen-json-schemas]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -50,7 +50,7 @@ args = ["test", "--workspace", "--", "--nocapture", "--show-output"]
 # CODE COVERAGE
 
 [tasks.create-coverage-dir]
-script = "mkdir ./coverage"
+script = "mkdir -p ./coverage"
 condition = { platforms = ["mac", "linux"] }
 
 [tasks.test-coverage]
@@ -59,7 +59,7 @@ run_task = { name = ["build", "test", "create-coverage-dir"] }
 
 [tasks.generate-report]
 command = "grcov"
-args = [".", "-s", "./crates", "--binary-path", "./target/debug", "-t", "lcov", "--branch", "--ignore-not-existing", "-o", "./coverage/report.txt"]
+args = [".", "-s", "./crates", "--binary-path", "./target/debug", "-t", "cobertura", "--branch", "--ignore-not-existing", "-o", "./coverage/report.xml"]
 
 [tasks.generate-html]
 command = "grcov"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -51,6 +51,7 @@ args = ["test", "--workspace", "--", "--nocapture", "--show-output"]
 
 [tasks.create-coverage-dir]
 script = "mkdir ./coverage"
+condition = { platforms = ["mac", "linux"] }
 
 [tasks.test-coverage]
 env = { RUSTFLAGS = "-Cinstrument-coverage", LLVM_PROFILE_FILE = "moon-%p-%m.profraw" }

--- a/crates/cli/tests/project_test.rs
+++ b/crates/cli/tests/project_test.rs
@@ -1,14 +1,8 @@
 use insta::assert_snapshot;
 use moon_utils::test::{create_moon_command, get_assert_output, get_assert_stderr_output};
 
-fn force_ansi_colors() {
-    std::env::set_var("CLICOLOR_FORCE", "1");
-}
-
 #[test]
 fn unknown_project() {
-    force_ansi_colors();
-
     let assert = create_moon_command("projects")
         .arg("project")
         .arg("unknown")
@@ -21,8 +15,6 @@ fn unknown_project() {
 
 #[test]
 fn empty_config() {
-    force_ansi_colors();
-
     let assert = create_moon_command("projects")
         .arg("project")
         .arg("emptyConfig")
@@ -33,8 +25,6 @@ fn empty_config() {
 
 #[test]
 fn no_config() {
-    force_ansi_colors();
-
     let assert = create_moon_command("projects")
         .arg("project")
         .arg("noConfig")
@@ -45,8 +35,6 @@ fn no_config() {
 
 #[test]
 fn basic_config() {
-    force_ansi_colors();
-
     // with dependsOn and fileGroups
     let assert = create_moon_command("projects")
         .arg("project")
@@ -58,8 +46,6 @@ fn basic_config() {
 
 #[test]
 fn advanced_config() {
-    force_ansi_colors();
-
     // with project metadata
     let assert = create_moon_command("projects")
         .arg("project")
@@ -71,8 +57,6 @@ fn advanced_config() {
 
 #[test]
 fn depends_on_paths() {
-    force_ansi_colors();
-
     // shows dependsOn paths when they exist
     let assert = create_moon_command("projects")
         .arg("project")
@@ -84,8 +68,6 @@ fn depends_on_paths() {
 
 #[test]
 fn with_tasks() {
-    force_ansi_colors();
-
     let assert = create_moon_command("projects")
         .arg("project")
         .arg("tasks")

--- a/crates/cli/tests/snapshots/project_test__advanced_config.snap
+++ b/crates/cli/tests/snapshots/project_test__advanced_config.snap
@@ -1,27 +1,28 @@
 ---
 source: crates/cli/tests/project_test.rs
-assertion_line: 69
+assertion_line: 55
 expression: get_assert_output(&assert)
 ---
 
 [38;5;16m[48;5;111m[1m ADVANCED [0m
 
-[38;5;248m[1mID[0m:[0m [38;5;111madvanced[0m
-[38;5;248m[1mSource[0m:[0m [38;5;36madvanced[0m
-[38;5;248m[1mType[0m:[0m Library
-[38;5;248m[1mName[0m:[0m Advanced
-[38;5;248m[1mDescription[0m:[0m Advanced example.
-[38;5;248m[1mOwner[0m:[0m Batman
-[38;5;248m[1mMaintainers[0m:[0m
- [38;5;239m-[0m Bruce Wayne
-[38;5;248m[1mChannel[0m:[0m #batcave
+ID: advanced
+Source: advanced
+Type: Library
+Name: Advanced
+Description: Advanced example.
+Owner: Batman
+Maintainers:
+ - Bruce Wayne
+Channel: #batcave
 
 [38;5;16m[48;5;15m[1m FILE GROUPS [0m
 
-[38;5;248m[1msources[0m:[0m
- [38;5;239m-[0m [38;5;36msrc/**/*[0m
- [38;5;239m-[0m [38;5;36mtypes/**/*[0m
-[38;5;248m[1mtests[0m:[0m
- [38;5;239m-[0m [38;5;36mtests/**/*[0m
+sources:
+ - src/**/*
+ - types/**/*
+tests:
+ - tests/**/*
+
 
 

--- a/crates/cli/tests/snapshots/project_test__basic_config.snap
+++ b/crates/cli/tests/snapshots/project_test__basic_config.snap
@@ -1,24 +1,25 @@
 ---
 source: crates/cli/tests/project_test.rs
-assertion_line: 56
+assertion_line: 44
 expression: get_assert_output(&assert)
 ---
 
 [38;5;16m[48;5;111m[1m BASIC [0m
 
-[38;5;248m[1mID[0m:[0m [38;5;111mbasic[0m
-[38;5;248m[1mSource[0m:[0m [38;5;36mbasic[0m
+ID: basic
+Source: basic
 
 [38;5;16m[48;5;15m[1m DEPENDS ON [0m
 
- [38;5;239m-[0m [38;5;111mnoConfig[0m [38;5;248m([0m[38;5;36mno-config[0m[38;5;248m)[0m
+ - noConfig (no-config)
 
 [38;5;16m[48;5;15m[1m FILE GROUPS [0m
 
-[38;5;248m[1msources[0m:[0m
- [38;5;239m-[0m [38;5;36msrc/**/*[0m
- [38;5;239m-[0m [38;5;36mtypes/**/*[0m
-[38;5;248m[1mtests[0m:[0m
- [38;5;239m-[0m [38;5;36m**/*_test.rs[0m
+sources:
+ - src/**/*
+ - types/**/*
+tests:
+ - **/*_test.rs
+
 
 

--- a/crates/cli/tests/snapshots/project_test__depends_on_paths.snap
+++ b/crates/cli/tests/snapshots/project_test__depends_on_paths.snap
@@ -1,25 +1,26 @@
 ---
 source: crates/cli/tests/project_test.rs
-assertion_line: 82
+assertion_line: 66
 expression: get_assert_output(&assert)
 ---
 
 [38;5;16m[48;5;111m[1m FOO [0m
 
-[38;5;248m[1mID[0m:[0m [38;5;111mfoo[0m
-[38;5;248m[1mSource[0m:[0m [38;5;36mdeps/foo[0m
+ID: foo
+Source: deps/foo
 
 [38;5;16m[48;5;15m[1m DEPENDS ON [0m
 
- [38;5;239m-[0m [38;5;111mbar[0m [38;5;248m([0m[38;5;36mdeps/bar[0m[38;5;248m)[0m
- [38;5;239m-[0m [38;5;111mbaz[0m [38;5;248m([0m[38;5;36mdeps/baz[0m[38;5;248m)[0m
+ - bar (deps/bar)
+ - baz (deps/baz)
 
 [38;5;16m[48;5;15m[1m FILE GROUPS [0m
 
-[38;5;248m[1msources[0m:[0m
- [38;5;239m-[0m [38;5;36msrc/**/*[0m
- [38;5;239m-[0m [38;5;36mtypes/**/*[0m
-[38;5;248m[1mtests[0m:[0m
- [38;5;239m-[0m [38;5;36mtests/**/*[0m
+sources:
+ - src/**/*
+ - types/**/*
+tests:
+ - tests/**/*
+
 
 

--- a/crates/cli/tests/snapshots/project_test__empty_config.snap
+++ b/crates/cli/tests/snapshots/project_test__empty_config.snap
@@ -1,20 +1,21 @@
 ---
 source: crates/cli/tests/project_test.rs
-assertion_line: 31
+assertion_line: 23
 expression: get_assert_output(&assert)
 ---
 
 [38;5;16m[48;5;111m[1m EMPTYCONFIG [0m
 
-[38;5;248m[1mID[0m:[0m [38;5;111memptyConfig[0m
-[38;5;248m[1mSource[0m:[0m [38;5;36mempty-config[0m
+ID: emptyConfig
+Source: empty-config
 
 [38;5;16m[48;5;15m[1m FILE GROUPS [0m
 
-[38;5;248m[1msources[0m:[0m
- [38;5;239m-[0m [38;5;36msrc/**/*[0m
- [38;5;239m-[0m [38;5;36mtypes/**/*[0m
-[38;5;248m[1mtests[0m:[0m
- [38;5;239m-[0m [38;5;36mtests/**/*[0m
+sources:
+ - src/**/*
+ - types/**/*
+tests:
+ - tests/**/*
+
 
 

--- a/crates/cli/tests/snapshots/project_test__no_config.snap
+++ b/crates/cli/tests/snapshots/project_test__no_config.snap
@@ -1,20 +1,21 @@
 ---
 source: crates/cli/tests/project_test.rs
-assertion_line: 43
+assertion_line: 33
 expression: get_assert_output(&assert)
 ---
 
 [38;5;16m[48;5;111m[1m NOCONFIG [0m
 
-[38;5;248m[1mID[0m:[0m [38;5;111mnoConfig[0m
-[38;5;248m[1mSource[0m:[0m [38;5;36mno-config[0m
+ID: noConfig
+Source: no-config
 
 [38;5;16m[48;5;15m[1m FILE GROUPS [0m
 
-[38;5;248m[1msources[0m:[0m
- [38;5;239m-[0m [38;5;36msrc/**/*[0m
- [38;5;239m-[0m [38;5;36mtypes/**/*[0m
-[38;5;248m[1mtests[0m:[0m
- [38;5;239m-[0m [38;5;36mtests/**/*[0m
+sources:
+ - src/**/*
+ - types/**/*
+tests:
+ - tests/**/*
+
 
 

--- a/crates/cli/tests/snapshots/project_test__unknown_project.snap
+++ b/crates/cli/tests/snapshots/project_test__unknown_project.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/cli/tests/project_test.rs
-assertion_line: 17
+assertion_line: 11
 expression: get_assert_stderr_output(&assert)
 ---
 
-[38;5;15m[48;5;161m[1m ERROR [0m No project has been configured with the ID [38;5;111munknown[0m.
+[38;5;15m[48;5;161m[1m ERROR [0m No project has been configured with the ID unknown.
+
 
 

--- a/crates/cli/tests/snapshots/project_test__with_tasks.snap
+++ b/crates/cli/tests/snapshots/project_test__with_tasks.snap
@@ -1,25 +1,26 @@
 ---
 source: crates/cli/tests/project_test.rs
-assertion_line: 94
+assertion_line: 76
 expression: get_assert_output(&assert)
 ---
 
 [38;5;16m[48;5;111m[1m TASKS [0m
 
-[38;5;248m[1mID[0m:[0m [38;5;111mtasks[0m
-[38;5;248m[1mSource[0m:[0m [38;5;36mtasks[0m
+ID: tasks
+Source: tasks
 
 [38;5;16m[48;5;15m[1m TASKS [0m
 
-[38;5;248m[1mlint[0m:[0m [38;5;183meslint --cache --report-unused-disable-directives[0m
-[38;5;248m[1mtest[0m:[0m [38;5;183mjest --cache --color[0m
+lint: eslint --cache --report-unused-disable-directives
+test: jest --cache --color
 
 [38;5;16m[48;5;15m[1m FILE GROUPS [0m
 
-[38;5;248m[1msources[0m:[0m
- [38;5;239m-[0m [38;5;36msrc/**/*[0m
- [38;5;239m-[0m [38;5;36mtypes/**/*[0m
-[38;5;248m[1mtests[0m:[0m
- [38;5;239m-[0m [38;5;36mtests/**/*[0m
+sources:
+ - src/**/*
+ - types/**/*
+tests:
+ - tests/**/*
+
 
 

--- a/crates/cli/tests/snapshots/run_test__node__inherits_moon_env_vars.snap
+++ b/crates/cli/tests/snapshots/run_test__node__inherits_moon_env_vars.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/cli/tests/run_test.rs
-assertion_line: 444
+assertion_line: 478
 expression: "get_path_safe_output(&assert, fixture.path())"
 ---
 ▪▪▪▪ npm install
 ▪▪▪▪ node:envVarsMoon
 MOON_CACHE=write
 MOON_CACHE_DIR=<WORKSPACE>/.moon/cache
-MOON_LOG=off
+MOON_LOG=trace
 MOON_PROJECT_ID=node
 MOON_PROJECT_ROOT=<WORKSPACE>/node
 MOON_PROJECT_RUNFILE=<WORKSPACE>/.moon/cache/runs/node/runfile.json
@@ -19,5 +19,6 @@ MOON_WORKSPACE_ROOT=<WORKSPACE>
 
 Tasks: 1 completed
  Time: 100ms
+
 
 

--- a/crates/cli/tests/snapshots/run_test__system__inherits_moon_env_vars.snap
+++ b/crates/cli/tests/snapshots/run_test__system__inherits_moon_env_vars.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/cli/tests/run_test.rs
-assertion_line: 905
+assertion_line: 939
 expression: "get_path_safe_output(&assert, fixture.path())"
 ---
 ▪▪▪▪ npm install
 ▪▪▪▪ system:envVarsMoon
 MOON_CACHE=write
 MOON_CACHE_DIR=<WORKSPACE>/.moon/cache
-MOON_LOG=off
+MOON_LOG=trace
 MOON_PROJECT_ID=system
 MOON_PROJECT_ROOT=<WORKSPACE>/system
 MOON_PROJECT_RUNFILE=<WORKSPACE>/.moon/cache/runs/system/runfile.json
@@ -19,5 +19,6 @@ MOON_WORKSPACE_ROOT=<WORKSPACE>
 
 Tasks: 1 completed
  Time: 100ms
+
 
 

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -291,17 +291,14 @@ impl Command {
             if value.is_some() {
                 let key_str = key.to_str().unwrap();
 
-                // This is very noisy, maybe with a verbose logging setting?
-                if key_str == "PATH" {
-                    continue;
+                if key_str.starts_with("MOON_") || key_str.starts_with("NODE_") {
+                    envs_list.push(format!(
+                        "\n  {}{}{}",
+                        key_str,
+                        color::muted("="),
+                        color::muted_light(value.unwrap().to_str().unwrap())
+                    ));
                 }
-
-                envs_list.push(format!(
-                    "\n  {}{}{}",
-                    key_str,
-                    color::muted("="),
-                    color::muted_light(value.unwrap().to_str().unwrap())
-                ));
             }
         }
 

--- a/crates/utils/src/test.rs
+++ b/crates/utils/src/test.rs
@@ -105,9 +105,8 @@ pub fn create_moon_command_in(path: &Path) -> assert_cmd::Command {
     cmd.env("MOON_TEST_HIDE_INSTALL_OUTPUT", "true");
     // Standardize file system paths for testing snapshots
     cmd.env("MOON_TEST_STANDARDIZE_PATHS", "true");
-    // Uncomment for debugging
-    cmd.env("MOON_LOG", "off");
-    // cmd.env("MOON_LOG", "trace")
+    // Enable logging for code coverage
+    cmd.env("MOON_LOG", "trace");
     cmd
 }
 
@@ -116,7 +115,24 @@ pub fn get_assert_output(assert: &assert_cmd::assert::Assert) -> String {
 }
 
 pub fn get_assert_stderr_output(assert: &assert_cmd::assert::Assert) -> String {
-    String::from_utf8(assert.get_output().stderr.to_owned()).unwrap()
+    let mut output = String::new();
+
+    for line in String::from_utf8(assert.get_output().stderr.to_owned())
+        .unwrap()
+        .split('\n')
+    {
+        if !line.starts_with("[error")
+            && !line.starts_with("[warn")
+            && !line.starts_with("[info")
+            && !line.starts_with("[debug")
+            && !line.starts_with("[trace")
+        {
+            output.push_str(line);
+            output.push('\n');
+        }
+    }
+
+    output
 }
 
 pub fn get_assert_stdout_output(assert: &assert_cmd::assert::Assert) -> String {

--- a/crates/utils/src/test.rs
+++ b/crates/utils/src/test.rs
@@ -117,6 +117,9 @@ pub fn get_assert_output(assert: &assert_cmd::assert::Assert) -> String {
 pub fn get_assert_stderr_output(assert: &assert_cmd::assert::Assert) -> String {
     let mut output = String::new();
 
+    // We need to always show logs for proper code coverage,
+    // but this breaks snapshots, and as such, we need to manually
+    // filter out the log lines!
     for line in String::from_utf8(assert.get_output().stderr.to_owned())
         .unwrap()
         .split('\n')

--- a/crates/utils/src/test.rs
+++ b/crates/utils/src/test.rs
@@ -119,16 +119,18 @@ pub fn get_assert_stderr_output(assert: &assert_cmd::assert::Assert) -> String {
 
     // We need to always show logs for proper code coverage,
     // but this breaks snapshots, and as such, we need to manually
-    // filter out the log lines!
+    // filter out log lines and env vars!
     for line in String::from_utf8(assert.get_output().stderr.to_owned())
         .unwrap()
         .split('\n')
     {
         if !line.starts_with("[error")
-            && !line.starts_with("[warn")
-            && !line.starts_with("[info")
+            && !line.starts_with("[ warn")
+            && !line.starts_with("[ info")
             && !line.starts_with("[debug")
             && !line.starts_with("[trace")
+            && !line.starts_with("  MOON_")
+            && !line.starts_with("  NODE_")
         {
             output.push_str(line);
             output.push('\n');


### PR DESCRIPTION
Our code coverage works, but it was an issue where each OS uploads there report at different intervals, resulting in the GitHub PR comment representing an invalid state. This is especially true for Windows, which is reported like 5 minutes after the others.

This changes code coverage to upload all 3 reports at the same time, hopefully generating a more accurate coverage percentage.

Edit: Looks like windows doesn't work at all...