### PR TITLE
ci: Write all `.profraw` files to the root for consistent code coverage.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,7 +118,7 @@ jobs:
           args: --workspace
         env:
           RUSTFLAGS: -Cinstrument-coverage
-          LLVM_PROFILE_FILE: moon-%p-%m.profraw
+          LLVM_PROFILE_FILE: ${{ env.PWD }}/moon-%p-%m.profraw
       # Windows fails to compile right now...
       - name: Generate code coverage
         if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,15 +118,12 @@ jobs:
           args: --workspace
         env:
           RUSTFLAGS: -Cinstrument-coverage
-          LLVM_PROFILE_FILE: ${{ env.PWD }}/moon-%p-%m.profraw
-      # Windows fails to compile right now...
+          LLVM_PROFILE_FILE: ${{ github.workspace }}/moon-%p-%m.profraw
       - name: Generate code coverage
-        if: ${{ matrix.os != 'windows-latest' }}
         run:
           grcov . -s ./crates --binary-path ./target/debug -t lcov --branch --ignore-not-existing -o
           ./report.txt
       - uses: actions/upload-artifact@v2
-        if: ${{ matrix.os != 'windows-latest' }}
         name: Upload coverage report
         with:
           name: coverage-${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,11 +119,14 @@ jobs:
         env:
           RUSTFLAGS: -Cinstrument-coverage
           LLVM_PROFILE_FILE: ${{ github.workspace }}/moon-%p-%m.profraw
+      # Windows fails to compile right now...
       - name: Generate code coverage
+        if: ${{ matrix.os != 'windows-latest' }}
         run:
           grcov . -s ./crates --binary-path ./target/debug -t lcov --branch --ignore-not-existing -o
           ./report.txt
       - uses: actions/upload-artifact@v2
+        if: ${{ matrix.os != 'windows-latest' }}
         name: Upload coverage report
         with:
           name: coverage-${{ matrix.os }}

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -50,7 +50,7 @@ args = ["test", "--workspace", "--", "--nocapture", "--show-output"]
 # CODE COVERAGE
 
 [tasks.test-coverage]
-env = { RUSTFLAGS = "-Cinstrument-coverage", LLVM_PROFILE_FILE = "moon-%p-%m.profraw" }
+env = { RUSTFLAGS = "-Cinstrument-coverage", LLVM_PROFILE_FILE = "${PWD}/moon-%p-%m.profraw" }
 run_task = { name = ["build", "test"] }
 
 [tasks.generate-report]
@@ -62,7 +62,7 @@ command = "grcov"
 args = [".", "-s", "./crates", "--binary-path", "./target/debug", "-t", "html", "--branch", "--ignore-not-existing", "-o", "./coverage"]
 
 [tasks.clean-profraw]
-script = "rm -rf *.profraw crates/**/*.profraw tests/fixtures/**/*.profraw"
+script = "rm -rf *.profraw"
 
 ## OTHER
 


### PR DESCRIPTION
When code coverage is ran, it generates a ton of `.profraw` files in the root, and a handful of nested folders. I noticed that  missing coverage is for tests that run the binary as a child process using `assert_cmd`, which places `.profraw` files in nested folders. I have a feeling that grcov does not recursively find these files and only checks the root.

After many attempts, I found that using an absolute file path for `LLVM_PROFILE_FILE` bumps coverage from 70% -> 85%. Success!