### PR TITLE
new: Support `dev` as a non-CI task ID.

### DIFF
--- a/crates/project/src/task.rs
+++ b/crates/project/src/task.rs
@@ -109,7 +109,7 @@ impl Task {
         let cloned_config = config.clone();
         let cloned_options = cloned_config.options;
         let command = cloned_config.command.unwrap_or_default();
-        let is_long_running = command == "serve" || command == "start";
+        let is_long_running = command == "dev" || command == "serve" || command == "start";
         let log_target = format!("moon:project:{}", target);
 
         let task = Task {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added a `moon dep-graph` command for displaying the entire dependency graph in DOT format.
 - Added `--language` and `--type` filter options to `moon query projects`.
 - Added `$language`, `$projectType`, and `$taskType` token variables.
+- Added `dev` as a non-CI task identifier (alongside `start` and `serve`).
 
 ## 0.6.0
 

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -367,7 +367,7 @@ tasks:
 
 Whether to run the task automatically in a CI (continuous integration) environment when affected by
 touched files, typically through the `moon ci` command. Defaults to `true` unless the task name is
-"start" or "serve", and is _always_ true when a task defines [`outputs`](#outputs).
+"dev", "start", or "serve", and is _always_ true when a task defines [`outputs`](#outputs).
 
 ```yaml title="project.yml" {5}
 tasks:

--- a/website/docs/guides/ci.mdx
+++ b/website/docs/guides/ci.mdx
@@ -41,8 +41,8 @@ tasks:
 :::caution
 
 This option _must_ be set to false for tasks that spawn a long-running or never-ending process, like
-HTTP or development servers. To help mitigate this, tasks named `start` or `serve` are false by
-default.
+HTTP or development servers. To help mitigate this, tasks named `dev`, `start`, or `serve` are false
+by default.
 
 :::
 


### PR DESCRIPTION
This is a rather popular name for this.