### PR TITLE
v0.4

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -15,5 +15,8 @@ projects:
   # runtime: 'packages/runtime'
   # website: 'website'
 
+actionRunner:
+  logRunningCommand: true
+
 vcs:
   defaultBranch: 'master'

--- a/.yarn/versions/a73d03ac.yml
+++ b/.yarn/versions/a73d03ac.yml
@@ -1,0 +1,7 @@
+releases:
+  "@moonrepo/cli": minor
+  "@moonrepo/core-linux-x64-gnu": minor
+  "@moonrepo/core-linux-x64-musl": minor
+  "@moonrepo/core-macos-arm64": minor
+  "@moonrepo/core-macos-x64": minor
+  "@moonrepo/core-windows-x64-msvc": minor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "shell-words",
  "tokio",
  "wax",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,16 +251,16 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadf76ddea74bab35ebeb8f1eb115b9bc04eaee42d8acc0d5f477dee6b176c9a"
+checksum = "12f5cd208ba696f870238022d81ca1d80ed9d696fd62341c747f2d8f6ecdd9fe"
 dependencies = [
  "async-trait",
  "async_once",
  "cached_proc_macro",
  "cached_proc_macro_types",
  "futures",
- "hashbrown 0.12.1",
+ "hashbrown",
  "lazy_static",
  "once_cell",
  "thiserror",
@@ -355,16 +355,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "terminal_size",
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
 dependencies = [
  "os_str_bytes",
 ]
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a1316fa6a23fea1ee41cb80321590385e5f3e575e99f77c4d918ce5d44379d"
+checksum = "2906f2480cdc015e998deac388331a0f1c1cd88744948c749513020c83c370bc"
 dependencies = [
  "const_format_proc_macros",
 ]
@@ -487,12 +487,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
 dependencies = [
  "cfg-if",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -627,9 +627,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
+checksum = "140206b78fb2bc3edbcfc9b5ccbd0b30699cfe8d348b8b31b330e47df5291a5a"
 
 [[package]]
 name = "either"
@@ -869,13 +869,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -920,12 +920,6 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hashbrown"
@@ -1083,12 +1077,12 @@ checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1105,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc3e639bcba360d9237acabd22014c16f3df772db463b7446cd81b070714767"
+checksum = "4126dd76ebfe2561486a1bd6738a33d2029ffb068a99ac446b7f8c77b2e58dbc"
 dependencies = [
  "console",
  "once_cell",
@@ -1164,9 +1158,9 @@ checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1972,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "f53dc8cf16a769a6f677e09e7ff2cd4be1ea0f48754aac39520536962011de0d"
 dependencies = [
  "proc-macro2",
 ]
@@ -2063,9 +2057,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
  "base64",
  "bytes",
@@ -2090,6 +2084,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2378,9 +2373,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum_macros"
@@ -2403,9 +2398,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2623,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -2732,9 +2727,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
@@ -2867,9 +2862,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2877,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2892,9 +2887,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2904,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2914,9 +2909,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2927,9 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "wax"
@@ -2951,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,7 @@ dependencies = [
  "moon_lang_node",
  "moon_utils",
  "regex",
+ "reqwest",
  "schemars",
  "semver",
  "serde",

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -1,5 +1,7 @@
 // https://github.com/clap-rs/clap/tree/master/examples/derive_ref#app-attributes
 
+use std::path::PathBuf;
+
 use crate::commands::bin::BinTools;
 use crate::commands::init::{InheritProjectsAs, PackageManager};
 use crate::commands::run::RunStatus;
@@ -207,6 +209,13 @@ pub struct App {
         default_value_t
     )]
     pub log: LogLevel,
+
+    #[clap(
+        long,
+        env = "MOON_LOG_FILE",
+        help = "Path to a file to dump the moon logs"
+    )]
+    pub log_file: Option<PathBuf>,
 
     #[clap(subcommand)]
     pub command: Commands,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -46,7 +46,7 @@ pub async fn run_cli() {
         env::set_var("MOON_LOG", args.log.to_string().to_lowercase());
     }
 
-    Logger::init(map_log_level(args.log));
+    Logger::init(map_log_level(args.log), args.log_file);
 
     // Setup caching
     if env::var("MOON_CACHE").is_err() {

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -142,6 +142,41 @@ mod configs {
     }
 }
 
+mod logs {
+    use super::*;
+    use moon_utils::test::create_fixtures_sandbox;
+
+    #[test]
+    fn creates_log_file() {
+        let fixture = create_fixtures_sandbox("cases");
+
+        create_moon_command_in(fixture.path())
+            .arg("--logFile=output.log")
+            .arg("run")
+            .arg("node:standard")
+            .assert();
+
+        let output_path = fixture.path().join("output.log");
+
+        assert!(output_path.exists());
+    }
+
+    #[test]
+    fn creates_nested_log_file() {
+        let fixture = create_fixtures_sandbox("cases");
+
+        create_moon_command_in(fixture.path())
+            .arg("--logFile=nested/output.log")
+            .arg("run")
+            .arg("node:standard")
+            .assert();
+
+        let output_path = fixture.path().join("nested/output.log");
+
+        assert!(output_path.exists());
+    }
+}
+
 mod caching {
     use super::*;
     use moon_cache::{CacheItem, RunTargetState};

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -69,6 +69,45 @@ fn errors_for_cycle_in_task_deps() {
     assert_snapshot!(get_assert_output(&assert));
 }
 
+#[cfg(not(windows))]
+mod general {
+    use super::*;
+
+    #[test]
+    fn logs_command_for_project_root() {
+        let fixture = create_fixtures_sandbox("cases");
+
+        append_workspace_config(
+            &fixture.path().join(".moon/workspace.yml"),
+            "actionRunner:\n  logRunningCommand: true",
+        );
+
+        let assert = create_moon_command_in(fixture.path())
+            .arg("run")
+            .arg("base:runFromProject")
+            .assert();
+
+        assert_snapshot!(get_assert_output(&assert));
+    }
+
+    #[test]
+    fn logs_command_for_workspace_root() {
+        let fixture = create_fixtures_sandbox("cases");
+
+        append_workspace_config(
+            &fixture.path().join(".moon/workspace.yml"),
+            "actionRunner:\n  logRunningCommand: true",
+        );
+
+        let assert = create_moon_command_in(fixture.path())
+            .arg("run")
+            .arg("base:runFromWorkspace")
+            .assert();
+
+        assert_snapshot!(get_assert_output(&assert));
+    }
+}
+
 mod configs {
     use super::*;
 

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
@@ -67,9 +67,3 @@ vcs:
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
 
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true
-

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
@@ -67,9 +67,3 @@ vcs:
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
 
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true
-

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
@@ -67,9 +67,3 @@ vcs:
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
 
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true
-

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
@@ -67,9 +67,3 @@ vcs:
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
 
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true
-

--- a/crates/cli/tests/snapshots/init_test__node__infers_version_from_nodenv.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_version_from_nodenv.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__infers_version_from_nodenv.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_version_from_nodenv.snap
@@ -66,9 +66,3 @@ vcs:
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
 
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true
-

--- a/crates/cli/tests/snapshots/init_test__node__infers_version_from_nvm.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_version_from_nvm.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__infers_version_from_nvm.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_version_from_nvm.snap
@@ -66,9 +66,3 @@ vcs:
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
 
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true
-

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm.snap
@@ -66,9 +66,3 @@ vcs:
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
 
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true
-

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm_from_package.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm_from_package.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm_from_package.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm_from_package.snap
@@ -70,9 +70,3 @@ vcs:
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
 
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true
-

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm.snap
@@ -70,9 +70,3 @@ vcs:
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
 
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true
-

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm_from_package.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm_from_package.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm_from_package.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm_from_package.snap
@@ -70,9 +70,3 @@ vcs:
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
 
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true
-

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn.snap
@@ -70,9 +70,3 @@ vcs:
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
 
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true
-

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn_from_package.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn_from_package.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn_from_package.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn_from_package.snap
@@ -70,9 +70,3 @@ vcs:
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
 
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true
-

--- a/crates/cli/tests/snapshots/run_test__general__logs_command_for_project_root.snap
+++ b/crates/cli/tests/snapshots/run_test__general__logs_command_for_project_root.snap
@@ -1,0 +1,15 @@
+---
+source: crates/cli/tests/run_test.rs
+assertion_line: 90
+expression: get_assert_output(&assert)
+---
+▪▪▪▪ npm install
+▪▪▪▪ base:runFromProject
+echo 'in project' (in ./base)
+in project
+
+Tasks: 1 completed
+ Time: 100ms
+
+
+

--- a/crates/cli/tests/snapshots/run_test__general__logs_command_for_workspace_root.snap
+++ b/crates/cli/tests/snapshots/run_test__general__logs_command_for_workspace_root.snap
@@ -1,0 +1,15 @@
+---
+source: crates/cli/tests/run_test.rs
+assertion_line: 107
+expression: get_assert_output(&assert)
+---
+▪▪▪▪ npm install
+▪▪▪▪ base:runFromWorkspace
+echo 'in workspace' (in workspace)
+in workspace
+
+Tasks: 1 completed
+ Time: 100ms
+
+
+

--- a/crates/cli/tests/snapshots/run_test__logs__creates_log_file.snap
+++ b/crates/cli/tests/snapshots/run_test__logs__creates_log_file.snap
@@ -1,0 +1,137 @@
+---
+source: crates/cli/tests/run_test.rs
+expression: log_contents
+---
+[TRACE 2022-06-21 14:22:14] moon:workspace Attempting to find workspace root at /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ
+[DEBUG 2022-06-21 14:22:14] moon:workspace Creating workspace at /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ (from working directory /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ)
+[TRACE 2022-06-21 14:22:14] moon:workspace Loading .moon/workspace.yml from /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ
+[TRACE 2022-06-21 14:22:14] moon:workspace Attempting to find .moon/project.yml in /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ
+[TRACE 2022-06-21 14:22:14] moon:workspace Loading package.json from /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ
+[TRACE 2022-06-21 14:22:14] moon:workspace Attempting to find tsconfig.json in /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ
+[DEBUG 2022-06-21 14:22:14] moon:cache Creating cache engine at /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/.moon/cache
+[DEBUG 2022-06-21 14:22:14] moon:toolchain Creating toolchain at ~/.moon
+[TRACE 2022-06-21 14:22:14] moon:toolchain Creating directory ~/.moon
+[TRACE 2022-06-21 14:22:14] moon:toolchain Creating directory ~/.moon/temp
+[TRACE 2022-06-21 14:22:14] moon:toolchain Creating directory ~/.moon/tools
+[DEBUG 2022-06-21 14:22:14] moon:project-graph Creating project graph with 11 projects
+[DEBUG 2022-06-21 14:22:14] moon:dep-graph Creating dependency graph
+[TRACE 2022-06-21 14:22:14] moon:project-graph Project node does not exist in the project graph, attempting to load
+[DEBUG 2022-06-21 14:22:14] moon:project:node Loading project from /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/node (id = node, path = node)
+[TRACE 2022-06-21 14:22:14] moon:project:node Attempting to find project.yml in /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/node
+[DEBUG 2022-06-21 14:22:14] moon:project:node Creating file groups
+[DEBUG 2022-06-21 14:22:14] moon:project:node Creating tasks
+[DEBUG 2022-06-21 14:22:14] moon:project:node:unhandledPromise Creating task node:unhandledPromise with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:throwError Creating task node:throwError with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:retryCount Creating task node:retryCount with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:envVarsMoon Creating task node:envVarsMoon with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:npm Creating task node:npm with command npm
+[DEBUG 2022-06-21 14:22:14] moon:project:node:cjs Creating task node:cjs with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:topLevelAwait Creating task node:topLevelAwait with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:runFromProject Creating task node:runFromProject with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:mjs Creating task node:mjs with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:standard Creating task node:standard with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:envVars Creating task node:envVars with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:exitCodeZero Creating task node:exitCodeZero with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:exitCodeNonZero Creating task node:exitCodeNonZero with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:runFromWorkspace Creating task node:runFromWorkspace with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:processExitNonZero Creating task node:processExitNonZero with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:passthroughArgs Creating task node:passthroughArgs with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:processExitZero Creating task node:processExitZero with command node
+[DEBUG 2022-06-21 14:22:14] moon:project:node:throwError Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:exitCodeNonZero Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:runFromProject Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:retryCount Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:runFromWorkspace Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:topLevelAwait Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:mjs Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:processExitZero Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:exitCodeZero Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:processExitNonZero Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:passthroughArgs Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:standard Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:cjs Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:unhandledPromise Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:envVars Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:npm Expanding deps, inputs, outputs, and args
+[DEBUG 2022-06-21 14:22:14] moon:project:node:envVarsMoon Expanding deps, inputs, outputs, and args
+[TRACE 2022-06-21 14:22:14] moon:dep-graph Target node:standard does not exist in the dependency graph, inserting
+[TRACE 2022-06-21 14:22:14] moon:dep-graph Syncing project node configs and dependencies
+[DEBUG 2022-06-21 14:22:14] moon:action-runner Creating action runner
+[TRACE 2022-06-21 14:22:14] moon:action-runner Deleting stale runfiles
+[DEBUG 2022-06-21 14:22:14] moon:action-runner Running 4 actions across 3 batches
+[TRACE 2022-06-21 14:22:14] moon:action-runner:batch:1 Running 1 actions
+[TRACE 2022-06-21 14:22:14] moon:action-runner:batch:1:1 Running action SetupToolchain
+[DEBUG 2022-06-21 14:22:14] moon:action:setup-toolchain Setting up toolchain
+[TRACE 2022-06-21 14:22:14] moon:cache:item Cache miss for /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/.moon/cache/workspaceState.json, does not exist
+[DEBUG 2022-06-21 14:22:14] moon:toolchain Downloading and installing tools
+[DEBUG 2022-06-21 14:22:14] moon:toolchain:node Tool has already been downloaded, continuing
+[DEBUG 2022-06-21 14:22:14] moon:toolchain:node Tool has already been installed, continuing
+[TRACE 2022-06-21 14:22:14] moon:utils Running command ~/.moon/tools/node/16.0.0/bin/npm --version (in working dir)
+[TRACE 2022-06-21 14:22:14] mio::poll registering event source with poller: token=Token(16777218), interests=READABLE | WRITABLE
+[TRACE 2022-06-21 14:22:14] mio::poll registering event source with poller: token=Token(16777217), interests=READABLE | WRITABLE
+[TRACE 2022-06-21 14:22:14] mio::poll deregistering event source from poller
+[TRACE 2022-06-21 14:22:14] mio::poll deregistering event source from poller
+[DEBUG 2022-06-21 14:22:14] moon:toolchain:npm Using the version (7.10.0) that came bundled with Node.js
+[DEBUG 2022-06-21 14:22:14] moon:toolchain:npm Tool has already been installed, continuing
+[TRACE 2022-06-21 14:22:14] moon:utils Running command ~/.moon/tools/node/16.0.0/bin/npm config get prefix (in working dir)
+[TRACE 2022-06-21 14:22:14] mio::poll registering event source with poller: token=Token(33554433), interests=READABLE | WRITABLE
+[TRACE 2022-06-21 14:22:14] mio::poll registering event source with poller: token=Token(33554434), interests=READABLE | WRITABLE
+[TRACE 2022-06-21 14:22:14] mio::poll deregistering event source from poller
+[TRACE 2022-06-21 14:22:14] mio::poll deregistering event source from poller
+[TRACE 2022-06-21 14:22:14] moon:cache:item Writing cache /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/.moon/cache/workspaceState.json
+[TRACE 2022-06-21 14:22:14] moon:action-runner:batch:1:1 Ran action SetupToolchain in 235.762125ms
+[TRACE 2022-06-21 14:22:14] moon:action-runner:batch:2 Running 2 actions
+[TRACE 2022-06-21 14:22:14] moon:action-runner:batch:2:1 Running action InstallNodeDeps
+[TRACE 2022-06-21 14:22:14] moon:action-runner:batch:2:2 Running action SyncProject(node)
+[TRACE 2022-06-21 14:22:14] moon:cache:item Cache hit for /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/.moon/cache/workspaceState.json, reading
+[TRACE 2022-06-21 14:22:14] moon:project:node Attempting to find package.json in /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/node
+[TRACE 2022-06-21 14:22:14] moon:project:node Attempting to find tsconfig.json in /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/node
+[TRACE 2022-06-21 14:22:14] moon:action-runner:batch:2:2 Ran action SyncProject(node) in 245.625µs
+[DEBUG 2022-06-21 14:22:14] moon:action:install-node-deps Installing Node.js dependencies
+[TRACE 2022-06-21 14:22:14] moon:utils Running command ~/.moon/tools/node/16.0.0/bin/npm install --no-audit --no-fund (in /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ)
+[TRACE 2022-06-21 14:22:14] mio::poll registering event source with poller: token=Token(50331650), interests=READABLE | WRITABLE
+[TRACE 2022-06-21 14:22:14] mio::poll registering event source with poller: token=Token(50331649), interests=READABLE | WRITABLE
+[TRACE 2022-06-21 14:22:15] mio::poll deregistering event source from poller
+[TRACE 2022-06-21 14:22:15] mio::poll deregistering event source from poller
+[TRACE 2022-06-21 14:22:15] moon:cache:item Writing cache /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/.moon/cache/workspaceState.json
+[TRACE 2022-06-21 14:22:15] moon:action-runner:batch:2:1 Ran action InstallNodeDeps in 227.119541ms
+[TRACE 2022-06-21 14:22:15] moon:action-runner:batch:3 Running 1 actions
+[TRACE 2022-06-21 14:22:15] moon:action-runner:batch:3:1 Running action RunTarget(node:standard)
+[DEBUG 2022-06-21 14:22:15] moon:action:run-target Running target node:standard
+[TRACE 2022-06-21 14:22:15] moon:cache:item Cache miss for /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/.moon/cache/runs/node/standard/lastRunState.json, does not exist
+[TRACE 2022-06-21 14:22:15] moon:project:node Attempting to find package.json in /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/node
+[TRACE 2022-06-21 14:22:15] moon:project:node Attempting to find tsconfig.json in /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/node
+[TRACE 2022-06-21 14:22:15] moon:utils Running command git ls-tree HEAD -r node (in /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ)
+[TRACE 2022-06-21 14:22:15] mio::poll registering event source with poller: token=Token(67108865), interests=READABLE | WRITABLE
+[TRACE 2022-06-21 14:22:15] mio::poll registering event source with poller: token=Token(67108866), interests=READABLE | WRITABLE
+[TRACE 2022-06-21 14:22:15] mio::poll deregistering event source from poller
+[TRACE 2022-06-21 14:22:15] mio::poll deregistering event source from poller
+[TRACE 2022-06-21 14:22:15] moon:utils Running command git status --porcelain --untracked-files -z (in /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ)
+[TRACE 2022-06-21 14:22:15] mio::poll registering event source with poller: token=Token(83886082), interests=READABLE | WRITABLE
+[TRACE 2022-06-21 14:22:15] mio::poll registering event source with poller: token=Token(83886081), interests=READABLE | WRITABLE
+[TRACE 2022-06-21 14:22:15] mio::poll deregistering event source from poller
+[TRACE 2022-06-21 14:22:15] mio::poll deregistering event source from poller
+[DEBUG 2022-06-21 14:22:15] moon:action:run-target Generated hash 3270284f4824b530c3006108757e715f73a43f949c811db7c0859aded12d9036 for target node:standard
+[DEBUG 2022-06-21 14:22:15] moon:action:run-target Creating node:standard command (in working directory /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/node)
+[TRACE 2022-06-21 14:22:15] moon:action:run-target Creating MOON_* environment variables
+[TRACE 2022-06-21 14:22:15] moon:cache:runfile Writing runfile /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/.moon/cache/runs/node/runfile.json
+[TRACE 2022-06-21 14:22:15] moon:utils Running command ~/.moon/tools/node/16.0.0/bin/node --preserve-symlinks --title node:standard --unhandled-rejections throw ./standard.js (in /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/node)
+  MOON_CACHE_DIR=/private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/.moon/cache
+  MOON_PROJECT_ID=node
+  MOON_PROJECT_ROOT=/private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/node
+  MOON_PROJECT_RUNFILE=/private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/.moon/cache/runs/node/runfile.json
+  MOON_PROJECT_SOURCE=node
+  MOON_TARGET=node:standard
+  MOON_TOOLCHAIN_DIR=/Users/terence/.moon
+  MOON_WORKING_DIR=/private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ
+  MOON_WORKSPACE_ROOT=/private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ
+[TRACE 2022-06-21 14:22:15] mio::poll registering event source with poller: token=Token(100663297), interests=READABLE | WRITABLE
+[TRACE 2022-06-21 14:22:15] mio::poll registering event source with poller: token=Token(100663298), interests=READABLE | WRITABLE
+[TRACE 2022-06-21 14:22:15] mio::poll deregistering event source from poller
+[TRACE 2022-06-21 14:22:15] mio::poll deregistering event source from poller
+[TRACE 2022-06-21 14:22:15] moon:cache:hash Writing hash /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/.moon/cache/hashes/3270284f4824b530c3006108757e715f73a43f949c811db7c0859aded12d9036.json
+[TRACE 2022-06-21 14:22:15] moon:cache:item Writing cache /private/var/folders/7q/mhms7bw57j3_zzppqf6djmcr0000gn/T/.tmpnPPvgQ/.moon/cache/runs/node/standard/lastRunState.json
+[TRACE 2022-06-21 14:22:15] moon:action-runner:batch:3:1 Ran action RunTarget(node:standard) in 54.26ms
+[DEBUG 2022-06-21 14:22:15] moon:action-runner Finished running 4 actions in 517.989541ms
+[TRACE 2022-06-21 14:22:15] mio::poll deregistering event source from poller
+

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -19,6 +19,7 @@ moon_utils = { path = "../utils"}
 figment = { version = "0.10.6", features = ["test", "yaml"] }
 json = "0.12.4"
 regex = "1.5.6"
+reqwest = { version = "0.11.10", features = ["blocking"] }
 schemars = "0.8.10"
 semver = "1.0.9"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2,6 +2,7 @@ pub mod constants;
 mod errors;
 pub mod package;
 mod project;
+mod providers;
 pub mod tsconfig;
 mod types;
 mod validators;

--- a/crates/config/src/project/global.rs
+++ b/crates/config/src/project/global.rs
@@ -3,8 +3,9 @@
 use crate::constants;
 use crate::errors::{create_validation_error, map_figment_error_to_validation_errors};
 use crate::project::task::TaskConfig;
+use crate::providers::url::Url;
 use crate::types::FileGroups;
-use crate::validators::validate_id;
+use crate::validators::{validate_extends, validate_id};
 use figment::value::{Dict, Map};
 use figment::{
     providers::{Format, Serialized, Yaml},
@@ -47,11 +48,14 @@ fn validate_tasks(map: &HashMap<String, TaskConfig>) -> Result<(), ValidationErr
 #[derive(Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalProjectConfig {
-    #[serde(default)]
+    #[validate(custom = "validate_extends")]
+    pub extends: Option<String>,
+
+    #[schemars(default)]
     #[validate(custom = "validate_file_groups")]
     pub file_groups: FileGroups,
 
-    #[serde(default)]
+    #[schemars(default)]
     #[validate(custom = "validate_tasks")]
     #[validate]
     pub tasks: HashMap<String, TaskConfig>,
@@ -71,7 +75,7 @@ impl Provider for GlobalProjectConfig {
     }
 
     fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
-        Serialized::defaults(GlobalProjectConfig::default()).data()
+        Serialized::defaults(self).data()
     }
 
     fn profile(&self) -> Option<Profile> {
@@ -81,16 +85,49 @@ impl Provider for GlobalProjectConfig {
 
 impl GlobalProjectConfig {
     pub fn load(path: PathBuf) -> Result<GlobalProjectConfig, ValidationErrors> {
-        let config: GlobalProjectConfig =
-            match Figment::from(Serialized::defaults(GlobalProjectConfig::default()))
-                .merge(Yaml::file(path))
-                .extract()
-            {
-                Ok(cfg) => cfg,
-                Err(error) => return Err(map_figment_error_to_validation_errors(&error)),
-            };
+        let mut config = GlobalProjectConfig::load_config(
+            Figment::from(GlobalProjectConfig::default()).merge(Yaml::file(&path)),
+        )?;
 
-        // Validate the fields before continuing
+        // This is janky, but figment does not support any kind of extends mechanism,
+        // and figment providers do not have access to the current config dataset,
+        // so we need to double-load this config and extract in the correct order!
+        if let Some(extends) = &config.extends {
+            let extended_config =
+                GlobalProjectConfig::load_config(if extends.starts_with("http") {
+                    Figment::from(Url::from(extends.to_owned()))
+                } else {
+                    Figment::from(Yaml::file(path.parent().unwrap().join(extends)))
+                })?;
+
+            // Figment does not merge hash maps but replaces entirely,
+            // so we need to manually handle this here!
+            if !extended_config.file_groups.is_empty() {
+                let mut map = HashMap::new();
+                map.extend(extended_config.file_groups);
+                map.extend(config.file_groups);
+
+                config.file_groups = map;
+            }
+
+            if !extended_config.tasks.is_empty() {
+                let mut map = HashMap::new();
+                map.extend(extended_config.tasks);
+                map.extend(config.tasks);
+
+                config.tasks = map;
+            }
+        }
+
+        Ok(config)
+    }
+
+    fn load_config(figment: Figment) -> Result<GlobalProjectConfig, ValidationErrors> {
+        let config: GlobalProjectConfig = match figment.extract() {
+            Ok(cfg) => cfg,
+            Err(error) => return Err(map_figment_error_to_validation_errors(&error)),
+        };
+
         if let Err(errors) = config.validate() {
             return Err(errors);
         }
@@ -105,9 +142,10 @@ mod tests {
     use crate::errors::tests::handled_jailed_error;
     use figment;
     use moon_utils::string_vec;
+    use std::path::Path;
 
-    fn load_jailed_config() -> Result<GlobalProjectConfig, figment::Error> {
-        match GlobalProjectConfig::load(PathBuf::from(constants::CONFIG_PROJECT_FILENAME)) {
+    fn load_jailed_config(root: &Path) -> Result<GlobalProjectConfig, figment::Error> {
+        match GlobalProjectConfig::load(root.join(constants::CONFIG_PROJECT_FILENAME)) {
             Ok(cfg) => Ok(cfg),
             Err(errors) => Err(handled_jailed_error(&errors)),
         }
@@ -124,11 +162,12 @@ fileGroups:
         - src/**/*"#,
             )?;
 
-            let config = load_jailed_config()?;
+            let config = load_jailed_config(jail.directory())?;
 
             assert_eq!(
                 config,
                 GlobalProjectConfig {
+                    extends: None,
                     file_groups: HashMap::from([(
                         String::from("sources"),
                         string_vec!["src/**/*"]
@@ -142,6 +181,227 @@ fileGroups:
         });
     }
 
+    mod extends {
+        use super::*;
+        use crate::project::task::TaskOptionsConfig;
+        use std::fs;
+
+        #[test]
+        #[should_panic(
+            expected = "Invalid field <id>extends</id>: Expected a string type, received unsigned int `123`."
+        )]
+        fn invalid_type() {
+            figment::Jail::expect_with(|jail| {
+                jail.create_file(super::constants::CONFIG_PROJECT_FILENAME, "extends: 123")?;
+
+                super::load_jailed_config(jail.directory())?;
+
+                Ok(())
+            });
+        }
+
+        #[test]
+        #[should_panic(
+            expected = "Invalid field <id>extends</id>: Must be a valid URL or relative file path (starts with ./)."
+        )]
+        fn not_a_url_or_file() {
+            figment::Jail::expect_with(|jail| {
+                jail.create_file(
+                    super::constants::CONFIG_PROJECT_FILENAME,
+                    "extends: random value",
+                )?;
+
+                super::load_jailed_config(jail.directory())?;
+
+                Ok(())
+            });
+        }
+
+        #[test]
+        #[should_panic(expected = "Invalid field <id>extends</id>: Only HTTPS URLs are supported.")]
+        fn not_a_https_url() {
+            figment::Jail::expect_with(|jail| {
+                jail.create_file(
+                    super::constants::CONFIG_PROJECT_FILENAME,
+                    "extends: http://domain.com",
+                )?;
+
+                super::load_jailed_config(jail.directory())?;
+
+                Ok(())
+            });
+        }
+
+        #[test]
+        #[should_panic(expected = "Invalid field <id>extends</id>: Must be a YAML document.")]
+        fn not_a_yaml_url() {
+            figment::Jail::expect_with(|jail| {
+                jail.create_file(
+                    super::constants::CONFIG_PROJECT_FILENAME,
+                    "extends: https://domain.com/file.txt",
+                )?;
+
+                super::load_jailed_config(jail.directory())?;
+
+                Ok(())
+            });
+        }
+
+        #[test]
+        #[should_panic(expected = "Invalid field <id>extends</id>: Must be a YAML document.")]
+        fn not_a_yaml_file() {
+            figment::Jail::expect_with(|jail| {
+                fs::create_dir_all(jail.directory().join("shared")).unwrap();
+
+                jail.create_file("shared/file.txt", "")?;
+
+                jail.create_file(
+                    super::constants::CONFIG_PROJECT_FILENAME,
+                    "extends: ./shared/file.txt",
+                )?;
+
+                super::load_jailed_config(jail.directory())?;
+
+                Ok(())
+            });
+        }
+
+        fn create_merged_tasks() -> HashMap<String, TaskConfig> {
+            HashMap::from([
+                (
+                    "onlyCommand".to_owned(),
+                    TaskConfig {
+                        command: Some(String::from("a")),
+                        ..TaskConfig::default()
+                    },
+                ),
+                (
+                    "stringArgs".to_owned(),
+                    TaskConfig {
+                        command: Some(String::from("b")),
+                        args: Some(string_vec!["string", "args"]),
+                        ..TaskConfig::default()
+                    },
+                ),
+                (
+                    "arrayArgs".to_owned(),
+                    TaskConfig {
+                        command: Some(String::from("c")),
+                        args: Some(string_vec!["array", "args"]),
+                        ..TaskConfig::default()
+                    },
+                ),
+                (
+                    "inputs".to_owned(),
+                    TaskConfig {
+                        command: Some(String::from("d")),
+                        inputs: Some(string_vec!["src/**/*"]),
+                        ..TaskConfig::default()
+                    },
+                ),
+                (
+                    "options".to_owned(),
+                    TaskConfig {
+                        command: Some(String::from("e")),
+                        options: TaskOptionsConfig {
+                            merge_args: None,
+                            merge_deps: None,
+                            merge_env: None,
+                            merge_inputs: None,
+                            merge_outputs: None,
+                            retry_count: None,
+                            run_in_ci: Some(false),
+                            run_from_workspace_root: None,
+                        },
+                        ..TaskConfig::default()
+                    },
+                ),
+            ])
+        }
+
+        #[test]
+        fn loads_from_file() {
+            figment::Jail::expect_with(|jail| {
+                fs::create_dir_all(jail.directory().join("shared")).unwrap();
+
+                jail.create_file(
+                    format!("shared/{}", super::constants::CONFIG_PROJECT_FILENAME),
+                    include_str!("../../../../tests/fixtures/config-extends/.moon/project.yml"),
+                )?;
+
+                jail.create_file(
+                    super::constants::CONFIG_PROJECT_FILENAME,
+                    r#"
+extends: ./shared/project.yml
+
+fileGroups:
+    sources:
+        - sources/**/*
+    configs:
+        - '*.js'
+"#,
+                )?;
+
+                let config: GlobalProjectConfig = super::load_jailed_config(jail.directory())?;
+
+                assert_eq!(config.extends, Some("./shared/project.yml".to_owned()));
+
+                // Ensure values are deep merged
+                assert_eq!(
+                    config.file_groups,
+                    HashMap::from([
+                        ("sources".to_owned(), string_vec!["sources/**/*"]), // NOT src/**/*
+                        ("tests".to_owned(), string_vec!["tests/**/*"]),
+                        ("configs".to_owned(), string_vec!["*.js"])
+                    ])
+                );
+
+                assert_eq!(config.tasks, create_merged_tasks());
+
+                Ok(())
+            });
+        }
+
+        #[test]
+        fn loads_from_url() {
+            figment::Jail::expect_with(|jail| {
+                jail.create_file(
+                    super::constants::CONFIG_PROJECT_FILENAME,
+r#"
+extends: https://raw.githubusercontent.com/moonrepo/moon/develop-0.4/tests/fixtures/config-extends/.moon/project.yml
+
+fileGroups:
+    sources:
+        - sources/**/*
+    configs:
+        - '*.js'
+"#,
+                )?;
+
+                let config: GlobalProjectConfig = super::load_jailed_config(jail.directory())?;
+
+                assert_eq!(
+                    config.extends,
+                    Some("https://raw.githubusercontent.com/moonrepo/moon/develop-0.4/tests/fixtures/config-extends/.moon/project.yml".to_owned())
+                );
+
+                // Ensure values are deep merged
+                assert_eq!(
+                    config.file_groups,
+                    HashMap::from([
+                        ("sources".to_owned(), string_vec!["sources/**/*"]), // NOT src/**/*
+                        ("tests".to_owned(), string_vec!["tests/**/*"]),
+                        ("configs".to_owned(), string_vec!["*.js"])
+                    ])
+                );
+
+                assert_eq!(config.tasks, create_merged_tasks());
+
+                Ok(())
+            });
+        }
+    }
+
     mod file_groups {
         #[test]
         #[should_panic(
@@ -151,7 +411,7 @@ fileGroups:
             figment::Jail::expect_with(|jail| {
                 jail.create_file(super::constants::CONFIG_PROJECT_FILENAME, "fileGroups: 123")?;
 
-                super::load_jailed_config()?;
+                super::load_jailed_config(jail.directory())?;
 
                 Ok(())
             });
@@ -170,7 +430,7 @@ fileGroups:
     sources: 123"#,
                 )?;
 
-                super::load_jailed_config()?;
+                super::load_jailed_config(jail.directory())?;
 
                 Ok(())
             });
@@ -192,7 +452,7 @@ tasks: 123
 "#,
                 )?;
 
-                super::load_jailed_config()?;
+                super::load_jailed_config(jail.directory())?;
 
                 Ok(())
             });
@@ -213,7 +473,7 @@ tasks:
 "#,
                 )?;
 
-                super::load_jailed_config()?;
+                super::load_jailed_config(jail.directory())?;
 
                 Ok(())
             });
