### PR TITLE
fix: Fix colors not being inherited correctly.

### DIFF
--- a/.yarn/versions/a73d03ac.yml
+++ b/.yarn/versions/a73d03ac.yml
@@ -1,7 +1,7 @@
 releases:
-  "@moonrepo/cli": minor
-  "@moonrepo/core-linux-x64-gnu": minor
-  "@moonrepo/core-linux-x64-musl": minor
-  "@moonrepo/core-macos-arm64": minor
-  "@moonrepo/core-macos-x64": minor
-  "@moonrepo/core-windows-x64-msvc": minor
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/.yarn/versions/a73d03ac.yml
+++ b/.yarn/versions/a73d03ac.yml
@@ -1,7 +1,7 @@
 releases:
-  "@moonrepo/cli": patch
-  "@moonrepo/core-linux-x64-gnu": patch
-  "@moonrepo/core-linux-x64-musl": patch
-  "@moonrepo/core-macos-arm64": patch
-  "@moonrepo/core-macos-x64": patch
-  "@moonrepo/core-windows-x64-msvc": patch
+  "@moonrepo/cli": minor
+  "@moonrepo/core-linux-x64-gnu": minor
+  "@moonrepo/core-linux-x64-musl": minor
+  "@moonrepo/core-macos-arm64": minor
+  "@moonrepo/core-macos-x64": minor
+  "@moonrepo/core-windows-x64-msvc": minor

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -1,7 +1,6 @@
 use crate::path;
 use moon_error::{map_io_to_process_error, MoonError};
 use moon_logger::{color, logging_enabled, trace};
-use std::env;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
@@ -246,12 +245,10 @@ impl Command {
     }
 
     pub fn inherit_colors(&mut self) -> &mut Command {
-        if let Ok(level) = env::var("FORCE_COLOR") {
-            self.env("FORCE_COLOR", &level);
-            self.env("CLICOLOR_FORCE", &level);
-        } else if env::var("NO_COLOR").is_ok() {
-            self.env("NO_COLOR", "1");
-        }
+        let level = color::supports_color().to_string();
+
+        self.env("FORCE_COLOR", &level);
+        self.env("CLICOLOR_FORCE", &level);
 
         // Force a terminal width so that we have consistent sizing
         // in our cached output, and its the same across all machines

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.
+
+#### 🐞 Fixes
+
+- More fixes around terminal color output and handling.
+
 ## 0.3.1
-
-#### 🚀 Updates
-
-- Added an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.
-
-#### 🚀 Updates
-
-- Added an `extends` setting to `.moon/workspace.yml` and `.moon/project.yml`.
 
 #### 🐞 Fixes
 


### PR DESCRIPTION
When you set `--color`, piped colors work correctly because we set `FORCE_COLOR`. For other scenarios, colors are lost. This was an oversight on my part.

This now will simply inherit color settings from your terminal and force them for the child process.