### PR TITLE
fix: Fix tasks referencing workspace files not being affected.

### DIFF
--- a/.yarn/versions/ec726743.yml
+++ b/.yarn/versions/ec726743.yml
@@ -1,0 +1,7 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/cli/src/commands/ci.rs
+++ b/crates/cli/src/commands/ci.rs
@@ -99,10 +99,6 @@ fn gather_runnable_targets(
     for project_id in workspace.projects.ids() {
         let project = workspace.projects.load(&project_id)?;
 
-        if !globally_affected && !project.is_affected(touched_files) {
-            continue;
-        }
-
         for (task_id, task) in &project.tasks {
             let target = Target::new(&project_id, task_id)?;
 

--- a/crates/workspace/src/dep_graph.rs
+++ b/crates/workspace/src/dep_graph.rs
@@ -304,17 +304,6 @@ impl DepGraph {
                 );
             }
 
-            // Validate project first
-            if !globally_affected && !project.is_affected(touched) {
-                trace!(
-                    target: TARGET,
-                    "Project {} not affected based on touched files, skipping",
-                    color::id(project_id),
-                );
-
-                return Ok(None);
-            }
-
             // Validate task exists for project
             if !globally_affected && !project.get_task(task_id)?.is_affected(touched)? {
                 trace!(

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where tasks referencing workspace relative files were not being marked as affected.
+
 ## 0.3.0
 
 #### 💥 Breaking


### PR DESCRIPTION
The `project.is_affected()` call was an old implementation that assumed all task inputs start with the project source. This isn't true because tasks can also reference workspace relative files.

Because of this, some targets wouldn't run in CI correctly.