### PR TITLE
new: Add an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,7 @@ dependencies = [
  "moon_lang_node",
  "moon_utils",
  "regex",
+ "reqwest",
  "schemars",
  "semver",
  "serde",

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
@@ -6,7 +6,7 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
-# extends: 'https://.../workspace.yml'
+# extends: './shared/workspace.yml'
 
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: 'https://.../workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
@@ -6,7 +6,7 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
-# extends: 'https://.../workspace.yml'
+# extends: './shared/workspace.yml'
 
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: 'https://.../workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
@@ -6,7 +6,7 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
-# extends: 'https://.../workspace.yml'
+# extends: './shared/workspace.yml'
 
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: 'https://.../workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
@@ -6,7 +6,7 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
-# extends: 'https://.../workspace.yml'
+# extends: './shared/workspace.yml'
 
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
@@ -5,6 +5,9 @@ expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: 'https://.../workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -19,6 +19,7 @@ moon_utils = { path = "../utils"}
 figment = { version = "0.10.6", features = ["test", "yaml"] }
 json = "0.12.4"
 regex = "1.5.6"
+reqwest = { version = "0.11.10", features = ["blocking"] }
 schemars = "0.8.10"
 semver = "1.0.9"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2,6 +2,7 @@ pub mod constants;
 mod errors;
 pub mod package;
 mod project;
+mod providers;
 pub mod tsconfig;
 mod types;
 mod validators;

--- a/crates/config/src/project/global.rs
+++ b/crates/config/src/project/global.rs
@@ -51,9 +51,11 @@ pub struct GlobalProjectConfig {
     #[validate(custom = "validate_extends")]
     pub extends: Option<String>,
 
+    #[schemars(default)]
     #[validate(custom = "validate_file_groups")]
     pub file_groups: FileGroups,
 
+    #[schemars(default)]
     #[validate(custom = "validate_tasks")]
     #[validate]
     pub tasks: HashMap<String, TaskConfig>,

--- a/crates/config/src/project/mod.rs
+++ b/crates/config/src/project/mod.rs
@@ -102,6 +102,7 @@ pub struct ProjectMetadataConfig {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 pub struct ProjectWorkspaceInheritedTasksConfig {
     pub exclude: Option<Vec<TaskID>>,
 
@@ -111,6 +112,7 @@ pub struct ProjectWorkspaceInheritedTasksConfig {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectWorkspaceConfig {
     #[validate]
@@ -119,6 +121,7 @@ pub struct ProjectWorkspaceConfig {
 
 /// Docs: https://moonrepo.dev/docs/config/project
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectConfig {
     pub depends_on: Vec<ProjectID>,

--- a/crates/config/src/project/mod.rs
+++ b/crates/config/src/project/mod.rs
@@ -107,14 +107,12 @@ pub struct ProjectWorkspaceInheritedTasksConfig {
 
     pub include: Option<Vec<TaskID>>,
 
-    #[serde(default)]
     pub rename: HashMap<TaskID, TaskID>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectWorkspaceConfig {
-    #[serde(default)]
     #[validate]
     pub inherited_tasks: ProjectWorkspaceInheritedTasksConfig,
 }
@@ -123,20 +121,16 @@ pub struct ProjectWorkspaceConfig {
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectConfig {
-    #[serde(default)]
     pub depends_on: Vec<ProjectID>,
 
-    #[serde(default)]
     #[validate(custom = "validate_file_groups")]
     pub file_groups: FileGroups,
 
-    #[serde(default)]
     pub language: ProjectLanguage,
 
     #[validate]
     pub project: Option<ProjectMetadataConfig>,
 
-    #[serde(default)]
     #[validate(custom = "validate_tasks")]
     #[validate]
     pub tasks: HashMap<String, TaskConfig>,
@@ -144,7 +138,6 @@ pub struct ProjectConfig {
     #[serde(rename = "type")]
     pub type_of: ProjectType,
 
-    #[serde(default)]
     #[validate]
     pub workspace: ProjectWorkspaceConfig,
 
@@ -159,7 +152,7 @@ impl Provider for ProjectConfig {
     }
 
     fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
-        Serialized::defaults(ProjectConfig::default()).data()
+        Serialized::defaults(self).data()
     }
 
     fn profile(&self) -> Option<Profile> {
@@ -169,14 +162,13 @@ impl Provider for ProjectConfig {
 
 impl ProjectConfig {
     pub fn load(path: &Path) -> Result<ProjectConfig, ValidationErrors> {
-        let config: ProjectConfig =
-            match Figment::from(Serialized::defaults(ProjectConfig::default()))
-                .merge(Yaml::file(path))
-                .extract()
-            {
-                Ok(cfg) => cfg,
-                Err(error) => return Err(map_figment_error_to_validation_errors(&error)),
-            };
+        let config: ProjectConfig = match Figment::from(ProjectConfig::default())
+            .merge(Yaml::file(path))
+            .extract()
+        {
+            Ok(cfg) => cfg,
+            Err(error) => return Err(map_figment_error_to_validation_errors(&error)),
+        };
 
         if let Err(errors) = config.validate() {
             return Err(errors);

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -99,7 +99,7 @@ impl Default for TaskOptionsConfig {
     }
 }
 
-// We use serde(default) here because figment *does not* apply defaults,
+// We use serde(default) here because figment *does not* apply defaults
 // for structs nested within collections. Primarily hash maps.
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct TaskConfig {

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -99,6 +99,8 @@ impl Default for TaskOptionsConfig {
     }
 }
 
+// We use serde(default) here because figment *does not* apply defaults,
+// for structs nested within collections. Primarily hash maps.
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct TaskConfig {
     #[serde(default)]
@@ -176,9 +178,9 @@ where
 #[serde(untagged)]
 enum ArgsField {
     #[allow(dead_code)]
-    Str(String),
+    String(String),
     #[allow(dead_code)]
-    Vec(Vec<String>),
+    Sequence(Vec<String>),
 }
 
 fn make_args_schema(_gen: &mut SchemaGenerator) -> Schema {

--- a/crates/config/src/providers/mod.rs
+++ b/crates/config/src/providers/mod.rs
@@ -1,0 +1,1 @@
+pub mod url;

--- a/crates/config/src/providers/url.rs
+++ b/crates/config/src/providers/url.rs
@@ -1,0 +1,46 @@
+// Based on https://docs.rs/figment/latest/figment/trait.Provider.html
+
+use figment::{
+    providers::{Format, Yaml},
+    value::{Dict, Map},
+    Error, Metadata, Profile, Provider,
+};
+
+pub struct Url {
+    url: String,
+}
+
+impl Url {
+    pub fn from(url: String) -> Self {
+        Url { url }
+    }
+}
+
+impl Provider for Url {
+    fn metadata(&self) -> Metadata {
+        Metadata::from("Extends", self.url.clone())
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, Error> {
+        // Unfortunate we must use blocking here,
+        // but figment doesn't support async/await
+        let resp = reqwest::blocking::get(&self.url)
+            .map_err(|e| {
+                Error::from(format!(
+                    "Failed to load extended config <url>{}</url>: {}",
+                    self.url, e
+                ))
+            })?
+            .text()
+            .map_err(|e| {
+                Error::from(format!(
+                    "Failed to parse extended config <url>{}</url>: {}",
+                    self.url, e
+                ))
+            })?;
+
+        // We expect the URLs to point to YAML files,
+        // so piggyback off the default YAML provider
+        Yaml::string(&resp).data()
+    }
+}

--- a/crates/config/src/validators.rs
+++ b/crates/config/src/validators.rs
@@ -3,7 +3,7 @@ use moon_utils::regex::{matches_id, matches_target};
 use semver::Version;
 use std::collections::HashMap;
 use std::path::Path;
-use validator::{Validate, ValidationError, ValidationErrors};
+use validator::{validate_url as validate_base_url, Validate, ValidationError, ValidationErrors};
 
 pub fn default_bool_true() -> bool {
     true
@@ -113,6 +113,27 @@ pub fn validate_target(key: &str, target_id: &str) -> Result<(), ValidationError
             "invalid_target",
             key,
             String::from("Must be a valid target format."),
+        ));
+    }
+
+    Ok(())
+}
+
+// Validate the value is a URL, and optionally check if HTTPS.
+pub fn validate_url(key: &str, value: &str, https_only: bool) -> Result<(), ValidationError> {
+    if !validate_base_url(value) {
+        return Err(create_validation_error(
+            "invalid_url",
+            key,
+            String::from("Must be a valid URL."),
+        ));
+    }
+
+    if https_only && !value.starts_with("https://") {
+        return Err(create_validation_error(
+            "invalid_https_url",
+            key,
+            String::from("Only HTTPS URLs are supported."),
         ));
     }
 

--- a/crates/config/src/validators.rs
+++ b/crates/config/src/validators.rs
@@ -139,3 +139,18 @@ pub fn validate_url(key: &str, value: &str, https_only: bool) -> Result<(), Vali
 
     Ok(())
 }
+
+// Validate the value is an acceptable URL for an "extends" YAML field.
+pub fn validate_extends_url(key: &str, value: &str) -> Result<(), ValidationError> {
+    validate_url(key, value, true)?;
+
+    if !value.ends_with(".yml") {
+        return Err(create_validation_error(
+            "invalid_yaml",
+            key,
+            String::from("Must be a YAML (.yml) document."),
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/config/src/validators.rs
+++ b/crates/config/src/validators.rs
@@ -144,11 +144,11 @@ pub fn validate_url(key: &str, value: &str, https_only: bool) -> Result<(), Vali
 pub fn validate_extends_url(key: &str, value: &str) -> Result<(), ValidationError> {
     validate_url(key, value, true)?;
 
-    if !value.ends_with(".yml") {
+    if !value.ends_with(".yml") && !value.ends_with(".yaml") {
         return Err(create_validation_error(
             "invalid_yaml",
             key,
-            String::from("Must be a YAML (.yml) document."),
+            String::from("Must be a YAML document."),
         ));
     }
 

--- a/crates/config/src/workspace/mod.rs
+++ b/crates/config/src/workspace/mod.rs
@@ -140,7 +140,7 @@ impl WorkspaceConfig {
                 Figment::from(Serialized::defaults(WorkspaceConfig::default()))
                     .merge(Url::from(extends))
                     .merge(Yaml::file(&path)),
-            )?
+            )?;
         }
 
         // Versions from env vars should take precedence

--- a/crates/config/src/workspace/mod.rs
+++ b/crates/config/src/workspace/mod.rs
@@ -51,6 +51,7 @@ fn validate_projects(projects: &ProjectsMap) -> Result<(), ValidationError> {
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionRunnerConfig {
     pub inherit_colors_for_piped_tasks: bool,
@@ -66,6 +67,7 @@ impl Default for ActionRunnerConfig {
 
 /// Docs: https://moonrepo.dev/docs/config/workspace
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceConfig {
     #[validate]

--- a/crates/config/src/workspace/node.rs
+++ b/crates/config/src/workspace/node.rs
@@ -73,6 +73,7 @@ impl VersionManager {
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 pub struct NpmConfig {
     #[validate(custom = "validate_npm_version")]
     pub version: String,
@@ -115,6 +116,7 @@ impl Default for YarnConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeConfig {
     pub add_engines_constraint: bool,

--- a/crates/config/src/workspace/node.rs
+++ b/crates/config/src/workspace/node.rs
@@ -1,4 +1,4 @@
-use crate::validators::{default_bool_true, validate_semver_version};
+use crate::validators::validate_semver_version;
 use moon_lang_node::{NODE, NODENV, NVMRC, PNPM, YARN};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -74,7 +74,6 @@ impl VersionManager {
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct NpmConfig {
-    #[serde(default = "default_npm_version")]
     #[validate(custom = "validate_npm_version")]
     pub version: String,
 }
@@ -89,7 +88,6 @@ impl Default for NpmConfig {
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct PnpmConfig {
-    #[serde(default = "default_pnpm_version")]
     #[validate(custom = "validate_pnpm_version")]
     pub version: String,
 }
@@ -104,7 +102,6 @@ impl Default for PnpmConfig {
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct YarnConfig {
-    #[serde(default = "default_yarn_version")]
     #[validate(custom = "validate_yarn_version")]
     pub version: String,
 }
@@ -120,28 +117,22 @@ impl Default for YarnConfig {
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeConfig {
-    #[serde(default = "default_bool_true")]
     pub add_engines_constraint: bool,
 
-    #[serde(default = "default_bool_true")]
     pub dedupe_on_lockfile_change: bool,
 
-    #[serde(default)]
     #[validate]
     pub npm: NpmConfig,
 
-    #[serde(default)]
     pub package_manager: PackageManager,
 
     #[validate]
     pub pnpm: Option<PnpmConfig>,
 
-    #[serde(default = "default_bool_true")]
     pub sync_project_workspace_dependencies: bool,
 
     pub sync_version_manager_config: Option<VersionManager>,
 
-    #[serde(default = "default_node_version")]
     #[validate(custom = "validate_node_version")]
     pub version: String,
 
@@ -152,12 +143,12 @@ pub struct NodeConfig {
 impl Default for NodeConfig {
     fn default() -> Self {
         NodeConfig {
-            add_engines_constraint: default_bool_true(),
-            dedupe_on_lockfile_change: default_bool_true(),
+            add_engines_constraint: true,
+            dedupe_on_lockfile_change: true,
             npm: NpmConfig::default(),
-            package_manager: PackageManager::Npm,
+            package_manager: PackageManager::default(),
             pnpm: None,
-            sync_project_workspace_dependencies: default_bool_true(),
+            sync_project_workspace_dependencies: true,
             sync_version_manager_config: None,
             version: default_node_version(),
             yarn: None,

--- a/crates/config/src/workspace/typescript.rs
+++ b/crates/config/src/workspace/typescript.rs
@@ -2,33 +2,22 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-fn default_config_file_name() -> String {
-    String::from("tsconfig.json")
-}
-
-fn default_sync_project_references() -> bool {
-    true
-}
-
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct TypeScriptConfig {
-    #[serde(default = "default_config_file_name")]
     pub project_config_file_name: String,
 
-    #[serde(default = "default_config_file_name")]
     pub root_config_file_name: String,
 
-    #[serde(default = "default_sync_project_references")]
     pub sync_project_references: bool,
 }
 
 impl Default for TypeScriptConfig {
     fn default() -> Self {
         TypeScriptConfig {
-            project_config_file_name: default_config_file_name(),
-            root_config_file_name: default_config_file_name(),
-            sync_project_references: default_sync_project_references(),
+            project_config_file_name: String::from("tsconfig.json"),
+            root_config_file_name: String::from("tsconfig.json"),
+            sync_project_references: true,
         }
     }
 }

--- a/crates/config/src/workspace/typescript.rs
+++ b/crates/config/src/workspace/typescript.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 #[serde(rename_all = "camelCase")]
 pub struct TypeScriptConfig {
     pub project_config_file_name: String,

--- a/crates/config/src/workspace/vcs.rs
+++ b/crates/config/src/workspace/vcs.rs
@@ -16,6 +16,7 @@ impl Default for VcsManager {
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
+#[schemars(default)]
 #[serde(rename_all = "camelCase")]
 pub struct VcsConfig {
     pub manager: VcsManager,

--- a/crates/config/src/workspace/vcs.rs
+++ b/crates/config/src/workspace/vcs.rs
@@ -2,10 +2,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-fn default_branch_default() -> String {
-    String::from("master")
-}
-
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum VcsManager {
@@ -22,10 +18,8 @@ impl Default for VcsManager {
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct VcsConfig {
-    #[serde(default)]
     pub manager: VcsManager,
 
-    #[serde(default = "default_branch_default")]
     pub default_branch: String,
 }
 
@@ -33,7 +27,7 @@ impl Default for VcsConfig {
     fn default() -> Self {
         VcsConfig {
             manager: VcsManager::default(),
-            default_branch: default_branch_default(),
+            default_branch: String::from("master"),
         }
     }
 }

--- a/crates/config/templates/global_project.yml
+++ b/crates/config/templates/global_project.yml
@@ -1,6 +1,6 @@
 $schema: 'https://moonrepo.dev/schemas/global-project.json'
 
-# Extend and inherit an external configuration file. Must be a valid HTTPS URL.
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: 'https://.../workspace.yml'
 
 # OPTIONAL: File groups are a mechanism for grouping similar types of files within a project

--- a/crates/config/templates/global_project.yml
+++ b/crates/config/templates/global_project.yml
@@ -1,7 +1,7 @@
 $schema: 'https://moonrepo.dev/schemas/global-project.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
-# extends: 'https://.../workspace.yml'
+# extends: './shared/project.yml'
 
 # OPTIONAL: File groups are a mechanism for grouping similar types of files within a project
 # using file glob patterns. These groups are then used by tasks to calculate functionality like

--- a/crates/config/templates/global_project.yml
+++ b/crates/config/templates/global_project.yml
@@ -1,5 +1,8 @@
 $schema: 'https://moonrepo.dev/schemas/global-project.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL.
+# extends: 'https://.../workspace.yml'
+
 # OPTIONAL: File groups are a mechanism for grouping similar types of files within a project
 # using file glob patterns. These groups are then used by tasks to calculate functionality like
 # cache computation, affected files since last change, command line arguments, deterministic

--- a/crates/config/templates/workspace.yml
+++ b/crates/config/templates/workspace.yml
@@ -1,7 +1,7 @@
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
-# extends: 'https://.../workspace.yml'
+# extends: './shared/workspace.yml'
 
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system

--- a/crates/config/templates/workspace.yml
+++ b/crates/config/templates/workspace.yml
@@ -1,6 +1,6 @@
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
-# Extend and inherit an external configuration file. Must be a valid HTTPS URL.
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: 'https://.../workspace.yml'
 
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.

--- a/crates/config/templates/workspace.yml
+++ b/crates/config/templates/workspace.yml
@@ -1,5 +1,8 @@
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL.
+# extends: 'https://.../workspace.yml'
+
 # REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
 # When using a map, each entry requires a unique project ID as the map key, and a file system
 # path to the project folder as the map value. File paths are relative from the workspace root,

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -18,6 +18,7 @@ fn mock_file_groups() -> HashMap<String, FileGroup> {
 
 fn mock_global_project_config() -> GlobalProjectConfig {
     GlobalProjectConfig {
+        extends: None,
         file_groups: HashMap::from([(String::from("sources"), string_vec!["src/**/*"])]),
         tasks: HashMap::new(),
         schema: String::new(),
@@ -167,8 +168,7 @@ fn overrides_global_file_groups() {
         &workspace_root,
         &GlobalProjectConfig {
             file_groups: HashMap::from([(String::from("tests"), string_vec!["tests/**/*"])]),
-            tasks: HashMap::new(),
-            schema: String::new(),
+            ..GlobalProjectConfig::default()
         },
     )
     .unwrap();
@@ -304,9 +304,8 @@ mod tasks {
             "tasks/no-tasks",
             &workspace_root,
             &GlobalProjectConfig {
-                file_groups: HashMap::new(),
                 tasks: HashMap::from([(String::from("standard"), mock_task_config("cmd"))]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             },
         )
         .unwrap();
@@ -345,9 +344,8 @@ mod tasks {
             "tasks/basic",
             &workspace_root,
             &GlobalProjectConfig {
-                file_groups: HashMap::new(),
                 tasks: HashMap::from([(String::from("standard"), mock_task_config("cmd"))]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             },
         )
         .unwrap();
@@ -415,7 +413,6 @@ mod tasks {
             project_source,
             &workspace_root,
             &GlobalProjectConfig {
-                file_groups: HashMap::new(),
                 tasks: HashMap::from([(
                     String::from("standard"),
                     TaskConfig {
@@ -429,7 +426,7 @@ mod tasks {
                         type_of: TaskType::Node,
                     },
                 )]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             },
         )
         .unwrap();
@@ -490,7 +487,6 @@ mod tasks {
             project_source,
             &workspace_root,
             &GlobalProjectConfig {
-                file_groups: HashMap::new(),
                 tasks: HashMap::from([(
                     String::from("standard"),
                     TaskConfig {
@@ -504,7 +500,7 @@ mod tasks {
                         type_of: TaskType::Node,
                     },
                 )]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             },
         )
         .unwrap();
@@ -568,7 +564,6 @@ mod tasks {
             project_source,
             &workspace_root,
             &GlobalProjectConfig {
-                file_groups: HashMap::new(),
                 tasks: HashMap::from([(
                     String::from("standard"),
                     TaskConfig {
@@ -582,7 +577,7 @@ mod tasks {
                         type_of: TaskType::Node,
                     },
                 )]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             },
         )
         .unwrap();
@@ -646,7 +641,6 @@ mod tasks {
             project_source,
             &workspace_root,
             &GlobalProjectConfig {
-                file_groups: HashMap::new(),
                 tasks: HashMap::from([(
                     String::from("standard"),
                     TaskConfig {
@@ -660,7 +654,7 @@ mod tasks {
                         type_of: TaskType::Node,
                     },
                 )]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             },
         )
         .unwrap();
@@ -842,7 +836,7 @@ mod tasks {
                             ..TaskConfig::default()
                         },
                     )]),
-                    schema: String::new(),
+                    ..GlobalProjectConfig::default()
                 },
             )
             .unwrap();
@@ -914,7 +908,7 @@ mod tasks {
                             ..TaskConfig::default()
                         },
                     )]),
-                    schema: String::new(),
+                    ..GlobalProjectConfig::default()
                 },
             )
             .unwrap();
@@ -969,7 +963,7 @@ mod tasks {
                             ..TaskConfig::default()
                         },
                     )]),
-                    schema: String::new(),
+                    ..GlobalProjectConfig::default()
                 },
             )
             .unwrap();
@@ -1023,7 +1017,7 @@ mod tasks {
                             ..TaskConfig::default()
                         },
                     )]),
-                    schema: String::new(),
+                    ..GlobalProjectConfig::default()
                 },
             )
             .unwrap();
@@ -1092,7 +1086,7 @@ mod workspace {
                         },
                     ),
                 ]),
-                schema: String::new(),
+                ..GlobalProjectConfig::default()
             }
         }
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.
+
 ## 0.3.0
 
 #### 💥 Breaking

--- a/tests/fixtures/config-extends/.moon/project.yml
+++ b/tests/fixtures/config-extends/.moon/project.yml
@@ -1,0 +1,27 @@
+# NOTE: This is used to test config extending. Changing this will definitely break something!
+
+fileGroups:
+  sources:
+    - src/**/*
+  tests:
+    - tests/**/*
+
+tasks:
+  onlyCommand:
+    command: a
+  stringArgs:
+    command: b
+    args: string args
+  arrayArgs:
+    command: c
+    args:
+      - array
+      - args
+  inputs:
+    command: d
+    inputs:
+      - src/**/*
+  options:
+    command: e
+    options:
+      runInCI: false

--- a/tests/fixtures/config-extends/.moon/workspace.yml
+++ b/tests/fixtures/config-extends/.moon/workspace.yml
@@ -1,0 +1,9 @@
+node:
+  # Use a unique version as to not collide with other tests
+  version: '16.1.0'
+
+typescript:
+  syncProjectReferences: false
+
+vcs:
+  manager: 'svn'

--- a/tests/fixtures/config-extends/.moon/workspace.yml
+++ b/tests/fixtures/config-extends/.moon/workspace.yml
@@ -1,6 +1,10 @@
+# NOTE: This is used to test config extending. Changing this will definitely break something!
+
 node:
-  # Use a unique version as to not collide with other tests
   version: '16.1.0'
+  addEnginesConstraint: false
+  npm:
+    version: '7.0.0'
 
 typescript:
   syncProjectReferences: false

--- a/website/docs/config/global-project.mdx
+++ b/website/docs/config/global-project.mdx
@@ -6,6 +6,26 @@ The `.moon/project.yml` file configures file groups and tasks that are inherited
 in the workspace. Projects can override or merge with these settings within their respective
 [`project.yml`](./project).
 
+## `extends`
+
+> `string`
+
+Defines an external `.moon/project.yml` to extend and inherit settings from. Perfect for reusability
+and sharing configuration across repositories and projects. When defined, this setting must be an
+HTTPS URL that points to a valid YAML document!
+
+```yaml title=".moon/workspace.yml" {1}
+extends: 'https://raw.githubusercontent.com/organization/repository/master/.moon/project.yml'
+```
+
+:::caution
+
+For map-based settings, `fileGroups` and `tasks`, entries from both the upstream extended
+configuration and local configuration are merged into a new map, with the values of the local taking
+precedence. Map values _are not_ deep merged!
+
+:::
+
 ## `fileGroups`
 
 > `Record<string, string[]>`

--- a/website/docs/config/global-project.mdx
+++ b/website/docs/config/global-project.mdx
@@ -12,7 +12,7 @@ in the workspace. Projects can override or merge with these settings within thei
 
 Defines an external `.moon/project.yml` to extend and inherit settings from. Perfect for reusability
 and sharing configuration across repositories and projects. When defined, this setting must be an
-HTTPS URL that points to a valid YAML document!
+HTTPS URL _or_ relative file system path that points to a valid YAML document!
 
 ```yaml title=".moon/workspace.yml" {1}
 extends: 'https://raw.githubusercontent.com/organization/repository/master/.moon/project.yml'
@@ -20,9 +20,9 @@ extends: 'https://raw.githubusercontent.com/organization/repository/master/.moon
 
 :::caution
 
-For map-based settings, `fileGroups` and `tasks`, entries from both the upstream extended
-configuration and local configuration are merged into a new map, with the values of the local taking
-precedence. Map values _are not_ deep merged!
+For map-based settings, `fileGroups` and `tasks`, entries from both the extended configuration and
+local configuration are merged into a new map, with the values of the local taking precedence. Map
+values _are not_ deep merged!
 
 :::
 

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -29,6 +29,26 @@ actionRunner:
   inheritColorsForPipedTasks: true # Default
 ```
 
+## `extends`
+
+> `string`
+
+Defines an external `.moon/workspace.yml` to extend and inherit settings from. Perfect for
+reusability and sharing configuration across repositories and projects. When defined, this setting
+must be an HTTPS URL that points to a valid YAML document!
+
+```yaml title=".moon/workspace.yml" {1}
+extends: 'https://raw.githubusercontent.com/organization/repository/master/.moon/workspace.yml'
+```
+
+:::caution
+
+Settings will be merged recursively for blocks, with values defined in the local configuration
+taking precedence over those defined in the extended upstream configuration. However, the `projects`
+setting _does not merge_!
+
+:::
+
 ## `projects`<RequiredLabel />
 
 > `Record<string, string> | string[]`

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -35,7 +35,7 @@ actionRunner:
 
 Defines an external `.moon/workspace.yml` to extend and inherit settings from. Perfect for
 reusability and sharing configuration across repositories and projects. When defined, this setting
-must be an HTTPS URL that points to a valid YAML document!
+must be an HTTPS URL _or_ relative file system path that points to a valid YAML document!
 
 ```yaml title=".moon/workspace.yml" {1}
 extends: 'https://raw.githubusercontent.com/organization/repository/master/.moon/workspace.yml'
@@ -44,8 +44,8 @@ extends: 'https://raw.githubusercontent.com/organization/repository/master/.moon
 :::caution
 
 Settings will be merged recursively for blocks, with values defined in the local configuration
-taking precedence over those defined in the extended upstream configuration. However, the `projects`
-setting _does not merge_!
+taking precedence over those defined in the extended configuration. However, the `projects` setting
+_does not merge_!
 
 :::
 

--- a/website/docs/guides/examples/eslint.mdx
+++ b/website/docs/guides/examples/eslint.mdx
@@ -43,8 +43,8 @@ tasks:
 			- 'tests/**/*'
 			# Other config files
 			- '*.config.*'
-			# Project configs, any format
-			- '.eslintrc.*'
+			# Project configs, any format, any depth
+			- '**/.eslintrc.*'
 			# Root configs, any format
 			- '/.eslintignore'
 			- '/.eslintrc.*'

--- a/website/docs/guides/examples/packemon.mdx
+++ b/website/docs/guides/examples/packemon.mdx
@@ -63,7 +63,7 @@ buildPackage:
 With this being defined globally, all package-based projects can inherit this task and rename it as
 follows.
 
-```yaml title="packages/*/project.yml"
+```yaml title="<package>/project.yml"
 # Rename the `buildPackage` task to `build` for this project
 workspace:
 	inheritedTasks:
@@ -80,7 +80,7 @@ tasks:
 However, for other project types like applications, this task will need to be _excluded_, otherwise
 it will run and fail in CI.
 
-```yaml title="apps/*/project.yml"
+```yaml title="<app>/project.yml"
 # Exclude the `buildPackage` task for this project
 workspace:
 	inheritedTasks:
@@ -90,7 +90,7 @@ workspace:
 </TabItem>
 <TabItem value="local">
 
-```yaml title="packages/*/project.yml"
+```yaml title="<package>/project.yml"
 build:
 	command: 'packemon'
 	args:

--- a/website/docs/guides/sharing-config.mdx
+++ b/website/docs/guides/sharing-config.mdx
@@ -6,9 +6,8 @@ the maintenance burden while ensuring a similar developer experience.
 
 To help streamline this process, moon provides an `extends` setting in both
 [`.moon/workspace.yml`](../config/workspace#extends) and
-[`.moon/project.yml`](../config/global-project#extends). This setting requires a valid HTTPS URL
-that points to a YAML document for the configuration in question, and of course, this URL must be
-accessible from moon.
+[`.moon/project.yml`](../config/global-project#extends). This setting requires a HTTPS URL _or_
+relative file system path that points to a valid YAML document for the configuration in question.
 
 A great way to share configuration is by using GitHub's "raw file view", as demonstrated below using
 our very own [examples repository](https://github.com/moonrepo/examples).
@@ -30,8 +29,8 @@ A rudimentary solution is to append a version to the upstream filename. When the
 new version should be created, while the previous version remains untouched.
 
 ```diff
--extends: 'https://company.com/some/path/to/project.yml'
-+extends: 'https://company.com/some/path/to/project-v1.yml'
+-extends: '../shared/project.yml'
++extends: '../shared/project-v1.yml'
 ```
 
 ### Using branches, tags, or commits

--- a/website/docs/guides/sharing-config.mdx
+++ b/website/docs/guides/sharing-config.mdx
@@ -1,0 +1,46 @@
+# Sharing workspace configuration
+
+For large companies, open source maintainers, and those that love reusability, more often than not
+you'll want to use the same configuration across all repositories for consistency. This helps reduce
+the maintenance burden while ensuring a similar developer experience.
+
+To help streamline this process, moon provides an `extends` setting in both
+[`.moon/workspace.yml`](../config/workspace#extends) and
+[`.moon/project.yml`](../config/global-project#extends). This setting requires a valid HTTPS URL
+that points to a YAML document for the configuration in question, and of course, this URL must be
+accessible from moon.
+
+A great way to share configuration is by using GitHub's "raw file view", as demonstrated below using
+our very own [examples repository](https://github.com/moonrepo/examples).
+
+```yaml title=".moon/project.yml"
+extends: 'https://raw.githubusercontent.com/moonrepo/examples/master/.moon/project.yml'
+```
+
+## Versioning
+
+Inheriting an upstream configuration can be dangerous, as the settings may change at any point,
+resulting in broken builds. To mitigate this, you can used a "versioned" upstream configuration,
+which is ideally a fixed point in time. How this is implemented is up to you or your company, but we
+suggest the following patterns:
+
+### Using versioned filenames
+
+A rudimentary solution is to append a version to the upstream filename. When the file is modified, a
+new version should be created, while the previous version remains untouched.
+
+```diff
+-extends: 'https://company.com/some/path/to/project.yml'
++extends: 'https://company.com/some/path/to/project-v1.yml'
+```
+
+### Using branches, tags, or commits
+
+When using a version control platform, like GitHub above, you can reference the upstream
+configuration through a branch, tag, commit, or sha. Since these are a reference point in time, they
+are relatively safe.
+
+```diff
+-extends: 'https://raw.githubusercontent.com/moonrepo/examples/master/.moon/project.yml'
++extends: 'https://raw.githubusercontent.com/moonrepo/examples/c3f10160bcd16b48b8d4d21b208bb50f6b09bd96/.moon/project.yml'
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -16,6 +16,7 @@ const sidebars = {
 			items: [
 				'guides/ci',
 				'guides/open-source',
+				'guides/sharing-config',
 				{
 					type: 'category',
 					label: 'Examples',

--- a/website/static/schemas/global-project.json
+++ b/website/static/schemas/global-project.json
@@ -4,6 +4,12 @@
   "description": "Docs: https://moonrepo.dev/docs/config/global-project",
   "type": "object",
   "properties": {
+    "extends": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "fileGroups": {
       "default": {},
       "type": "object",

--- a/website/static/schemas/project.json
+++ b/website/static/schemas/project.json
@@ -3,9 +3,6 @@
   "title": "ProjectConfig",
   "description": "Docs: https://moonrepo.dev/docs/config/project",
   "type": "object",
-  "required": [
-    "type"
-  ],
   "properties": {
     "dependsOn": {
       "default": [],
@@ -33,6 +30,7 @@
       ]
     },
     "project": {
+      "default": null,
       "anyOf": [
         {
           "$ref": "#/definitions/ProjectMetadataConfig"
@@ -50,7 +48,12 @@
       }
     },
     "type": {
-      "$ref": "#/definitions/ProjectType"
+      "default": "library",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProjectType"
+        }
+      ]
     },
     "workspace": {
       "default": {
@@ -136,6 +139,7 @@
       "type": "object",
       "properties": {
         "exclude": {
+          "default": null,
           "type": [
             "array",
             "null"
@@ -145,6 +149,7 @@
           }
         },
         "include": {
+          "default": null,
           "type": [
             "array",
             "null"

--- a/website/static/schemas/workspace.json
+++ b/website/static/schemas/workspace.json
@@ -14,6 +14,12 @@
         }
       ]
     },
+    "extends": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "node": {
       "default": {
         "addEnginesConstraint": true,

--- a/website/static/schemas/workspace.json
+++ b/website/static/schemas/workspace.json
@@ -15,6 +15,7 @@
       ]
     },
     "extends": {
+      "default": null,
       "type": [
         "string",
         "null"
@@ -122,6 +123,7 @@
           ]
         },
         "pnpm": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/PnpmConfig"
@@ -136,6 +138,7 @@
           "type": "boolean"
         },
         "syncVersionManagerConfig": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/VersionManager"
@@ -150,6 +153,7 @@
           "type": "string"
         },
         "yarn": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/YarnConfig"
@@ -180,9 +184,11 @@
     },
     "PnpmConfig": {
       "type": "object",
+      "required": [
+        "version"
+      ],
       "properties": {
         "version": {
-          "default": "7.1.5",
           "type": "string"
         }
       }
@@ -237,9 +243,11 @@
     },
     "YarnConfig": {
       "type": "object",
+      "required": [
+        "version"
+      ],
       "properties": {
         "version": {
-          "default": "3.2.1",
           "type": "string"
         }
       }


### PR DESCRIPTION
This new `extends` setting can be defined with an HTTPS URL/file path that points to an external YAML file, which will then be downloaded, parsed, and merged _before_ the local config file.

This enables config sharing and reuse.