### PR TITLE
breaking: Move `type` setting in `project.yml` to the top-level.

### DIFF
--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -28,8 +28,9 @@ pub async fn project(id: &str, json: bool) -> Result<(), Box<dyn std::error::Err
     }
 
     if let Some(config) = project.config {
+        term.render_entry("Type", &term.format(&config.type_of))?;
+
         if let Some(meta) = config.project {
-            term.render_entry("Type", &term.format(&meta.type_of))?;
             term.render_entry("Name", &meta.name)?;
             term.render_entry("Description", &meta.description)?;
             term.render_entry("Owner", &meta.owner)?;

--- a/crates/cli/tests/snapshots/project_test__advanced_config.snap
+++ b/crates/cli/tests/snapshots/project_test__advanced_config.snap
@@ -8,7 +8,7 @@ expression: get_assert_output(&assert)
 
 ID: advanced
 Source: advanced
-Type: Library
+Type: Application
 Name: Advanced
 Description: Advanced example.
 Owner: Batman

--- a/crates/cli/tests/snapshots/project_test__basic_config.snap
+++ b/crates/cli/tests/snapshots/project_test__basic_config.snap
@@ -8,6 +8,7 @@ expression: get_assert_output(&assert)
 
 ID: basic
 Source: basic
+Type: Library
 
  DEPENDS ON 
 

--- a/crates/cli/tests/snapshots/project_test__depends_on_paths.snap
+++ b/crates/cli/tests/snapshots/project_test__depends_on_paths.snap
@@ -8,6 +8,7 @@ expression: get_assert_output(&assert)
 
 ID: foo
 Source: deps/foo
+Type: Library
 
  DEPENDS ON 
 

--- a/crates/cli/tests/snapshots/project_test__empty_config.snap
+++ b/crates/cli/tests/snapshots/project_test__empty_config.snap
@@ -8,6 +8,7 @@ expression: get_assert_output(&assert)
 
 ID: emptyConfig
 Source: empty-config
+Type: Library
 
  FILE GROUPS 
 

--- a/crates/cli/tests/snapshots/project_test__with_tasks.snap
+++ b/crates/cli/tests/snapshots/project_test__with_tasks.snap
@@ -8,6 +8,7 @@ expression: get_assert_output(&assert)
 
 ID: tasks
 Source: tasks
+Type: Library
 
  TASKS 
 

--- a/crates/config/src/project/mod.rs
+++ b/crates/config/src/project/mod.rs
@@ -64,13 +64,17 @@ pub enum ProjectType {
     Application,
     Library,
     Tool,
+    Unknown,
+}
+
+impl Default for ProjectType {
+    fn default() -> Self {
+        ProjectType::Library
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct ProjectMetadataConfig {
-    #[serde(rename = "type")]
-    pub type_of: ProjectType,
-
     pub name: String,
 
     pub description: String,
@@ -119,6 +123,9 @@ pub struct ProjectConfig {
     #[validate(custom = "validate_tasks")]
     #[validate]
     pub tasks: HashMap<String, TaskConfig>,
+
+    #[serde(rename = "type")]
+    pub type_of: ProjectType,
 
     #[serde(default)]
     #[validate]

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -139,13 +139,13 @@ fn advanced_config() {
             id: String::from("advanced"),
             config: Some(ProjectConfig {
                 project: Some(ProjectMetadataConfig {
-                    type_of: ProjectType::Library,
                     name: String::from("Advanced"),
                     description: String::from("Advanced example."),
                     owner: String::from("Batman"),
                     maintainers: string_vec!["Bruce Wayne"],
                     channel: String::from("#batcave"),
                 }),
+                type_of: ProjectType::Application,
                 ..ProjectConfig::default()
             }),
             log_target: String::from("moon:project:advanced"),

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### 💥 Breaking
+
+- Moved the `project.type` setting in `project.yml` to the top-level. Is now simply `type`.
+
 #### 🚀 Updates
 
 - Added support for a list of globs when configuring `projects` in `.moon/workspace.yml`.

--- a/tests/fixtures/projects/advanced/project.yml
+++ b/tests/fixtures/projects/advanced/project.yml
@@ -5,3 +5,5 @@ project:
   channel: '#batcave'
   owner: 'Batman'
   maintainers: ['Bruce Wayne']
+
+type: 'application'

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -73,7 +73,6 @@ when defined, all fields within it _must_ be defined as well.
 
 ```yaml title="project.yml"
 project:
-  type: 'tool'
   name: 'moon'
   description: 'A monorepo management tool.'
   channel: '#moon'
@@ -118,16 +117,6 @@ A human readable name of the project. This is _different_ from the unique projec
 
 The team or organization that owns the project. Can be a title, LDAP name, GitHub team, etc. We
 suggest _not_ listing people/developers as the owner, use [maintainers](#maintainers) instead.
-
-### `type`
-
-> `ProjectType`
-
-The type of project. Supports the following values:
-
-- `application` - A backend or frontend application that communicates over HTTP, TCP, RPC, etc.
-- `library` - A self-contained, shareable, and publishable set of code.
-- `tool` - An internal tool, command line program, one-off script, etc.
 
 ## `tasks`
 
@@ -397,6 +386,20 @@ tasks:
 
 > This field exists because of our [toolchain](../concepts/toolchain), and moon ensuring the correct
 > command is ran.
+
+## `type`
+
+> `ProjectType`
+
+The type of project. Supports the following values:
+
+- `application` - A backend or frontend application that communicates over HTTP, TCP, RPC, etc.
+- `library` (default) - A self-contained, shareable, and publishable set of code.
+- `tool` - An internal tool, command line program, one-off script, etc.
+
+```yaml title="project.yml"
+type: 'application'
+```
 
 ## `workspace`
 

--- a/website/static/schemas/project.json
+++ b/website/static/schemas/project.json
@@ -3,6 +3,9 @@
   "title": "ProjectConfig",
   "description": "Docs: https://moonrepo.dev/docs/config/project",
   "type": "object",
+  "required": [
+    "type"
+  ],
   "properties": {
     "dependsOn": {
       "default": [],
@@ -38,6 +41,9 @@
         "$ref": "#/definitions/TaskConfig"
       }
     },
+    "type": {
+      "$ref": "#/definitions/ProjectType"
+    },
     "workspace": {
       "default": {
         "inheritedTasks": {
@@ -61,8 +67,7 @@
         "description",
         "maintainers",
         "name",
-        "owner",
-        "type"
+        "owner"
       ],
       "properties": {
         "channel": {
@@ -82,9 +87,6 @@
         },
         "owner": {
           "type": "string"
-        },
-        "type": {
-          "$ref": "#/definitions/ProjectType"
         }
       }
     },
@@ -93,7 +95,8 @@
       "enum": [
         "application",
         "library",
-        "tool"
+        "tool",
+        "unknown"
       ]
     },
     "ProjectWorkspaceConfig": {


### PR DESCRIPTION
This allows the type to be configured without having to define all the `project` metadata.