### PR TITLE
internal: Run package binaries directly on Windows.

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,3 +1,5 @@
+# Trigger CI: 1
+
 $schema: '../schemas/workspace.json'
 
 node:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,7 @@ name = "moon_lang_node"
 version = "0.1.0"
 dependencies = [
  "assert_fs",
+ "cached",
  "lazy_static",
  "moon_lang",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,9 @@ name = "moon_lang_node"
 version = "0.1.0"
 dependencies = [
  "assert_fs",
+ "lazy_static",
  "moon_lang",
+ "regex",
  "serial_test",
 ]
 

--- a/crates/action-runner/src/actions/target/node.rs
+++ b/crates/action-runner/src/actions/target/node.rs
@@ -1,9 +1,9 @@
 use crate::errors::ActionRunnerError;
 use moon_project::{Project, Task};
 use moon_toolchain::{get_path_env_var, Executable};
+use moon_utils::path::relative_from;
 use moon_utils::process::Command;
 use moon_utils::string_vec;
-use moon_utils::path::relative_from;
 use moon_workspace::Workspace;
 
 fn create_node_options(task: &Task) -> Vec<String> {
@@ -51,7 +51,8 @@ pub fn create_node_target_command(
             cmd = node.get_yarn().unwrap().get_bin_path();
         }
         bin => {
-            let bin_path = relative_from(node.find_package_bin(bin, &project.root)?, &project.root).unwrap();
+            let bin_path =
+                relative_from(node.find_package_bin(bin, &project.root)?, &project.root).unwrap();
 
             args.extend(create_node_options(task));
             args.push(path::path_to_string(&bin_path)?);

--- a/crates/action-runner/src/actions/target/node.rs
+++ b/crates/action-runner/src/actions/target/node.rs
@@ -24,7 +24,6 @@ fn create_node_options(task: &Task) -> Vec<String> {
 ///
 /// ~/.moon/tools/node/1.2.3/bin/node --inspect /path/to/node_modules/.bin/eslint
 ///     --cache --color --fix --ext .ts,.tsx,.js,.jsx
-#[cfg(not(windows))]
 #[track_caller]
 pub fn create_node_target_command(
     workspace: &Workspace,
@@ -65,47 +64,6 @@ pub fn create_node_target_command(
         "PATH",
         get_path_env_var(node.get_bin_path().parent().unwrap()),
     );
-
-    Ok(command)
-}
-
-/// Windows works quite differently than other systems, so we cannot do the above.
-/// On Windows, the package binary is a ".cmd" file, which means it needs to run
-/// through "cmd.exe" and not "node.exe". Because of this, the order of operations
-/// is switched, and "node.exe" is detected through the `PATH` env var.
-#[cfg(windows)]
-#[track_caller]
-pub fn create_node_target_command(
-    workspace: &Workspace,
-    project: &Project,
-    task: &Task,
-) -> Result<Command, ActionRunnerError> {
-    use moon_lang_node::node;
-
-    let node = workspace.toolchain.get_node();
-
-    let cmd = match task.command.as_str() {
-        "node" => node.get_bin_path().clone(),
-        "npm" => node.get_npm().get_bin_path().clone(),
-        "pnpm" => node.get_pnpm().unwrap().get_bin_path().clone(),
-        "yarn" => node.get_yarn().unwrap().get_bin_path().clone(),
-        bin => node.find_package_bin(bin, &project.root)?,
-    };
-
-    // Create the command
-    let mut command = Command::new(cmd);
-
-    command
-        .args(&task.args)
-        .envs(&task.env)
-        .env(
-            "PATH",
-            get_path_env_var(node.get_bin_path().parent().unwrap()),
-        )
-        .env(
-            "NODE_OPTIONS",
-            node::extend_node_options_env_var(&create_node_options(task).join(" ")),
-        );
 
     Ok(command)
 }

--- a/crates/action-runner/src/actions/target/node.rs
+++ b/crates/action-runner/src/actions/target/node.rs
@@ -3,6 +3,7 @@ use moon_project::{Project, Task};
 use moon_toolchain::{get_path_env_var, Executable};
 use moon_utils::process::Command;
 use moon_utils::string_vec;
+use moon_utils::path::relative_from;
 use moon_workspace::Workspace;
 
 fn create_node_options(task: &Task) -> Vec<String> {
@@ -50,7 +51,7 @@ pub fn create_node_target_command(
             cmd = node.get_yarn().unwrap().get_bin_path();
         }
         bin => {
-            let bin_path = node.find_package_bin(bin, &project.root)?;
+            let bin_path = relative_from(node.find_package_bin(bin, &project.root)?, &project.root).unwrap();
 
             args.extend(create_node_options(task));
             args.push(path::path_to_string(&bin_path)?);

--- a/crates/lang-node/Cargo.toml
+++ b/crates/lang-node/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 moon_lang = { path = "../lang" }
+cached = "0.34.0"
 lazy_static = "1.4.0"
 regex = "1.5.6"
 

--- a/crates/lang-node/Cargo.toml
+++ b/crates/lang-node/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 moon_lang = { path = "../lang" }
+lazy_static = "1.4.0"
+regex = "1.5.6"
 
 [dev-dependencies]
 assert_fs = "1.0.7"

--- a/crates/lang-node/src/node.rs
+++ b/crates/lang-node/src/node.rs
@@ -57,9 +57,7 @@ pub fn find_package_bin(starting_dir: &Path, bin_name: &str) -> Option<PathBuf> 
                 bin_path
                     .parent()
                     .unwrap()
-                    .join(extract_bin_from_cmd_file(&bin_path, &contents))
-                    .canonicalize()
-                    .unwrap(),
+                    .join(extract_bin_from_cmd_file(&bin_path, &contents)),
             );
         }
 

--- a/crates/lang-node/src/node.rs
+++ b/crates/lang-node/src/node.rs
@@ -429,11 +429,10 @@ node "%~dp0\{path}" %*
                     path.unwrap(),
                     sandbox
                         .path()
-                        .join("node_modules")
+                        .join("node_modules/.bin")
+                        .join("..")
                         .join("baz")
                         .join("bin.js")
-                        .canonicalize()
-                        .unwrap()
                 );
             } else {
                 assert_eq!(
@@ -453,11 +452,10 @@ node "%~dp0\{path}" %*
                     path.unwrap(),
                     sandbox
                         .path()
-                        .join("node_modules")
+                        .join("node_modules/.bin")
+                        .join("..")
                         .join("baz")
                         .join("bin.js")
-                        .canonicalize()
-                        .unwrap()
                 );
             } else {
                 assert_eq!(

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -388,7 +388,7 @@ impl Command {
         }
 
         trace!(
-            target: "moon:utils",
+            target: "moon:utils:process",
             "Running command {} (in {}){}",
             color::shell(&command_line),
             if let Some(cwd) = working_dir {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,7 +9,7 @@
   - To start, `moon query touched-files` can be used to query touched files. The same files
     `moon ci` and `moon run` use.
   - Also `moon query projects` can be used to query about projects in the project graph.
-- Added `bash` as a support value for the project `language` setting.
+- Added `bash` as a supported value for the project `language` setting.
 
 #### 🐞 Fixes
 
@@ -21,6 +21,8 @@
 
 - Updated Rust to v1.62.
 - Refactored our action runner to support additional languages in the future.
+- Refactored Windows to execute package binaries with `node.exe` directly, instead of with 
+  `cmd.exe` + the `.bin/*.cmd` file.
 
 ## 0.5.0
 


### PR DESCRIPTION
Previously, moon would execute the `node_modules/.bin/*.cmd` files directly with cmd.exe when running a task. This worked and is how Node.js package managers also work. 

However, with this approach, we can't pass Node.js CLI arguments directly and must use `NODE_OPTIONS`. This worked until we needed to support [CPU/heap profiling](https://github.com/moonrepo/moon/pull/181), and as it turns out, not every argument can be passed to `NODE_OPTIONS`. Because of this restriction, that PR is currently blocked.

To work around this issue, I'm updating the Windows logic to execute the package binary directly with node.exe. This is rather complicated since it's impossible to infer the npm package name from the binary... but, the `*.cmd` file contains a relative path to the binary. So now I'm extracting this path using regex -- which seems rather flaky -- but I'm not aware of another path forward.