@@ -235,7 +495,7 @@ tasks:
 "#,
                 )?;
 
-                super::load_jailed_config()?;
+                super::load_jailed_config(jail.directory())?;
 
                 Ok(())
             });
@@ -257,7 +517,7 @@ tasks:
 "#,
                 )?;
 
-                super::load_jailed_config()?;
+                super::load_jailed_config(jail.directory())?;
 
                 Ok(())
             });

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -1,5 +1,6 @@
 use crate::types::{FilePath, FilePathOrGlob, TargetID};
 use crate::validators::{validate_child_or_root_path, validate_target};
+use moon_utils::process::split_args;
 use schemars::gen::SchemaGenerator;
 use schemars::schema::Schema;
 use schemars::{schema_for, JsonSchema};
@@ -158,7 +159,7 @@ impl<'de> de::Visitor<'de> for DeserializeArgs {
     where
         E: de::Error,
     {
-        match shell_words::split(value) {
+        match split_args(value) {
             Ok(args) => Ok(args),
             Err(error) => Err(E::custom(error)),
         }

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -99,6 +99,8 @@ impl Default for TaskOptionsConfig {
     }
 }
 
+// We use serde(default) here because figment *does not* apply defaults
+// for structs nested within collections. Primarily hash maps.
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct TaskConfig {
     #[serde(default)]
@@ -176,9 +178,9 @@ where
 #[serde(untagged)]
 enum ArgsField {
     #[allow(dead_code)]
-    Str(String),
+    String(String),
     #[allow(dead_code)]
-    Vec(Vec<String>),
+    Sequence(Vec<String>),
 }
 
 fn make_args_schema(_gen: &mut SchemaGenerator) -> Schema {

--- a/crates/config/src/providers/mod.rs
+++ b/crates/config/src/providers/mod.rs
@@ -1,0 +1,1 @@
+pub mod url;

--- a/crates/config/src/providers/url.rs
+++ b/crates/config/src/providers/url.rs
@@ -1,0 +1,46 @@
+// Based on https://docs.rs/figment/latest/figment/trait.Provider.html
+
+use figment::{
+    providers::{Format, Yaml},
+    value::{Dict, Map},
+    Error, Metadata, Profile, Provider,
+};
+
+pub struct Url {
+    url: String,
+}
+
+impl Url {
+    pub fn from(url: String) -> Self {
+        Url { url }
+    }
+}
+
+impl Provider for Url {
+    fn metadata(&self) -> Metadata {
+        Metadata::from("Extends", self.url.clone())
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, Error> {
+        // Unfortunate we must use blocking here,
+        // but figment doesn't support async/await
+        let resp = reqwest::blocking::get(&self.url)
+            .map_err(|e| {
+                Error::from(format!(
+                    "Failed to load extended config <url>{}</url>: {}",
+                    self.url, e
+                ))
+            })?
+            .text()
+            .map_err(|e| {
+                Error::from(format!(
+                    "Failed to parse extended config <url>{}</url>: {}",
+                    self.url, e
+                ))
+            })?;
+
+        // We expect the URLs to point to YAML files,
+        // so piggyback off the default YAML provider
+        Yaml::string(&resp).data()
+    }
+}

--- a/crates/config/src/workspace/mod.rs
+++ b/crates/config/src/workspace/mod.rs
@@ -55,12 +55,15 @@ fn validate_projects(projects: &ProjectsMap) -> Result<(), ValidationError> {
 #[serde(rename_all = "camelCase")]
 pub struct ActionRunnerConfig {
     pub inherit_colors_for_piped_tasks: bool,
+
+    pub log_running_command: bool,
 }
 
 impl Default for ActionRunnerConfig {
     fn default() -> Self {
         ActionRunnerConfig {
             inherit_colors_for_piped_tasks: true,
+            log_running_command: false,
         }
     }
 }

--- a/crates/config/src/workspace/node.rs
+++ b/crates/config/src/workspace/node.rs
@@ -1,4 +1,4 @@
-use crate::validators::{default_bool_true, validate_semver_version};
+use crate::validators::validate_semver_version;
 use moon_lang_node::{NODE, NODENV, NVMRC, PNPM, YARN};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -73,8 +73,8 @@ impl VersionManager {
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 pub struct NpmConfig {
-    #[serde(default = "default_npm_version")]
     #[validate(custom = "validate_npm_version")]
     pub version: String,
 }
@@ -89,7 +89,6 @@ impl Default for NpmConfig {
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct PnpmConfig {
-    #[serde(default = "default_pnpm_version")]
     #[validate(custom = "validate_pnpm_version")]
     pub version: String,
 }
@@ -104,7 +103,6 @@ impl Default for PnpmConfig {
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct YarnConfig {
-    #[serde(default = "default_yarn_version")]
     #[validate(custom = "validate_yarn_version")]
     pub version: String,
 }
@@ -118,30 +116,25 @@ impl Default for YarnConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeConfig {
-    #[serde(default = "default_bool_true")]
     pub add_engines_constraint: bool,
 
-    #[serde(default = "default_bool_true")]
     pub dedupe_on_lockfile_change: bool,
 
-    #[serde(default)]
     #[validate]
     pub npm: NpmConfig,
 
-    #[serde(default)]
     pub package_manager: PackageManager,
 
     #[validate]
     pub pnpm: Option<PnpmConfig>,
 
-    #[serde(default = "default_bool_true")]
     pub sync_project_workspace_dependencies: bool,
 
     pub sync_version_manager_config: Option<VersionManager>,
 
-    #[serde(default = "default_node_version")]
     #[validate(custom = "validate_node_version")]
     pub version: String,
 
@@ -152,12 +145,12 @@ pub struct NodeConfig {
 impl Default for NodeConfig {
     fn default() -> Self {
         NodeConfig {
-            add_engines_constraint: default_bool_true(),
-            dedupe_on_lockfile_change: default_bool_true(),
+            add_engines_constraint: true,
+            dedupe_on_lockfile_change: true,
             npm: NpmConfig::default(),
-            package_manager: PackageManager::Npm,
+            package_manager: PackageManager::default(),
             pnpm: None,
-            sync_project_workspace_dependencies: default_bool_true(),
+            sync_project_workspace_dependencies: true,
             sync_version_manager_config: None,
             version: default_node_version(),
             yarn: None,

--- a/crates/config/src/workspace/typescript.rs
+++ b/crates/config/src/workspace/typescript.rs
@@ -2,33 +2,23 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-fn default_config_file_name() -> String {
-    String::from("tsconfig.json")
-}
-
-fn default_sync_project_references() -> bool {
-    true
-}
-
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 #[serde(rename_all = "camelCase")]
 pub struct TypeScriptConfig {
-    #[serde(default = "default_config_file_name")]
     pub project_config_file_name: String,
 
-    #[serde(default = "default_config_file_name")]
     pub root_config_file_name: String,
 
-    #[serde(default = "default_sync_project_references")]
     pub sync_project_references: bool,
 }
 
 impl Default for TypeScriptConfig {
     fn default() -> Self {
         TypeScriptConfig {
-            project_config_file_name: default_config_file_name(),
-            root_config_file_name: default_config_file_name(),
-            sync_project_references: default_sync_project_references(),
+            project_config_file_name: String::from("tsconfig.json"),
+            root_config_file_name: String::from("tsconfig.json"),
+            sync_project_references: true,
         }
     }
 }

--- a/crates/config/src/workspace/vcs.rs
+++ b/crates/config/src/workspace/vcs.rs
@@ -2,10 +2,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-fn default_branch_default() -> String {
-    String::from("master")
-}
-
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum VcsManager {
@@ -20,12 +16,11 @@ impl Default for VcsManager {
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 #[serde(rename_all = "camelCase")]
 pub struct VcsConfig {
-    #[serde(default)]
     pub manager: VcsManager,
 
-    #[serde(default = "default_branch_default")]
     pub default_branch: String,
 }
 
@@ -33,7 +28,7 @@ impl Default for VcsConfig {
     fn default() -> Self {
         VcsConfig {
             manager: VcsManager::default(),
-            default_branch: default_branch_default(),
+            default_branch: String::from("master"),
         }
     }
 }

--- a/crates/config/templates/global_project.yml
+++ b/crates/config/templates/global_project.yml
@@ -1,5 +1,8 @@
 $schema: 'https://moonrepo.dev/schemas/global-project.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/project.yml'
+
 # File groups are a mechanism for grouping similar types of files within a project
 # using file glob patterns. These groups are then used by tasks to calculate functionality like
 # cache computation, affected files since last change, command line arguments, deterministic

--- a/crates/config/templates/workspace.yml
+++ b/crates/config/templates/workspace.yml
@@ -1,5 +1,8 @@
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/config/templates/workspace.yml
+++ b/crates/config/templates/workspace.yml
@@ -78,9 +78,3 @@ vcs:
   # local branch against. For git, this is is typically "master" or "main",
   # and must include the remote prefix (before /). For svn, this should always be "trunk".
   defaultBranch: 'master'
-
-# Configures aspects of the action runner.
-actionRunner:
-  # Force colors to be inherited for all tasks that are ran as a child process
-  # and their output is piped to the action runner.
-  inheritColorsForPipedTasks: true

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -18,6 +18,7 @@ fn mock_file_groups() -> HashMap<String, FileGroup> {
 
 fn mock_global_project_config() -> GlobalProjectConfig {
     GlobalProjectConfig {
+        extends: None,
         file_groups: HashMap::from([(String::from("sources"), string_vec!["src/**/*"])]),
         tasks: HashMap::new(),
         schema: String::new(),
@@ -167,8 +168,7 @@ fn overrides_global_file_groups() {
         &workspace_root,
         &GlobalProjectConfig {
             file_groups: HashMap::from([(String::from("tests"), string_vec!["tests/**/*"])]),
-            tasks: HashMap::new(),
-            schema: String::new(),
+            ..GlobalProjectConfig::default()
         },
     )
     .unwrap();
@@ -304,9 +304,8 @@ mod tasks {
             "tasks/no-tasks",
             &workspace_root,
             &GlobalProjectConfig {
-                file_groups: HashMap::new(),
                 tasks: HashMap::from([(String::from("standard"), mock_task_config("cmd"))]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             },
         )
         .unwrap();
@@ -345,9 +344,8 @@ mod tasks {
             "tasks/basic",
             &workspace_root,
             &GlobalProjectConfig {
-                file_groups: HashMap::new(),
                 tasks: HashMap::from([(String::from("standard"), mock_task_config("cmd"))]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             },
         )
         .unwrap();
@@ -415,7 +413,6 @@ mod tasks {
             project_source,
             &workspace_root,
             &GlobalProjectConfig {
-                file_groups: HashMap::new(),
                 tasks: HashMap::from([(
                     String::from("standard"),
                     TaskConfig {
@@ -429,7 +426,7 @@ mod tasks {
                         type_of: TaskType::Node,
                     },
                 )]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             },
         )
         .unwrap();
@@ -490,7 +487,6 @@ mod tasks {
             project_source,
             &workspace_root,
             &GlobalProjectConfig {
-                file_groups: HashMap::new(),
                 tasks: HashMap::from([(
                     String::from("standard"),
                     TaskConfig {
@@ -504,7 +500,7 @@ mod tasks {
                         type_of: TaskType::Node,
                     },
                 )]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             },
         )
         .unwrap();
@@ -568,7 +564,6 @@ mod tasks {
             project_source,
             &workspace_root,
             &GlobalProjectConfig {
-                file_groups: HashMap::new(),
                 tasks: HashMap::from([(
                     String::from("standard"),
                     TaskConfig {
@@ -582,7 +577,7 @@ mod tasks {
                         type_of: TaskType::Node,
                     },
                 )]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             },
         )
         .unwrap();
@@ -646,7 +641,6 @@ mod tasks {
             project_source,
             &workspace_root,
             &GlobalProjectConfig {
-                file_groups: HashMap::new(),
                 tasks: HashMap::from([(
                     String::from("standard"),
                     TaskConfig {
@@ -660,7 +654,7 @@ mod tasks {
                         type_of: TaskType::Node,
                     },
                 )]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             },
         )
         .unwrap();
@@ -842,7 +836,7 @@ mod tasks {
                             ..TaskConfig::default()
                         },
                     )]),
-                    schema: String::new(),
+                    ..GlobalProjectConfig::default()
                 },
             )
             .unwrap();
@@ -914,7 +908,7 @@ mod tasks {
                             ..TaskConfig::default()
                         },
                     )]),
-                    schema: String::new(),
+                    ..GlobalProjectConfig::default()
                 },
             )
             .unwrap();
@@ -969,7 +963,7 @@ mod tasks {
                             ..TaskConfig::default()
                         },
                     )]),
-                    schema: String::new(),
+                    ..GlobalProjectConfig::default()
                 },
             )
             .unwrap();
@@ -1023,7 +1017,7 @@ mod tasks {
                             ..TaskConfig::default()
                         },
                     )]),
-                    schema: String::new(),
+                    ..GlobalProjectConfig::default()
                 },
             )
             .unwrap();
@@ -1092,7 +1086,7 @@ mod workspace {
                         },
                     ),
                 ]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             }
         }
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -19,6 +19,7 @@ path-clean = "0.1.0"
 regex = "1.5.6"
 serde = "1.0.137"
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
+shell-words = "1.1.0"
 tokio = { version = "1.18.2", features = ["full"] }
 wax = "0.5.0"
 

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -8,7 +8,6 @@ pub mod time;
 
 use cached::proc_macro::cached;
 use std::env;
-use std::time::Duration;
 
 #[macro_export]
 macro_rules! string_vec {
@@ -26,28 +25,32 @@ pub fn is_ci() -> bool {
     env::var("CI").is_ok()
 }
 
+// TODO: This doesn't work behind VPN or corporate proxies. Disabling for now
+// until we can figure out a better solution.
 #[cached(time = 60)]
 pub fn is_offline() -> bool {
-    use std::net::{Shutdown, SocketAddr, TcpStream};
+    false
+    // use std::time::Duration;
+    // use std::net::{Shutdown, SocketAddr, TcpStream};
 
-    let addresses = [
-        // Cloudflare DNS: https://1.1.1.1/dns/
-        SocketAddr::from(([1, 1, 1, 1], 53)),
-        SocketAddr::from(([1, 0, 0, 1], 53)),
-        // Google DNS: https://developers.google.com/speed/public-dns
-        SocketAddr::from(([8, 8, 8, 8], 53)),
-        SocketAddr::from(([8, 8, 4, 4], 53)),
-    ];
+    // let addresses = [
+    //     // Cloudflare DNS: https://1.1.1.1/dns/
+    //     SocketAddr::from(([1, 1, 1, 1], 53)),
+    //     SocketAddr::from(([1, 0, 0, 1], 53)),
+    //     // Google DNS: https://developers.google.com/speed/public-dns
+    //     SocketAddr::from(([8, 8, 8, 8], 53)),
+    //     SocketAddr::from(([8, 8, 4, 4], 53)),
+    // ];
 
-    for address in addresses {
-        if let Ok(stream) = TcpStream::connect_timeout(&address, Duration::new(3, 0)) {
-            stream.shutdown(Shutdown::Both).unwrap();
+    // for address in addresses {
+    //     if let Ok(stream) = TcpStream::connect_timeout(&address, Duration::new(3, 0)) {
+    //         stream.shutdown(Shutdown::Both).unwrap();
 
-            return false;
-        }
-    }
+    //         return false;
+    //     }
+    // }
 
-    true
+    // true
 }
 
 pub fn is_test_env() -> bool {

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -1,7 +1,6 @@
 use crate::path;
 use moon_error::{map_io_to_process_error, MoonError};
 use moon_logger::{color, logging_enabled, trace};
-use std::env;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
@@ -246,12 +245,10 @@ impl Command {
     }
 
     pub fn inherit_colors(&mut self) -> &mut Command {
-        if let Ok(level) = env::var("FORCE_COLOR") {
-            self.env("FORCE_COLOR", &level);
-            self.env("CLICOLOR_FORCE", &level);
-        } else if env::var("NO_COLOR").is_ok() {
-            self.env("NO_COLOR", "1");
-        }
+        let level = color::supports_color().to_string();
+
+        self.env("FORCE_COLOR", &level);
+        self.env("CLICOLOR_FORCE", &level);
 
         // Force a terminal width so that we have consistent sizing
         // in our cached output, and its the same across all machines

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -8,6 +8,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command as TokioCommand;
 use tokio::task;
 
+pub use shell_words::{join as join_args, split as split_args};
 pub use std::process::{ExitStatus, Output, Stdio};
 
 // Based on how Node.js executes Windows commands:
@@ -244,6 +245,24 @@ impl Command {
         Ok(output)
     }
 
+    pub fn get_command_line(&self) -> (String, Option<&Path>) {
+        let cmd = &self.cmd.as_std();
+
+        let args = cmd
+            .get_args()
+            .into_iter()
+            .map(|a| a.to_str().unwrap())
+            .collect::<Vec<_>>();
+
+        let line = if args.is_empty() {
+            self.bin.to_owned()
+        } else {
+            format!("{} {}", self.bin, join_args(args))
+        };
+
+        (path::replace_home_dir(&line), cmd.get_current_dir())
+    }
+
     pub fn inherit_colors(&mut self) -> &mut Command {
         let level = color::supports_color().to_string();
 
@@ -291,12 +310,7 @@ impl Command {
         }
 
         let cmd = &self.cmd.as_std();
-        let args = cmd
-            .get_args()
-            .into_iter()
-            .map(|a| a.to_str().unwrap())
-            .collect::<Vec<_>>();
-        let mut command_line = path::replace_home_dir(&format!("{} {}", self.bin, args.join(" ")));
+        let (mut command_line, working_dir) = self.get_command_line();
 
         if input.is_some() {
             command_line = format!("{} > {}", input.unwrap().replace('\n', " "), command_line);
@@ -323,7 +337,7 @@ impl Command {
             target: "moon:utils",
             "Running command {} (in {}){}",
             color::shell(&command_line),
-            if let Some(cwd) = cmd.get_current_dir() {
+            if let Some(cwd) = working_dir {
                 color::path(cwd)
             } else {
                 String::from("working dir")

--- a/crates/workspace/src/actions/run_target.rs
+++ b/crates/workspace/src/actions/run_target.rs
@@ -8,7 +8,7 @@ use moon_logger::{color, debug, trace, warn};
 use moon_project::{Project, Target, Task};
 use moon_terminal::output::{label_checkpoint, Checkpoint};
 use moon_toolchain::{get_path_env_var, Executable};
-use moon_utils::process::{output_to_string, Command, Output};
+use moon_utils::process::{join_args, output_to_string, Command, Output};
 use moon_utils::{is_ci, is_test_env, path, string_vec, time};
 use std::collections::HashMap;
 use std::path::Path;
@@ -305,12 +305,14 @@ pub async fn run_target(
             // Print label *before* output is streamed since it may stay open forever,
             // or it may use ANSI escape codes to alter the terminal.
             print_target_label(target_id, &attempt, attempt_total, Checkpoint::Pass);
+            print_target_command(&workspace, &project, task, passthrough_args);
 
             // If this target matches the primary target (the last task to run),
             // then we want to stream the output directly to the parent (inherit mode).
             command.exec_stream_and_capture_output().await
         } else {
             print_target_label(target_id, &attempt, attempt_total, Checkpoint::Start);
+            print_target_command(&workspace, &project, task, passthrough_args);
 
             // Otherwise we run the process in the background and write the output
             // once it has completed.
@@ -402,6 +404,46 @@ fn print_target_label(target: &str, attempt: &Attempt, attempt_total: u8, checkp
     } else {
         println!("{}", label);
     }
+}
+
+fn print_target_command(
+    workspace: &Workspace,
+    project: &Project,
+    task: &Task,
+    passthrough_args: &[String],
+) {
+    if !workspace.config.action_runner.log_running_command {
+        return;
+    }
+
+    let mut args = vec![];
+    args.extend(&task.args);
+    args.extend(passthrough_args);
+
+    let command_line = if args.is_empty() {
+        task.command.clone()
+    } else {
+        format!("{} {}", task.command, join_args(args))
+    };
+
+    let working_dir = if task.options.run_from_workspace_root || project.root == workspace.root {
+        String::from("workspace")
+    } else {
+        format!(
+            ".{}{}",
+            std::path::MAIN_SEPARATOR,
+            project
+                .root
+                .strip_prefix(&workspace.root)
+                .unwrap()
+                .to_string_lossy(),
+        )
+    };
+
+    let suffix = format!("(in {})", working_dir);
+    let message = format!("{} {}", command_line, color::muted(&suffix));
+
+    println!("{}", color::muted_light(&message));
 }
 
 fn print_cache_item(item: &RunTargetState) {

--- a/crates/workspace/src/actions/run_target.rs
+++ b/crates/workspace/src/actions/run_target.rs
@@ -295,7 +295,8 @@ pub async fn run_target(
     let attempt_total = task.options.retry_count + 1;
     let mut attempt_index = 1;
     let mut attempts = vec![];
-    let stream_output = is_primary || is_ci() && !is_test_env();
+    let is_real_ci = is_ci() && !is_test_env();
+    let stream_output = is_primary || is_real_ci;
     let output;
 
     loop {
@@ -309,7 +310,9 @@ pub async fn run_target(
 
             // If this target matches the primary target (the last task to run),
             // then we want to stream the output directly to the parent (inherit mode).
-            command.exec_stream_and_capture_output().await
+            command
+                .exec_stream_and_capture_output(if is_real_ci { Some(target_id) } else { None })
+                .await
         } else {
             print_target_label(target_id, &attempt, attempt_total, Checkpoint::Start);
             print_target_command(&workspace, &project, task, passthrough_args);

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.
+
+#### 🐞 Fixes
+
+- More fixes around terminal color output and handling.
+
 ## 0.3.1
-
-#### 🚀 Updates
-
-- Added an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.
-
-#### 🚀 Updates
-
-- Added an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.
 
 #### 🐞 Fixes
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.
 - Added a `actionRunner.logRunningCommand` setting to `.moon/workspace.yml` for logging the task
   command being ran.
+- Added a global `--logFile` option to the CLI. Also supports a new `MOON_LOG_FILE` environment
+  variable.
 
 #### 🐞 Fixes
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.3.1
 
+#### 🚀 Updates
+
+- Added an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.
+
 #### 🐞 Fixes
 
 - Fixed an issue where tasks referencing workspace relative files were not being marked as affected.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,7 +12,12 @@
 
 - More fixes around terminal color output and handling.
 
-## 0.3.1
+#### ⚙️ Internal
+
+- Temporarily disabling offline internet checks as it has issues with VPNs. Will revisit in the
+  future.
+
+### 0.3.1
 
 #### 🐞 Fixes
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@
 #### 🚀 Updates
 
 - Added an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.
+- Added a `actionRunner.logRunningCommand` setting to `.moon/workspace.yml` for logging the task
+  command being ran.
 
 #### 🐞 Fixes
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,8 @@
   command being ran.
 - Added a global `--logFile` option to the CLI. Also supports a new `MOON_LOG_FILE` environment
   variable.
+- When targets are being ran in parallel, their output is now prefixed with the target name to
+  differentiate. This is currently only enabled in CI.
 
 #### 🐞 Fixes
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.
 
+#### 🚀 Updates
+
+- Added an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.
+
 #### 🐞 Fixes
 
 - Fixed an issue where tasks referencing workspace relative files were not being marked as affected.

--- a/tests/fixtures/cases/base/project.yml
+++ b/tests/fixtures/cases/base/project.yml
@@ -1,1 +1,11 @@
-tasks: {}
+tasks:
+  runFromProject:
+    command: echo
+    args: '"in project"'
+    type: system
+  runFromWorkspace:
+    command: echo
+    args: '"in workspace"'
+    options:
+      runFromWorkspaceRoot: true
+    type: system

--- a/tests/fixtures/config-extends/.moon/project.yml
+++ b/tests/fixtures/config-extends/.moon/project.yml
@@ -1,0 +1,27 @@
+# NOTE: This is used to test config extending. Changing this will definitely break something!
+
+fileGroups:
+  sources:
+    - src/**/*
+  tests:
+    - tests/**/*
+
+tasks:
+  onlyCommand:
+    command: a
+  stringArgs:
+    command: b
+    args: string args
+  arrayArgs:
+    command: c
+    args:
+      - array
+      - args
+  inputs:
+    command: d
+    inputs:
+      - src/**/*
+  options:
+    command: e
+    options:
+      runInCI: false

--- a/tests/fixtures/config-extends/.moon/workspace.yml
+++ b/tests/fixtures/config-extends/.moon/workspace.yml
@@ -1,0 +1,13 @@
+# NOTE: This is used to test config extending. Changing this will definitely break something!
+
+node:
+  version: '16.1.0'
+  addEnginesConstraint: false
+  npm:
+    version: '7.0.0'
+
+typescript:
+  syncProjectReferences: false
+
+vcs:
+  manager: 'svn'

--- a/website/docs/commands/overview.mdx
+++ b/website/docs/commands/overview.mdx
@@ -8,6 +8,7 @@ The following options are available for _all_ moon commands.
 - `--color` - Force [colored output](#colors) for moon (not tasks).
 - `--help` - Display the help menu for the current command.
 - `--log <level>` - The lowest [log level to output](#logging).
+- `--logFile <file>` - Write logs to the defined file.
 - `--version` - Display the version of the CLI.
 
 Global options _must_ be passed after the `moon` binary and before the command.
@@ -92,4 +93,16 @@ levels are supported, in priority order.
 $ moon --log trace run app:build
 # Or
 $ MOON_LOG=trace moon run app:build
+```
+
+### Outputting logs to a file
+
+moon can dump the logs from a command to a file using the `--logFile` option, or the `MOON_LOG_FILE`
+environment variable. The dumped logs will respect the `--log` option and filter the logs piped to
+the output file.
+
+```shell
+$ moon --logFile=output.log run app:build
+# Or
+$ MOON_LOG_FILE=output.log moon run app:build
 ```

--- a/website/docs/config/global-project.mdx
+++ b/website/docs/config/global-project.mdx
@@ -6,6 +6,26 @@ The `.moon/project.yml` file configures file groups and tasks that are inherited
 in the workspace. Projects can override or merge with these settings within their respective
 [`project.yml`](./project).
 
+## `extends`
+
+> `string`
+
+Defines an external `.moon/project.yml` to extend and inherit settings from. Perfect for reusability
+and sharing configuration across repositories and projects. When defined, this setting must be an
+HTTPS URL _or_ relative file system path that points to a valid YAML document!
+
+```yaml title=".moon/workspace.yml" {1}
+extends: 'https://raw.githubusercontent.com/organization/repository/master/.moon/project.yml'
+```
+
+:::caution
+
+For map-based settings, `fileGroups` and `tasks`, entries from both the extended configuration and
+local configuration are merged into a new map, with the values of the local taking precedence. Map
+values _are not_ deep merged!
+
+:::
+
 ## `fileGroups`
 
 > `Record<string, string[]>`

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -29,6 +29,26 @@ actionRunner:
   inheritColorsForPipedTasks: true # Default
 ```
 
+## `extends`
+
+> `string`
+
+Defines an external `.moon/workspace.yml` to extend and inherit settings from. Perfect for
+reusability and sharing configuration across repositories and projects. When defined, this setting
+must be an HTTPS URL _or_ relative file system path that points to a valid YAML document!
+
+```yaml title=".moon/workspace.yml" {1}
+extends: 'https://raw.githubusercontent.com/organization/repository/master/.moon/workspace.yml'
+```
+
+:::caution
+
+Settings will be merged recursively for blocks, with values defined in the local configuration
+taking precedence over those defined in the extended configuration. However, the `projects` setting
+_does not merge_!
+
+:::
+
 ## `projects`<RequiredLabel />
 
 > `Record<string, string> | string[]`

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -21,12 +21,24 @@ Configures aspects of the action runner.
 > `boolean`
 
 Force colors to be inherited from the current terminal for all tasks that are ran as a child process
-and their output is piped to the action runner.
+and their output is piped to the action runner. Defaults to `true`.
 [View more about color handling in moon](../commands/overview#colors).
 
 ```yaml title=".moon/workspace.yml" {2}
 actionRunner:
-  inheritColorsForPipedTasks: true # Default
+  inheritColorsForPipedTasks: true
+```
+
+### `logRunningCommand`
+
+> `boolean`
+
+When enabled, will log the task's command, resolved arguments, and working directory when a target
+is ran. Defaults to `false`.
+
+```yaml title=".moon/workspace.yml" {2}
+actionRunner:
+  logRunningCommand: true
 ```
 
 ## `extends`

--- a/website/docs/guides/examples/eslint.mdx
+++ b/website/docs/guides/examples/eslint.mdx
@@ -43,8 +43,8 @@ tasks:
 			- 'tests/**/*'
 			# Other config files
 			- '*.config.*'
-			# Project configs, any format
-			- '.eslintrc.*'
+			# Project configs, any format, any depth
+			- '**/.eslintrc.*'
 			# Root configs, any format
 			- '/.eslintignore'
 			- '/.eslintrc.*'

--- a/website/docs/guides/examples/packemon.mdx
+++ b/website/docs/guides/examples/packemon.mdx
@@ -63,7 +63,7 @@ buildPackage:
 With this being defined globally, all package-based projects can inherit this task and rename it as
 follows.
 
-```yaml title="packages/*/project.yml"
+```yaml title="<package>/project.yml"
 # Rename the `buildPackage` task to `build` for this project
 workspace:
 	inheritedTasks:
@@ -80,7 +80,7 @@ tasks:
 However, for other project types like applications, this task will need to be _excluded_, otherwise
 it will run and fail in CI.
 
-```yaml title="apps/*/project.yml"
+```yaml title="<app>/project.yml"
 # Exclude the `buildPackage` task for this project
 workspace:
 	inheritedTasks:
@@ -90,7 +90,7 @@ workspace:
 </TabItem>
 <TabItem value="local">
 
-```yaml title="packages/*/project.yml"
+```yaml title="<package>/project.yml"
 build:
 	command: 'packemon'
 	args:

--- a/website/docs/guides/sharing-config.mdx
+++ b/website/docs/guides/sharing-config.mdx
@@ -1,0 +1,45 @@
+# Sharing workspace configuration
+
+For large companies, open source maintainers, and those that love reusability, more often than not
+you'll want to use the same configuration across all repositories for consistency. This helps reduce
+the maintenance burden while ensuring a similar developer experience.
+
+To help streamline this process, moon provides an `extends` setting in both
+[`.moon/workspace.yml`](../config/workspace#extends) and
+[`.moon/project.yml`](../config/global-project#extends). This setting requires a HTTPS URL _or_
+relative file system path that points to a valid YAML document for the configuration in question.
+
+A great way to share configuration is by using GitHub's "raw file view", as demonstrated below using
+our very own [examples repository](https://github.com/moonrepo/examples).
+
+```yaml title=".moon/project.yml"
+extends: 'https://raw.githubusercontent.com/moonrepo/examples/master/.moon/project.yml'
+```
+
+## Versioning
+
+Inheriting an upstream configuration can be dangerous, as the settings may change at any point,
+resulting in broken builds. To mitigate this, you can used a "versioned" upstream configuration,
+which is ideally a fixed point in time. How this is implemented is up to you or your company, but we
+suggest the following patterns:
+
+### Using versioned filenames
+
+A rudimentary solution is to append a version to the upstream filename. When the file is modified, a
+new version should be created, while the previous version remains untouched.
+
+```diff
+-extends: '../shared/project.yml'
++extends: '../shared/project-v1.yml'
+```
+
+### Using branches, tags, or commits
+
+When using a version control platform, like GitHub above, you can reference the upstream
+configuration through a branch, tag, commit, or sha. Since these are a reference point in time, they
+are relatively safe.
+
+```diff
+-extends: 'https://raw.githubusercontent.com/moonrepo/examples/master/.moon/project.yml'
++extends: 'https://raw.githubusercontent.com/moonrepo/examples/c3f10160bcd16b48b8d4d21b208bb50f6b09bd96/.moon/project.yml'
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -16,6 +16,7 @@ const sidebars = {
 			items: [
 				'guides/ci',
 				'guides/open-source',
+				'guides/sharing-config',
 				{
 					type: 'category',
 					label: 'Examples',

--- a/website/static/schemas/global-project.json
+++ b/website/static/schemas/global-project.json
@@ -4,6 +4,12 @@
   "description": "Docs: https://moonrepo.dev/docs/config/global-project",
   "type": "object",
   "properties": {
+    "extends": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "fileGroups": {
       "default": {},
       "type": "object",

--- a/website/static/schemas/project.json
+++ b/website/static/schemas/project.json
@@ -3,9 +3,6 @@
   "title": "ProjectConfig",
   "description": "Docs: https://moonrepo.dev/docs/config/project",
   "type": "object",
-  "required": [
-    "type"
-  ],
   "properties": {
     "dependsOn": {
       "default": [],
@@ -33,6 +30,7 @@
       ]
     },
     "project": {
+      "default": null,
       "anyOf": [
         {
           "$ref": "#/definitions/ProjectMetadataConfig"
@@ -50,7 +48,12 @@
       }
     },
     "type": {
-      "$ref": "#/definitions/ProjectType"
+      "default": "library",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProjectType"
+        }
+      ]
     },
     "workspace": {
       "default": {
@@ -136,6 +139,7 @@
       "type": "object",
       "properties": {
         "exclude": {
+          "default": null,
           "type": [
             "array",
             "null"
@@ -145,6 +149,7 @@
           }
         },
         "include": {
+          "default": null,
           "type": [
             "array",
             "null"

--- a/website/static/schemas/workspace.json
+++ b/website/static/schemas/workspace.json
@@ -6,7 +6,8 @@
   "properties": {
     "actionRunner": {
       "default": {
-        "inheritColorsForPipedTasks": true
+        "inheritColorsForPipedTasks": true,
+        "logRunningCommand": false
       },
       "allOf": [
         {
@@ -89,6 +90,10 @@
       "properties": {
         "inheritColorsForPipedTasks": {
           "default": true,
+          "type": "boolean"
+        },
+        "logRunningCommand": {
+          "default": false,
           "type": "boolean"
         }
       }

--- a/website/static/schemas/workspace.json
+++ b/website/static/schemas/workspace.json
@@ -14,6 +14,13 @@
         }
       ]
     },
+    "extends": {
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "node": {
       "default": {
         "addEnginesConstraint": true,
@@ -116,6 +123,7 @@
           ]
         },
         "pnpm": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/PnpmConfig"
@@ -130,6 +138,7 @@
           "type": "boolean"
         },
         "syncVersionManagerConfig": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/VersionManager"
@@ -144,6 +153,7 @@
           "type": "string"
         },
         "yarn": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/YarnConfig"
@@ -174,9 +184,11 @@
     },
     "PnpmConfig": {
       "type": "object",
+      "required": [
+        "version"
+      ],
       "properties": {
         "version": {
-          "default": "7.1.5",
           "type": "string"
         }
       }
@@ -231,9 +243,11 @@
     },
     "YarnConfig": {
       "type": "object",
+      "required": [
+        "version"
+      ],
       "properties": {
         "version": {
-          "default": "3.2.1",
           "type": "string"
         }
       }


### PR DESCRIPTION
Roadmap for v0.4:

- [x] Add `extends` support to `.moon/workspace.yml` and `.moon/project.yml`, which can extend from an external HTTPS source.
- [x] Add a `--logFile` global option, where all logs are routed to.
- [x] Log the command being executed when running a target.