### PR TITLE
internal: Migrate to `AsRef`.

### DIFF
--- a/crates/action/src/run_target.rs
+++ b/crates/action/src/run_target.rs
@@ -269,7 +269,7 @@ fn print_target_label(target: &str, attempt: &Attempt, attempt_total: u8, checkp
     }
 
     if !comments.is_empty() {
-        let metadata = color::muted(&format!("({})", comments.join(", ")));
+        let metadata = color::muted(format!("({})", comments.join(", ")));
 
         label = format!("{} {}", label, metadata);
     };
@@ -316,9 +316,9 @@ fn print_target_command(
     };
 
     let suffix = format!("(in {})", working_dir);
-    let message = format!("{} {}", command_line, color::muted(&suffix));
+    let message = format!("{} {}", command_line, color::muted(suffix));
 
-    println!("{}", color::muted_light(&message));
+    println!("{}", color::muted_light(message));
 }
 
 fn print_cache_item(item: &RunTargetState) {

--- a/crates/action/src/sync_node_project.rs
+++ b/crates/action/src/sync_node_project.rs
@@ -33,7 +33,7 @@ async fn create_missing_tsconfig(
 
     let json = TsConfigJson {
         extends: Some(path::to_virtual_string(
-            &path::relative_from(&tsconfig_options_path, &project.root).unwrap(),
+            path::relative_from(&tsconfig_options_path, &project.root).unwrap(),
         )?),
         include: Some(string_vec!["**/*"]),
         references: Some(vec![]),
@@ -152,7 +152,7 @@ pub async fn sync_node_project(
                 if let Some(tsconfig_json) = &mut project_tsconfig_json {
                     let tsconfig_branch_name = &typescript_config.project_config_file_name;
                     let dep_ref_path = path::to_string(
-                        &path::relative_from(&dep_project.root, &project.root).unwrap_or_default(),
+                        path::relative_from(&dep_project.root, &project.root).unwrap_or_default(),
                     )?;
 
                     // Only add if the dependent project has a `tsconfig.json`,

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -19,17 +19,17 @@ pub async fn project(id: &str, json: bool) -> Result<(), Box<dyn std::error::Err
 
     term.write_line("")?;
     term.render_label(Label::Brand, &project.id)?;
-    term.render_entry("ID", &color::id(&project.id))?;
-    term.render_entry("Source", &color::file(&project.source))?;
+    term.render_entry("ID", color::id(&project.id))?;
+    term.render_entry("Source", color::file(&project.source))?;
 
     // Dont show in test snapshots
     if !is_test_env() {
-        term.render_entry("Root", &color::path(&project.root))?;
+        term.render_entry("Root", color::path(&project.root))?;
     }
 
     if let Some(config) = project.config {
-        term.render_entry("Language", &term.format(&config.language))?;
-        term.render_entry("Type", &term.format(&config.type_of))?;
+        term.render_entry("Language", term.format(&config.language))?;
+        term.render_entry("Type", term.format(&config.type_of))?;
 
         if let Some(meta) = config.project {
             term.render_entry("Name", &meta.name)?;
@@ -61,7 +61,7 @@ pub async fn project(id: &str, json: bool) -> Result<(), Box<dyn std::error::Err
         if !deps.is_empty() {
             term.write_line("")?;
             term.render_label(Label::Default, "Depends on")?;
-            term.render_list(&deps)?;
+            term.render_list(deps)?;
         }
     }
 
@@ -74,7 +74,7 @@ pub async fn project(id: &str, json: bool) -> Result<(), Box<dyn std::error::Err
 
             term.render_entry(
                 name,
-                &color::shell(&format!("{} {}", task.command, task.args.join(" "))),
+                color::shell(format!("{} {}", task.command, task.args.join(" "))),
             )?;
         }
     }
@@ -90,7 +90,7 @@ pub async fn project(id: &str, json: bool) -> Result<(), Box<dyn std::error::Err
                 files.push(color::file(file));
             }
 
-            term.render_entry_list(group, &files)?;
+            term.render_entry_list(group, files)?;
         }
     }
 

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -66,21 +66,21 @@ pub fn render_result_stats(
 
     if pass_count > 0 {
         if cached_count > 0 {
-            counts_message.push(color::success(&format!(
+            counts_message.push(color::success(format!(
                 "{} completed ({} cached)",
                 pass_count, cached_count
             )));
         } else {
-            counts_message.push(color::success(&format!("{} completed", pass_count)));
+            counts_message.push(color::success(format!("{} completed", pass_count)));
         }
     }
 
     if fail_count > 0 {
-        counts_message.push(color::failure(&format!("{} failed", fail_count)));
+        counts_message.push(color::failure(format!("{} failed", fail_count)));
     }
 
     if invalid_count > 0 {
-        counts_message.push(color::invalid(&format!("{} invalid", invalid_count)));
+        counts_message.push(color::invalid(format!("{} invalid", invalid_count)));
     }
 
     let term = Term::buffered_stdout();

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -109,7 +109,7 @@ mod configs {
             .arg("project:task")
             .assert();
 
-        assert_snapshot!(standardize_separators(&get_path_safe_output(
+        assert_snapshot!(standardize_separators(get_path_safe_output(
             &assert,
             &PathBuf::from("./fake/path")
         )));
@@ -122,7 +122,7 @@ mod configs {
             .arg("project:task")
             .assert();
 
-        assert_snapshot!(standardize_separators(&get_path_safe_output(
+        assert_snapshot!(standardize_separators(get_path_safe_output(
             &assert,
             &PathBuf::from("./fake/path")
         )));
@@ -135,7 +135,7 @@ mod configs {
             .arg("test:task")
             .assert();
 
-        assert_snapshot!(standardize_separators(&get_path_safe_output(
+        assert_snapshot!(standardize_separators(get_path_safe_output(
             &assert,
             &PathBuf::from("./fake/path")
         )));

--- a/crates/cli/tests/utils.rs
+++ b/crates/cli/tests/utils.rs
@@ -26,7 +26,7 @@ pub fn update_version_workspace_config(dir: &Path, old_version: &str, new_versio
 }
 
 pub fn get_path_safe_output(assert: &assert_cmd::assert::Assert, fixtures_dir: &Path) -> String {
-    let result = replace_home_dir(&replace_fixtures_dir(
+    let result = replace_home_dir(replace_fixtures_dir(
         &get_assert_output(assert),
         fixtures_dir,
     ));

--- a/crates/cli/tests/utils.rs
+++ b/crates/cli/tests/utils.rs
@@ -27,7 +27,7 @@ pub fn update_version_workspace_config(dir: &Path, old_version: &str, new_versio
 
 pub fn get_path_safe_output(assert: &assert_cmd::assert::Assert, fixtures_dir: &Path) -> String {
     let result = replace_home_dir(replace_fixtures_dir(
-        &get_assert_output(assert),
+        get_assert_output(assert),
         fixtures_dir,
     ));
 

--- a/crates/hasher/src/hasher.rs
+++ b/crates/hasher/src/hasher.rs
@@ -76,7 +76,7 @@ impl TargetHasher {
             // Standardize on `/` separators so that the hash is
             // the same between windows and nix machines.
             self.input_hashes
-                .insert(path::standardize_separators(&file), hash);
+                .insert(path::standardize_separators(file), hash);
         }
     }
 

--- a/crates/lang-node/src/package.rs
+++ b/crates/lang-node/src/package.rs
@@ -175,7 +175,9 @@ impl PackageJson {
     /// Add a package and version range to the `dependencies` field.
     /// If `is_missing` is true, only add if it doesn't already exist.
     /// Return true if the new value is different from the old value.
-    pub fn add_dependency(&mut self, name: &str, range: &str, if_missing: bool) -> bool {
+    pub fn add_dependency<T: AsRef<str>>(&mut self, name: T, range: T, if_missing: bool) -> bool {
+        let name = name.as_ref();
+        let range = range.as_ref();
         let mut dependencies = match &self.dependencies {
             Some(deps) => deps.clone(),
             None => BTreeMap::new(),
@@ -196,7 +198,10 @@ impl PackageJson {
 
     /// Add a version range to the `engines` field.
     /// Return true if the new value is different from the old value.
-    pub fn add_engine(&mut self, engine: &str, range: &str) -> bool {
+    pub fn add_engine<T: AsRef<str>>(&mut self, engine: T, range: T) -> bool {
+        let engine = engine.as_ref();
+        let range = range.as_ref();
+
         if let Some(engines) = &mut self.engines {
             if engines.contains_key(engine) && engines.get(engine).unwrap() == range {
                 return false;
@@ -214,7 +219,9 @@ impl PackageJson {
 
     /// Set the `packageManager` field.
     /// Return true if the new value is different from the old value.
-    pub fn set_package_manager(&mut self, value: &str) -> bool {
+    pub fn set_package_manager<T: AsRef<str>>(&mut self, value: T) -> bool {
+        let value = value.as_ref();
+
         if self.package_manager.is_some() && self.package_manager.as_ref().unwrap() == value {
             return false;
         }

--- a/crates/lang-node/src/tsconfig.rs
+++ b/crates/lang-node/src/tsconfig.rs
@@ -64,7 +64,8 @@ pub struct TsConfigJson {
 }
 
 impl TsConfigJson {
-    pub async fn load_with_extends(path: &Path) -> Result<TsConfigJson, MoonError> {
+    pub async fn load_with_extends<T: AsRef<Path>>(path: T) -> Result<TsConfigJson, MoonError> {
+        let path = path.as_ref();
         let values = load_to_value(path, true)?;
 
         let mut cfg: TsConfigJson =
@@ -77,7 +78,9 @@ impl TsConfigJson {
     /// Add a project reference to the `references` field with the defined
     /// path and tsconfig file name, and sort the list based on path.
     /// Return true if the new value is different from the old value.
-    pub fn add_project_ref(&mut self, base_path: &str, tsconfig_name: &str) -> bool {
+    pub fn add_project_ref<T: AsRef<str>>(&mut self, base_path: T, tsconfig_name: T) -> bool {
+        let base_path = base_path.as_ref();
+        let tsconfig_name = tsconfig_name.as_ref();
         let mut path = standardize_separators(base_path);
 
         // File name is optional when using standard naming
@@ -139,7 +142,8 @@ fn merge(a: &mut Value, b: Value) {
     }
 }
 
-pub fn load_to_value(path: &Path, extend: bool) -> Result<Value, MoonError> {
+pub fn load_to_value<T: AsRef<Path>>(path: T, extend: bool) -> Result<Value, MoonError> {
+    let path = path.as_ref();
     let json =
         std::fs::read_to_string(path).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
 

--- a/crates/lang/src/lib.rs
+++ b/crates/lang/src/lib.rs
@@ -39,7 +39,9 @@ pub struct VersionManager {
     pub version_filename: StaticString,
 }
 
-pub fn is_using_package_manager(base_dir: &Path, pm: &PackageManager) -> bool {
+pub fn is_using_package_manager<T: AsRef<Path>>(base_dir: T, pm: &PackageManager) -> bool {
+    let base_dir = base_dir.as_ref();
+
     for lockfile in pm.lock_filenames {
         if base_dir.join(lockfile).exists() {
             return true;
@@ -55,7 +57,9 @@ pub fn is_using_package_manager(base_dir: &Path, pm: &PackageManager) -> bool {
     false
 }
 
-pub fn is_using_version_manager(base_dir: &Path, vm: &VersionManager) -> bool {
+pub fn is_using_version_manager<T: AsRef<Path>>(base_dir: T, vm: &VersionManager) -> bool {
+    let base_dir = base_dir.as_ref();
+
     if base_dir.join(vm.version_filename).exists() {
         return true;
     }

--- a/crates/logger/src/color.rs
+++ b/crates/logger/src/color.rs
@@ -24,63 +24,64 @@ pub enum Color {
     GrayLight = 248,
 }
 
-pub fn paint(color: u8, value: &str) -> String {
-    style(value).color256(color).to_string()
+pub fn paint<T: AsRef<str>>(color: u8, value: T) -> String {
+    style(value.as_ref()).color256(color).to_string()
 }
 
-pub fn muted(value: &str) -> String {
+pub fn muted<T: AsRef<str>>(value: T) -> String {
     paint(Color::Gray as u8, value)
 }
 
-pub fn muted_light(value: &str) -> String {
+pub fn muted_light<T: AsRef<str>>(value: T) -> String {
     paint(Color::GrayLight as u8, value)
 }
 
-pub fn success(value: &str) -> String {
+pub fn success<T: AsRef<str>>(value: T) -> String {
     paint(Color::Green as u8, value)
 }
 
-pub fn failure(value: &str) -> String {
+pub fn failure<T: AsRef<str>>(value: T) -> String {
     paint(Color::Red as u8, value)
 }
 
-pub fn invalid(value: &str) -> String {
+pub fn invalid<T: AsRef<str>>(value: T) -> String {
     paint(Color::Yellow as u8, value)
 }
 
-pub fn file(path: &str) -> String {
+pub fn file<T: AsRef<str>>(path: T) -> String {
     paint(Color::Teal as u8, path)
 }
 
-pub fn path(path: &Path) -> String {
+pub fn path<T: AsRef<Path>>(path: T) -> String {
     paint(
         Color::Cyan as u8,
-        &clean_path(path.to_str().unwrap_or("<unknown>")),
+        clean_path(path.as_ref().to_str().unwrap_or("<unknown>")),
     )
 }
 
-pub fn url(url: &str) -> String {
+pub fn url<T: AsRef<str>>(url: T) -> String {
     paint(Color::Blue as u8, url)
 }
 
-pub fn shell(cmd: &str) -> String {
+pub fn shell<T: AsRef<str>>(cmd: T) -> String {
     paint(Color::Pink as u8, &clean_path(cmd))
 }
 
-pub fn symbol(value: &str) -> String {
+pub fn symbol<T: AsRef<str>>(value: T) -> String {
     paint(Color::Lime as u8, value)
 }
 
-pub fn id(value: &str) -> String {
+pub fn id<T: AsRef<str>>(value: T) -> String {
     paint(Color::Purple as u8, value)
 }
 
-pub fn target(value: &str) -> String {
+pub fn target<T: AsRef<str>>(value: T) -> String {
     paint(Color::Blue as u8, value)
 }
 
 // Based on https://github.com/debug-js/debug/blob/master/src/common.js#L41
-pub fn log_target(value: &str) -> String {
+pub fn log_target<T: AsRef<str>>(value: T) -> String {
+    let value = value.as_ref();
     let mut hash: u32 = 0;
 
     for b in value.bytes() {
@@ -150,7 +151,8 @@ pub const COLOR_LIST: [u8; 76] = [
 
 pub const COLOR_LIST_UNSUPPORTED: [u8; 6] = [6, 2, 3, 4, 5, 1];
 
-fn clean_path(path: &str) -> String {
+fn clean_path<T: AsRef<str>>(path: T) -> String {
+    let path = path.as_ref();
     let mut path_str = path.to_owned();
 
     if let Some(home_dir) = get_home_dir() {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -281,7 +281,7 @@ impl Project {
         workspace_root: &Path,
         global_config: &GlobalProjectConfig,
     ) -> Result<Project, ProjectError> {
-        let root = workspace_root.join(&path::normalize_separators(source));
+        let root = workspace_root.join(path::normalize_separators(source));
         let log_target = format!("moon:project:{}", id);
 
         debug!(

--- a/crates/project/src/token.rs
+++ b/crates/project/src/token.rs
@@ -245,14 +245,6 @@ impl<'a> TokenResolver<'a> {
         let token = matches.get(0).unwrap().as_str(); // $var
         let var = matches.get(1).unwrap().as_str(); // var
 
-        // trace!(
-        //     target: "moon:token",
-        //     "Resolving token variable {} for {} value {}",
-        //     color::id(token),
-        //     self.context.context_label(),
-        //     color::file(value)
-        // );
-
         let (project_id, task_id) = Target::parse(&task.target)?.ids()?;
         let workspace_root = self.data.workspace_root;
         let project_root = self.data.project_root;

--- a/crates/terminal/src/helpers.rs
+++ b/crates/terminal/src/helpers.rs
@@ -17,8 +17,8 @@ pub fn safe_exit(code: i32) -> ! {
     std::process::exit(code)
 }
 
-pub fn replace_style_tokens(value: &str) -> String {
-    String::from(STYLE_TOKEN.replace_all(value, |caps: &Captures| {
+pub fn replace_style_tokens<T: AsRef<str>>(value: T) -> String {
+    String::from(STYLE_TOKEN.replace_all(value.as_ref(), |caps: &Captures| {
         let token = caps.get(1).map_or("", |m| m.as_str());
         let inner = caps.get(2).map_or("", |m| m.as_str());
 

--- a/crates/terminal/src/output.rs
+++ b/crates/terminal/src/output.rs
@@ -23,7 +23,7 @@ pub fn label_moon() -> String {
     )
 }
 
-pub fn label_checkpoint(label: &str, checkpoint: Checkpoint) -> String {
+pub fn label_checkpoint<T: AsRef<str>>(label: T, checkpoint: Checkpoint) -> String {
     let colors = match checkpoint {
         Checkpoint::Fail => FAIL_COLORS,
         Checkpoint::Pass => PASS_COLORS,
@@ -36,6 +36,6 @@ pub fn label_checkpoint(label: &str, checkpoint: Checkpoint) -> String {
         color::paint(colors[1], STEP_CHAR),
         color::paint(colors[2], STEP_CHAR),
         color::paint(colors[3], STEP_CHAR),
-        style(label).bold()
+        style(label.as_ref()).bold()
     )
 }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -61,13 +61,13 @@ impl ExtendedTerm for Term {
     }
 
     fn render_entry(&self, key: &str, value: &str) -> TermWriteResult {
-        let label = color::muted_light(&format!("{}:", style(key).bold()));
+        let label = color::muted_light(format!("{}:", style(key).bold()));
 
         self.write_line(&format!("{} {}", label, value))
     }
 
     fn render_entry_list(&self, key: &str, values: &[String]) -> TermWriteResult {
-        let label = color::muted_light(&format!("{}:", style(key).bold()));
+        let label = color::muted_light(format!("{}:", style(key).bold()));
 
         self.write_line(&label)?;
         self.render_list(values)?;

--- a/crates/toolchain/src/pms/npm.rs
+++ b/crates/toolchain/src/pms/npm.rs
@@ -157,7 +157,7 @@ impl Installable<NodeTool> for NpmTool {
             debug!(
                 target: log_target,
                 "Enabling package manager with {}",
-                color::shell(&format!("corepack prepare {} --activate", package))
+                color::shell(format!("corepack prepare {} --activate", package))
             );
 
             node.exec_corepack(["prepare", &package, "--activate"])
@@ -166,7 +166,7 @@ impl Installable<NodeTool> for NpmTool {
             debug!(
                 target: log_target,
                 "Installing package manager with {}",
-                color::shell(&format!("npm install -g {}", package))
+                color::shell(format!("npm install -g {}", package))
             );
 
             self.install_global_dep("npm", &self.config.version).await?;

--- a/crates/toolchain/src/pms/pnpm.rs
+++ b/crates/toolchain/src/pms/pnpm.rs
@@ -97,7 +97,7 @@ impl Installable<NodeTool> for PnpmTool {
             debug!(
                 target: log_target,
                 "Enabling package manager with {}",
-                color::shell(&format!("corepack prepare {} --activate", package))
+                color::shell(format!("corepack prepare {} --activate", package))
             );
 
             node.exec_corepack(["prepare", &package, "--activate"])
@@ -106,7 +106,7 @@ impl Installable<NodeTool> for PnpmTool {
             debug!(
                 target: log_target,
                 "Installing package manager with {}",
-                color::shell(&format!("npm install -g {}", package))
+                color::shell(format!("npm install -g {}", package))
             );
 
             npm.install_global_dep("pnpm", &self.config.version).await?;

--- a/crates/toolchain/src/pms/yarn.rs
+++ b/crates/toolchain/src/pms/yarn.rs
@@ -56,7 +56,7 @@ impl Lifecycle<NodeTool> for YarnTool {
         debug!(
             target: self.get_log_target(),
             "Updating package manager version with {}",
-            color::shell(&format!("yarn set version {}", self.config.version))
+            color::shell(format!("yarn set version {}", self.config.version))
         );
 
         self.create_command()
@@ -128,7 +128,7 @@ impl Installable<NodeTool> for YarnTool {
             debug!(
                 target: log_target,
                 "Enabling package manager with {}",
-                color::shell(&format!("corepack prepare {} --activate", package))
+                color::shell(format!("corepack prepare {} --activate", package))
             );
 
             node.exec_corepack(["prepare", &package, "--activate"])
@@ -139,7 +139,7 @@ impl Installable<NodeTool> for YarnTool {
             debug!(
                 target: log_target,
                 "Installing package with {}",
-                color::shell(&format!("npm install -g {}", package))
+                color::shell(format!("npm install -g {}", package))
             );
 
             npm.install_global_dep("yarn", &self.config.version).await?;

--- a/crates/toolchain/src/tools/node.rs
+++ b/crates/toolchain/src/tools/node.rs
@@ -192,7 +192,7 @@ impl Downloadable<Toolchain> for NodeTool {
         let log_target = self.get_log_target();
 
         // Download the node.tar.gz archive
-        let download_url = node::get_nodejs_url(version, host, &node::get_download_file(version)?);
+        let download_url = node::get_nodejs_url(version, host, node::get_download_file(version)?);
         let download_path = self.get_download_path()?;
 
         download_file_from_url(&download_url, download_path).await?;

--- a/crates/utils/src/glob.rs
+++ b/crates/utils/src/glob.rs
@@ -40,7 +40,8 @@ pub fn create_glob(pattern: &str) -> Result<Glob, GlobError> {
 }
 
 // This is not very exhaustive and may be inaccurate.
-pub fn is_glob(value: &str) -> bool {
+pub fn is_glob<T: AsRef<str>>(value: T) -> bool {
+    let value = value.as_ref();
     let single_values = vec!['*', '?', '!'];
     let paired_values = vec![('{', '}'), ('[', ']')];
     let mut bytes = value.bytes();
@@ -83,13 +84,13 @@ pub fn is_glob(value: &str) -> bool {
     false
 }
 
-pub fn is_path_glob(path: &Path) -> bool {
-    is_glob(&path.to_string_lossy())
+pub fn is_path_glob<T: AsRef<Path>>(path: T) -> bool {
+    is_glob(path.as_ref().to_string_lossy())
 }
 
-pub fn normalize(path: &Path) -> Result<String, MoonError> {
+pub fn normalize<T: AsRef<Path>>(path: T) -> Result<String, MoonError> {
     // Always use forward slashes for globs
-    let glob = path::to_virtual_string(path)?;
+    let glob = path::to_virtual_string(path.as_ref())?;
 
     // Remove UNC and drive prefix as it breaks glob matching
     if cfg!(windows) {

--- a/crates/utils/src/glob.rs
+++ b/crates/utils/src/glob.rs
@@ -120,13 +120,13 @@ pub fn split_patterns(patterns: &[String]) -> Result<(Vec<Glob>, Vec<Glob>), Glo
 }
 
 #[track_caller]
-pub fn walk(base_dir: &Path, patterns: &[String]) -> Result<Vec<PathBuf>, GlobError> {
+pub fn walk<T: AsRef<Path>>(base_dir: T, patterns: &[String]) -> Result<Vec<PathBuf>, GlobError> {
     let (globs, negations) = split_patterns(patterns)?;
     let negation = Negation::try_from_patterns(negations).unwrap();
     let mut paths = vec![];
 
     for glob in globs {
-        for entry in glob.walk_with_behavior(base_dir, LinkBehavior::ReadFile) {
+        for entry in glob.walk_with_behavior(base_dir.as_ref(), LinkBehavior::ReadFile) {
             match entry {
                 Ok(e) => {
                     // Filter out negated results

--- a/crates/utils/src/path.rs
+++ b/crates/utils/src/path.rs
@@ -6,11 +6,19 @@ use std::path::{Path, PathBuf};
 pub use pathdiff::diff_paths as relative_from;
 
 /// If a file starts with "/", expand from the workspace root, otherwise the project root.
-pub fn expand_root_path(file: &str, workspace_root: &Path, project_root: &Path) -> PathBuf {
+pub fn expand_root_path<F, P>(file: F, workspace_root: P, project_root: P) -> PathBuf
+where
+    F: AsRef<str>,
+    P: AsRef<Path>,
+{
+    let file = file.as_ref();
+
     if file.starts_with('/') {
-        workspace_root.join(file.strip_prefix('/').unwrap())
+        workspace_root
+            .as_ref()
+            .join(file.strip_prefix('/').unwrap())
     } else {
-        project_root.join(file)
+        project_root.as_ref().join(file)
     }
 }
 

--- a/crates/utils/src/path.rs
+++ b/crates/utils/src/path.rs
@@ -14,21 +14,23 @@ pub fn expand_root_path(file: &str, workspace_root: &Path, project_root: &Path) 
     }
 }
 
-pub fn normalize(path: &Path) -> PathBuf {
-    path.to_path_buf().clean()
+pub fn normalize<T: AsRef<Path>>(path: T) -> PathBuf {
+    path.as_ref().to_path_buf().clean()
 }
 
 #[cfg(not(windows))]
-pub fn normalize_separators(path: &str) -> String {
-    path.replace('\\', "/")
+pub fn normalize_separators<T: AsRef<str>>(path: T) -> String {
+    path.as_ref().replace('\\', "/")
 }
 
 #[cfg(windows)]
-pub fn normalize_separators(path: &str) -> String {
-    path.replace('/', "\\")
+pub fn normalize_separators<T: AsRef<str>>(path: T) -> String {
+    path.as_ref().replace('/', "\\")
 }
 
-pub fn replace_home_dir(value: &str) -> String {
+pub fn replace_home_dir<T: AsRef<str>>(value: T) -> String {
+    let value = value.as_ref();
+
     if let Some(home_dir) = get_home_dir() {
         let home_dir_str = home_dir.to_str().unwrap_or_default();
 
@@ -41,17 +43,17 @@ pub fn replace_home_dir(value: &str) -> String {
     value.to_owned()
 }
 
-pub fn standardize_separators(path: &str) -> String {
-    path.replace('\\', "/")
+pub fn standardize_separators<T: AsRef<str>>(path: T) -> String {
+    path.as_ref().replace('\\', "/")
 }
 
-pub fn to_string(path: &Path) -> Result<String, MoonError> {
-    match path.to_str() {
+pub fn to_string<T: AsRef<Path>>(path: T) -> Result<String, MoonError> {
+    match path.as_ref().to_str() {
         Some(p) => Ok(p.to_owned()),
-        None => Err(MoonError::PathInvalidUTF8(path.to_path_buf())),
+        None => Err(MoonError::PathInvalidUTF8(path.as_ref().to_path_buf())),
     }
 }
 
-pub fn to_virtual_string(path: &Path) -> Result<String, MoonError> {
-    Ok(standardize_separators(&to_string(path)?))
+pub fn to_virtual_string<T: AsRef<Path>>(path: T) -> Result<String, MoonError> {
+    Ok(standardize_separators(to_string(path)?))
 }

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -229,7 +229,7 @@ impl Command {
         let captured_stdout_clone = Arc::clone(&captured_stdout);
 
         let prefix: Arc<str> = prefix
-            .map(|p| color::muted(&format!("[{}]", p)))
+            .map(|p| color::muted(format!("[{}]", p)))
             .unwrap_or_default()
             .into();
         let stderr_prefix = Arc::clone(&prefix);

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -313,7 +313,7 @@ impl Command {
             format!("{} {}", self.bin, join_args(args))
         };
 
-        (path::replace_home_dir(&line), cmd.get_current_dir())
+        (path::replace_home_dir(line), cmd.get_current_dir())
     }
 
     pub fn inherit_colors(&mut self) -> &mut Command {

--- a/crates/utils/src/test.rs
+++ b/crates/utils/src/test.rs
@@ -95,7 +95,7 @@ pub fn replace_fixtures_dir(value: &str, dir: &Path) -> String {
 }
 
 // We need to do this so slashes are accurate and always forward
-pub fn wrap_glob(path: &Path) -> PathBuf {
+pub fn wrap_glob<T: AsRef<Path>>(path: T) -> PathBuf {
     PathBuf::from(glob::normalize(path).unwrap())
 }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -87,13 +87,6 @@ fn load_workspace_config(root_dir: &Path) -> Result<WorkspaceConfig, WorkspaceEr
 async fn load_package_json(root_dir: &Path) -> Result<PackageJson, WorkspaceError> {
     let package_json_path = root_dir.join("package.json");
 
-    trace!(
-        target: LOG_TARGET,
-        "Loading {} from {}",
-        color::file("package.json"),
-        color::path(root_dir),
-    );
-
     if !package_json_path.exists() {
         return Err(WorkspaceError::MissingPackageJson);
     }
@@ -107,13 +100,6 @@ async fn load_tsconfig_json(
     tsconfig_name: &str,
 ) -> Result<Option<TsConfigJson>, WorkspaceError> {
     let tsconfig_json_path = root_dir.join(tsconfig_name);
-
-    trace!(
-        target: LOG_TARGET,
-        "Attempting to find {} in {}",
-        color::file(tsconfig_name),
-        color::path(root_dir),
-    );
 
     if !tsconfig_json_path.exists() {
         return Ok(None);


### PR DESCRIPTION
All of our shared code/utils should be using `AsRef`, so this starts that initial process.