### PR TITLE
new: Add caching to VCS layer.

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -20,3 +20,4 @@ actionRunner:
 
 vcs:
   defaultBranch: 'master'
+# bump

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -20,4 +20,3 @@ actionRunner:
 
 vcs:
   defaultBranch: 'master'
-# bump

--- a/crates/cli/src/commands/ci.rs
+++ b/crates/cli/src/commands/ci.rs
@@ -40,7 +40,7 @@ async fn gather_touched_files(
 ) -> Result<TouchedFilePaths, WorkspaceError> {
     print_header("Gathering touched files");
 
-    let vcs = workspace.detect_vcs()?;
+    let vcs = &workspace.vcs;
     let default_branch = vcs.get_default_branch();
     let current_branch = vcs.get_local_branch().await?;
 

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -40,7 +40,7 @@ async fn get_touched_files(
     status: &RunStatus,
     upstream: bool,
 ) -> Result<TouchedFilePaths, WorkspaceError> {
-    let vcs = workspace.detect_vcs()?;
+    let vcs = &workspace.vcs;
 
     let touched_files = if upstream {
         vcs.get_touched_files_between_revisions(vcs.get_default_branch(), "HEAD")

--- a/crates/workspace/src/actions/hashing/target.rs
+++ b/crates/workspace/src/actions/hashing/target.rs
@@ -34,7 +34,7 @@ pub async fn create_target_hasher(
     task: &Task,
     passthrough_args: &[String],
 ) -> Result<TargetHasher, WorkspaceError> {
-    let vcs = workspace.detect_vcs()?;
+    let vcs = &workspace.vcs;
     let globset = task.create_globset()?;
     let mut hasher = TargetHasher::new(workspace.config.node.version.clone());
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -145,6 +145,9 @@ pub struct Workspace {
     /// The root `tsconfig.json`.
     pub tsconfig_json: Option<TsConfigJson>,
 
+    /// Configured version control system.
+    pub vcs: Box<dyn Vcs + Send + Sync>,
+
     /// The current working directory.
     pub working_dir: PathBuf,
 }
@@ -178,6 +181,7 @@ impl Workspace {
         let toolchain = Toolchain::create(&root_dir, &config).await?;
         let projects =
             ProjectGraph::create(&root_dir, project_config, &config.projects, &cache).await?;
+        let vcs = VcsManager::load(&config, &root_dir)?;
 
         Ok(Workspace {
             cache,
@@ -187,12 +191,8 @@ impl Workspace {
             root: root_dir,
             toolchain,
             tsconfig_json,
+            vcs,
             working_dir,
         })
-    }
-
-    /// Detect the version control system currently being used.
-    pub fn detect_vcs(&self) -> Result<Box<dyn Vcs + Send + Sync>, WorkspaceError> {
-        VcsManager::load(&self.config, &self.working_dir)
     }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added caching to our VCS layer which should greatly reduce the amount of `git` commands being
+  executed.
+
 ### 0.4.1
 
 #### 🐞 Fixes


### PR DESCRIPTION
We were constantly calling `git status` and `git ls-tree` commands. This should greatly reduce that.