### PR TITLE
new: Support implicit inputs for all tasks.

### DIFF
--- a/crates/action-runner/src/dep_graph.rs
+++ b/crates/action-runner/src/dep_graph.rs
@@ -2,7 +2,7 @@ use crate::errors::DepGraphError;
 use crate::node::Node;
 use moon_config::ProjectLanguage;
 use moon_lang::SupportedLanguage;
-use moon_logger::{color, debug, map_list, trace, warn};
+use moon_logger::{color, debug, map_list, trace};
 use moon_project::{Project, ProjectGraph, Target, TargetError, TargetProject, TouchedFilePaths};
 use petgraph::algo::toposort;
 use petgraph::dot::{Config, Dot};
@@ -342,17 +342,7 @@ impl DepGraph {
 
         // Compare against touched files if provided
         if let Some(touched) = touched_files {
-            let globally_affected = projects.is_globally_affected(touched);
-
-            if globally_affected {
-                warn!(
-                    target: TARGET,
-                    "Moon files touched, marking all targets as affected",
-                );
-            }
-
-            // Validate task exists for project
-            if !globally_affected && !project.get_task(task_id)?.is_affected(touched)? {
+            if !project.get_task(task_id)?.is_affected(touched)? {
                 trace!(
                     target: TARGET,
                     "Project {} task {} not affected based on touched files, skipping",

--- a/crates/action-runner/tests/dep_graph_test.rs
+++ b/crates/action-runner/tests/dep_graph_test.rs
@@ -1,18 +1,15 @@
 use insta::assert_snapshot;
 use moon_action_runner::{BatchedTopoSort, DepGraph, NodeIndex};
 use moon_cache::CacheEngine;
-use moon_config::GlobalProjectConfig;
+use moon_config::{GlobalProjectConfig, WorkspaceConfig};
 use moon_project::{ProjectGraph, Target};
 use moon_utils::test::get_fixtures_dir;
 use std::collections::{HashMap, HashSet};
 
 async fn create_project_graph() -> ProjectGraph {
     let workspace_root = get_fixtures_dir("projects");
-
-    ProjectGraph::create(
-        &workspace_root,
-        GlobalProjectConfig::default(),
-        &HashMap::from([
+    let workspace_config = WorkspaceConfig {
+        projects: HashMap::from([
             ("advanced".to_owned(), "advanced".to_owned()),
             ("basic".to_owned(), "basic".to_owned()),
             ("emptyConfig".to_owned(), "empty-config".to_owned()),
@@ -22,6 +19,13 @@ async fn create_project_graph() -> ProjectGraph {
             ("baz".to_owned(), "deps/baz".to_owned()),
             ("tasks".to_owned(), "tasks".to_owned()),
         ]),
+        ..WorkspaceConfig::default()
+    };
+
+    ProjectGraph::create(
+        &workspace_root,
+        &workspace_config,
+        GlobalProjectConfig::default(),
         &CacheEngine::create(&workspace_root).await.unwrap(),
     )
     .await
@@ -30,15 +34,8 @@ async fn create_project_graph() -> ProjectGraph {
 
 async fn create_tasks_project_graph() -> ProjectGraph {
     let workspace_root = get_fixtures_dir("tasks");
-    let global_config = GlobalProjectConfig {
-        file_groups: HashMap::from([("sources".to_owned(), vec!["src/**/*".to_owned()])]),
-        ..GlobalProjectConfig::default()
-    };
-
-    ProjectGraph::create(
-        &workspace_root,
-        global_config,
-        &HashMap::from([
+    let workspace_config = WorkspaceConfig {
+        projects: HashMap::from([
             ("basic".to_owned(), "basic".to_owned()),
             ("build-a".to_owned(), "build-a".to_owned()),
             ("build-b".to_owned(), "build-b".to_owned()),
@@ -53,6 +50,17 @@ async fn create_tasks_project_graph() -> ProjectGraph {
             ("mergeReplace".to_owned(), "merge-replace".to_owned()),
             ("no-tasks".to_owned(), "no-tasks".to_owned()),
         ]),
+        ..WorkspaceConfig::default()
+    };
+    let global_config = GlobalProjectConfig {
+        file_groups: HashMap::from([("sources".to_owned(), vec!["src/**/*".to_owned()])]),
+        ..GlobalProjectConfig::default()
+    };
+
+    ProjectGraph::create(
+        &workspace_root,
+        &workspace_config,
+        global_config,
         &CacheEngine::create(&workspace_root).await.unwrap(),
     )
     .await

--- a/crates/action/src/sync_node_project.rs
+++ b/crates/action/src/sync_node_project.rs
@@ -223,6 +223,7 @@ mod tests {
             "deps-a",
             fixture.path(),
             &GlobalProjectConfig::default(),
+            &[],
         )
         .unwrap();
 
@@ -254,6 +255,7 @@ mod tests {
             "deps-a",
             fixture.path(),
             &GlobalProjectConfig::default(),
+            &[],
         )
         .unwrap();
 
@@ -290,6 +292,7 @@ mod tests {
             "deps-b",
             fixture.path(),
             &GlobalProjectConfig::default(),
+            &[],
         )
         .unwrap();
 

--- a/crates/cli/src/commands/ci.rs
+++ b/crates/cli/src/commands/ci.rs
@@ -63,14 +63,6 @@ fn gather_runnable_targets(
     print_header("Gathering runnable targets");
 
     let mut targets = vec![];
-    let globally_affected = workspace.projects.is_globally_affected(touched_files);
-
-    if globally_affected {
-        debug!(
-            target: TARGET,
-            "Moon files touched, marking all targets as affected",
-        );
-    }
 
     // Required for dependents
     workspace.projects.load_all()?;
@@ -82,7 +74,7 @@ fn gather_runnable_targets(
             let target = Target::new(&project_id, task_id)?;
 
             if task.should_run_in_ci() {
-                if globally_affected || task.is_affected(touched_files)? {
+                if task.is_affected(touched_files)? {
                     targets.push(target);
                 }
             } else {

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -248,7 +248,7 @@ mod caching {
         assert_eq!(state.item.target, "node:standard");
         assert_eq!(
             state.item.hash,
-            "0b8322277df4ebf0292b5dab81447f012ed7bf6a072364bd3399119b60a1a3a3"
+            "eaa3c43c707b54fbff25b11ebc7528716c8a893d559f7898b1aac3f46767c361"
         );
     }
 }

--- a/crates/cli/tests/snapshots/run_test__caching__creates_run_state_cache.snap
+++ b/crates/cli/tests/snapshots/run_test__caching__creates_run_state_cache.snap
@@ -11,6 +11,7 @@ expression: "read_to_string(fixture.path().join(format!(\".moon/cache/hashes/{}.
   "deps": [],
   "envVars": {},
   "inputHashes": {
+    ".moon/workspace.yml": "7ca1e0fd35ca95465b01f5551df5e5beab704116",
     "node/cjsFile.cjs": "91382f667258361b9397214d0aec54d8d576ae19",
     "node/cwd.js": "47d4aa44cd6363251821ab9c59f4c68df455445c",
     "node/envVars.js": "44b0fda6bce364122223fbfc67b65ecbc52aec91",

--- a/crates/config/src/workspace/mod.rs
+++ b/crates/config/src/workspace/mod.rs
@@ -13,6 +13,7 @@ use figment::{
     providers::{Format, Serialized, Yaml},
     Error as FigmentError, Figment,
 };
+use moon_utils::string_vec;
 pub use node::{NodeConfig, NpmConfig, PackageManager, PnpmConfig, YarnConfig};
 use schemars::gen::SchemaGenerator;
 use schemars::schema::Schema;
@@ -53,6 +54,8 @@ fn validate_projects(projects: &ProjectsMap) -> Result<(), ValidationError> {
 #[schemars(default)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionRunnerConfig {
+    pub implicit_inputs: Vec<String>,
+
     pub inherit_colors_for_piped_tasks: bool,
 
     pub log_running_command: bool,
@@ -61,6 +64,13 @@ pub struct ActionRunnerConfig {
 impl Default for ActionRunnerConfig {
     fn default() -> Self {
         ActionRunnerConfig {
+            implicit_inputs: string_vec![
+                // When a project changes
+                "package.json",
+                // When root config changes
+                "/.moon/project.yml",
+                "/.moon/workspace.yml",
+            ],
             inherit_colors_for_piped_tasks: true,
             log_running_command: false,
         }

--- a/crates/project/src/project_graph.rs
+++ b/crates/project/src/project_graph.rs
@@ -279,7 +279,13 @@ impl ProjectGraph {
             None => return Err(ProjectError::UnconfiguredID(String::from(id))),
         };
 
-        let project = Project::new(id, source, &self.workspace_root, &self.global_config)?;
+        let project = Project::new(
+            id,
+            source,
+            &self.workspace_root,
+            &self.global_config,
+            &self.implicit_inputs,
+        )?;
         let depends_on = project.get_dependencies();
 
         // Insert the project into the graph

--- a/crates/project/src/project_graph.rs
+++ b/crates/project/src/project_graph.rs
@@ -2,11 +2,9 @@ use crate::constants::ROOT_NODE_ID;
 use crate::errors::ProjectError;
 use crate::helpers::detect_projects_with_globs;
 use crate::project::Project;
-use crate::types::{ProjectsSourceMap, TouchedFilePaths};
+use crate::types::ProjectsSourceMap;
 use moon_cache::CacheEngine;
-use moon_config::constants::{
-    CONFIG_DIRNAME, CONFIG_PROJECT_FILENAME, CONFIG_WORKSPACE_FILENAME, FLAG_PROJECTS_USING_GLOB,
-};
+use moon_config::constants::FLAG_PROJECTS_USING_GLOB;
 use moon_config::{GlobalProjectConfig, ProjectID};
 use moon_logger::{color, debug, map_list, trace};
 use petgraph::dot::{Config, Dot};
@@ -202,21 +200,6 @@ impl ProjectGraph {
             .collect();
 
         Ok(deps)
-    }
-
-    /// Return true if global config files have been touched.
-    pub fn is_globally_affected(&self, touched_files: &TouchedFilePaths) -> bool {
-        let cfg_dir = self.workspace_root.join(CONFIG_DIRNAME);
-
-        if touched_files.contains(&cfg_dir.join(CONFIG_WORKSPACE_FILENAME)) {
-            return true;
-        }
-
-        if touched_files.contains(&cfg_dir.join(CONFIG_PROJECT_FILENAME)) {
-            return true;
-        }
-
-        false
     }
 
     /// Format as a DOT string.

--- a/crates/project/src/task.rs
+++ b/crates/project/src/task.rs
@@ -165,7 +165,7 @@ impl Task {
         // strings with tokens, and file paths when tokens are resolved.
         for arg in &self.args {
             if token_resolver.has_token_func(arg) {
-                for resolved_arg in token_resolver.resolve_func(arg, Some(self))? {
+                for resolved_arg in token_resolver.resolve_func(arg, self)? {
                     // When running within a project:
                     //  - Project paths are relative and start with "./"
                     //  - Workspace paths are relative up to the root
@@ -257,7 +257,7 @@ impl Task {
             return Ok(());
         }
 
-        for input in &token_resolver.resolve(&self.inputs, None)? {
+        for input in &token_resolver.resolve(&self.inputs, self)? {
             // We cant canonicalize here as these inputs may not exist!
             if glob::is_path_glob(input) {
                 self.input_globs.push(glob::normalize(input)?);
@@ -275,7 +275,7 @@ impl Task {
             return Ok(());
         }
 
-        for output in &token_resolver.resolve(&self.outputs, None)? {
+        for output in &token_resolver.resolve(&self.outputs, self)? {
             if glob::is_path_glob(output) {
                 return Err(ProjectError::NoOutputGlob(
                     output.to_owned(),

--- a/crates/project/src/task.rs
+++ b/crates/project/src/task.rs
@@ -292,42 +292,28 @@ impl Task {
     /// Return true if this task is affected, based on touched files.
     /// Will attempt to find any file that matches our list of inputs.
     pub fn is_affected(&self, touched_files: &TouchedFilePaths) -> Result<bool, ProjectError> {
-        trace!(
-            target: self.get_log_target(),
-            "Checking if affected using input files: {}",
-            map_list(&Vec::from_iter(self.input_paths.iter()), |p| color::path(p))
-        );
-
         let has_globs = !self.input_globs.is_empty();
         let globset = self.create_globset()?;
 
-        if has_globs {
-            trace!(
-                target: self.get_log_target(),
-                "Checking if affected using input globs: {}",
-                map_list(&self.input_globs, |f| color::file(f))
-            );
-        }
-
         for file in touched_files {
-            let mut affected = self.input_paths.contains(file);
+            if self.input_paths.contains(file) {
+                trace!(
+                    target: self.get_log_target(),
+                    "Affected by {} (using input files)",
+                    color::path(file),
+                );
 
-            if !affected && has_globs {
-                affected = globset.matches(file)?;
+                return Ok(true);
             }
 
-            trace!(
-                target: self.get_log_target(),
-                "Is affected by {} = {}",
-                color::path(file),
-                if affected {
-                    color::success("true")
-                } else {
-                    color::failure("false")
-                },
-            );
+            if has_globs && globset.matches(file)? {
+                trace!(
+                    target: self.get_log_target(),
+                    "Affected by {} (using input globs: {})",
+                    color::path(file),
+                    map_list(&self.input_globs, |f| color::file(f))
+                );
 
-            if affected {
                 return Ok(true);
             }
         }

--- a/crates/project/src/task.rs
+++ b/crates/project/src/task.rs
@@ -192,7 +192,7 @@ impl Task {
                     }
                 }
             } else if token_resolver.has_token_var(arg) {
-                args.push(token_resolver.resolve_var(arg, self)?);
+                args.push(token_resolver.resolve_vars(arg, self)?);
             } else {
                 args.push(arg.clone());
             }

--- a/crates/project/src/test.rs
+++ b/crates/project/src/test.rs
@@ -73,15 +73,19 @@ pub fn create_file_groups() -> HashMap<String, FileGroup> {
     map
 }
 
+pub fn create_initial_task(config: Option<TaskConfig>) -> Task {
+    Task::from_config(
+        Target::format("project", "task").unwrap(),
+        &config.unwrap_or_default(),
+    )
+}
+
 pub fn create_expanded_task(
     workspace_root: &Path,
     project_root: &Path,
     config: Option<TaskConfig>,
 ) -> Result<Task, ProjectError> {
-    let mut task = Task::from_config(
-        Target::format("project", "task").unwrap(),
-        &config.unwrap_or_default(),
-    );
+    let mut task = create_initial_task(config);
     let file_groups = create_file_groups();
     let project_config = ProjectConfig::new(project_root);
     let metadata =

--- a/crates/project/tests/project_graph_test.rs
+++ b/crates/project/tests/project_graph_test.rs
@@ -1,6 +1,6 @@
 use insta::assert_snapshot;
 use moon_cache::CacheEngine;
-use moon_config::GlobalProjectConfig;
+use moon_config::{GlobalProjectConfig, WorkspaceConfig};
 use moon_project::ProjectGraph;
 use moon_utils::string_vec;
 use moon_utils::test::get_fixtures_dir;
@@ -8,16 +8,20 @@ use std::collections::HashMap;
 
 async fn get_dependencies_graph() -> ProjectGraph {
     let workspace_root = get_fixtures_dir("project-graph/dependencies");
-
-    ProjectGraph::create(
-        &workspace_root,
-        GlobalProjectConfig::default(),
-        &HashMap::from([
+    let workspace_config = WorkspaceConfig {
+        projects: HashMap::from([
             ("a".to_owned(), "a".to_owned()),
             ("b".to_owned(), "b".to_owned()),
             ("c".to_owned(), "c".to_owned()),
             ("d".to_owned(), "d".to_owned()),
         ]),
+        ..WorkspaceConfig::default()
+    };
+
+    ProjectGraph::create(
+        &workspace_root,
+        &workspace_config,
+        GlobalProjectConfig::default(),
         &CacheEngine::create(&workspace_root).await.unwrap(),
     )
     .await
@@ -26,16 +30,20 @@ async fn get_dependencies_graph() -> ProjectGraph {
 
 async fn get_dependents_graph() -> ProjectGraph {
     let workspace_root = get_fixtures_dir("project-graph/dependents");
-
-    ProjectGraph::create(
-        &workspace_root,
-        GlobalProjectConfig::default(),
-        &HashMap::from([
+    let workspace_config = WorkspaceConfig {
+        projects: HashMap::from([
             ("a".to_owned(), "a".to_owned()),
             ("b".to_owned(), "b".to_owned()),
             ("c".to_owned(), "c".to_owned()),
             ("d".to_owned(), "d".to_owned()),
         ]),
+        ..WorkspaceConfig::default()
+    };
+
+    ProjectGraph::create(
+        &workspace_root,
+        &workspace_config,
+        GlobalProjectConfig::default(),
         &CacheEngine::create(&workspace_root).await.unwrap(),
     )
     .await

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -436,7 +436,7 @@ mod tasks {
         lint.inputs.extend(implicit_inputs);
 
         assert_eq!(project.get_task("build").unwrap().inputs, build.inputs);
-        assert_eq!(project.get_task("std").unwrap().inputs, std.inputs);
+        assert_eq!(project.get_task("standard").unwrap().inputs, std.inputs);
         assert_eq!(project.get_task("test").unwrap().inputs, test.inputs);
         assert_eq!(project.get_task("lint").unwrap().inputs, lint.inputs);
     }

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -32,6 +32,7 @@ fn doesnt_exist() {
         "projects/missing",
         &get_fixtures_root(),
         &mock_global_project_config(),
+        &[],
     )
     .unwrap();
 }
@@ -44,6 +45,7 @@ fn no_config() {
         "projects/no-config",
         &workspace_root,
         &mock_global_project_config(),
+        &[],
     )
     .unwrap();
 
@@ -68,6 +70,7 @@ fn empty_config() {
         "projects/empty-config",
         &workspace_root,
         &mock_global_project_config(),
+        &[],
     )
     .unwrap();
 
@@ -93,6 +96,7 @@ fn basic_config() {
         "projects/basic",
         &workspace_root,
         &mock_global_project_config(),
+        &[],
     )
     .unwrap();
     let project_root = workspace_root.join("projects/basic");
@@ -131,6 +135,7 @@ fn advanced_config() {
         "projects/advanced",
         &workspace_root,
         &mock_global_project_config(),
+        &[],
     )
     .unwrap();
 
@@ -170,6 +175,7 @@ fn overrides_global_file_groups() {
             file_groups: HashMap::from([(String::from("tests"), string_vec!["tests/**/*"])]),
             ..GlobalProjectConfig::default()
         },
+        &[],
     )
     .unwrap();
 
@@ -284,6 +290,7 @@ mod tasks {
                 tasks: HashMap::from([(String::from("standard"), mock_task_config("cmd"))]),
                 ..GlobalProjectConfig::default()
             },
+            &[],
         )
         .unwrap();
 
@@ -327,6 +334,7 @@ mod tasks {
                 tasks: HashMap::from([(String::from("standard"), mock_task_config("cmd"))]),
                 ..GlobalProjectConfig::default()
             },
+            &[],
         )
         .unwrap();
 
@@ -386,6 +394,54 @@ mod tasks {
     }
 
     #[test]
+    fn inherits_implicit_inputs() {
+        let workspace_root = get_fixtures_root();
+        let implicit_inputs = string_vec!["package.json", "/.moon/workspace.yml"];
+        let project = Project::new(
+            "id",
+            "tasks/basic",
+            &workspace_root,
+            &GlobalProjectConfig {
+                tasks: HashMap::from([(String::from("standard"), mock_task_config("cmd"))]),
+                ..GlobalProjectConfig::default()
+            },
+            &implicit_inputs,
+        )
+        .unwrap();
+
+        let mut build = Task::from_config(
+            Target::format("id", "build").unwrap(),
+            &mock_task_config("webpack"),
+        );
+
+        let mut std = Task::from_config(
+            Target::format("id", "standard").unwrap(),
+            &mock_task_config("cmd"),
+        );
+
+        let mut test = Task::from_config(
+            Target::format("id", "test").unwrap(),
+            &mock_task_config("jest"),
+        );
+
+        let mut lint = Task::from_config(
+            Target::format("id", "lint").unwrap(),
+            &mock_task_config("eslint"),
+        );
+
+        // Expanded
+        build.inputs.extend(implicit_inputs.clone());
+        std.inputs.extend(implicit_inputs.clone());
+        test.inputs.extend(implicit_inputs.clone());
+        lint.inputs.extend(implicit_inputs);
+
+        assert_eq!(project.get_task("build").unwrap().inputs, build.inputs);
+        assert_eq!(project.get_task("std").unwrap().inputs, std.inputs);
+        assert_eq!(project.get_task("test").unwrap().inputs, test.inputs);
+        assert_eq!(project.get_task("lint").unwrap().inputs, lint.inputs);
+    }
+
+    #[test]
     fn strategy_replace() {
         let workspace_root = get_fixtures_root();
         let project_source = "tasks/merge-replace";
@@ -409,6 +465,7 @@ mod tasks {
                 )]),
                 ..GlobalProjectConfig::default()
             },
+            &[],
         )
         .unwrap();
 
@@ -483,6 +540,7 @@ mod tasks {
                 )]),
                 ..GlobalProjectConfig::default()
             },
+            &[],
         )
         .unwrap();
 
@@ -560,6 +618,7 @@ mod tasks {
                 )]),
                 ..GlobalProjectConfig::default()
             },
+            &[],
         )
         .unwrap();
 
@@ -637,6 +696,7 @@ mod tasks {
                 )]),
                 ..GlobalProjectConfig::default()
             },
+            &[],
         )
         .unwrap();
 
@@ -716,6 +776,7 @@ mod tasks {
                 "self",
                 &get_fixtures_dir("task-deps"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 
@@ -732,6 +793,7 @@ mod tasks {
                 "self-dupes",
                 &get_fixtures_dir("task-deps"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 
@@ -748,6 +810,7 @@ mod tasks {
                 "deps",
                 &get_fixtures_dir("task-deps"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 
@@ -764,6 +827,7 @@ mod tasks {
                 "deps-dupes",
                 &get_fixtures_dir("task-deps"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 
@@ -781,6 +845,7 @@ mod tasks {
                 "all",
                 &get_fixtures_dir("task-deps"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
         }
@@ -819,6 +884,7 @@ mod tasks {
                     )]),
                     ..GlobalProjectConfig::default()
                 },
+                &[],
             )
             .unwrap();
 
@@ -891,6 +957,7 @@ mod tasks {
                     )]),
                     ..GlobalProjectConfig::default()
                 },
+                &[],
             )
             .unwrap();
 
@@ -946,6 +1013,7 @@ mod tasks {
                     )]),
                     ..GlobalProjectConfig::default()
                 },
+                &[],
             )
             .unwrap();
 
@@ -1000,6 +1068,7 @@ mod tasks {
                     )]),
                     ..GlobalProjectConfig::default()
                 },
+                &[],
             )
             .unwrap();
 
@@ -1024,6 +1093,55 @@ mod tasks {
                     project_root.join("dir/other.tsx"),
                     project_root.join("dir/subdir/another.ts"),
                     workspace_root.join("package.json"),
+                ]
+                .iter()
+                .map(PathBuf::from),
+            );
+
+            assert_eq!(a, b);
+        }
+
+        #[test]
+        fn expands_implicit_inputs() {
+            let workspace_root = get_fixtures_dir("base");
+            let project_root = workspace_root.join("files-and-dirs");
+            let project = Project::new(
+                "id",
+                "files-and-dirs",
+                &workspace_root,
+                &GlobalProjectConfig {
+                    file_groups: create_file_groups_config(),
+                    tasks: HashMap::from([(
+                        String::from("test"),
+                        TaskConfig {
+                            command: Some(String::from("test")),
+                            inputs: Some(string_vec!["local.ts",]),
+                            type_of: TaskType::Node,
+                            ..TaskConfig::default()
+                        },
+                    )]),
+                    ..GlobalProjectConfig::default()
+                },
+                &[
+                    "/.moon/$taskType-$projectType.yml".to_owned(),
+                    "*.yml".to_owned(),
+                ],
+            )
+            .unwrap();
+
+            let task = project.tasks.get("test").unwrap();
+
+            assert_eq!(
+                task.input_globs,
+                vec![wrap_glob(&project_root.join("*.yml")).to_string_lossy(),]
+            );
+
+            let a: HashSet<PathBuf> =
+                HashSet::from_iter(task.input_paths.iter().map(PathBuf::from));
+            let b: HashSet<PathBuf> = HashSet::from_iter(
+                vec![
+                    project_root.join("local.ts"),
+                    workspace_root.join(".moon/node-unknown.yml"),
                 ]
                 .iter()
                 .map(PathBuf::from),
@@ -1084,6 +1202,7 @@ mod workspace {
                 "include",
                 &get_fixtures_dir("task-inheritance"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 
@@ -1097,6 +1216,7 @@ mod workspace {
                 "include-none",
                 &get_fixtures_dir("task-inheritance"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 
@@ -1110,6 +1230,7 @@ mod workspace {
                 "exclude",
                 &get_fixtures_dir("task-inheritance"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 
@@ -1123,6 +1244,7 @@ mod workspace {
                 "exclude-all",
                 &get_fixtures_dir("task-inheritance"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 
@@ -1136,6 +1258,7 @@ mod workspace {
                 "exclude-none",
                 &get_fixtures_dir("task-inheritance"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 
@@ -1149,6 +1272,7 @@ mod workspace {
                 "rename",
                 &get_fixtures_dir("task-inheritance"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 
@@ -1166,6 +1290,7 @@ mod workspace {
                 "rename-merge",
                 &workspace_root,
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 
@@ -1189,6 +1314,7 @@ mod workspace {
                 "include-exclude",
                 &get_fixtures_dir("task-inheritance"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 
@@ -1202,6 +1328,7 @@ mod workspace {
                 "include-exclude-rename",
                 &get_fixtures_dir("task-inheritance"),
                 &mock_global_project_config(),
+                &[],
             )
             .unwrap();
 

--- a/crates/toolchain/src/toolchain.rs
+++ b/crates/toolchain/src/toolchain.rs
@@ -51,7 +51,7 @@ impl Toolchain {
     pub async fn create_from_dir(
         base_dir: &Path,
         root_dir: &Path,
-        config: &WorkspaceConfig,
+        workspace_config: &WorkspaceConfig,
     ) -> Result<Toolchain, ToolchainError> {
         let dir = base_dir.join(CONFIG_DIRNAME);
         let temp_dir = dir.join("temp");
@@ -75,19 +75,19 @@ impl Toolchain {
             node: None,
         };
 
-        toolchain.node = Some(NodeTool::new(&toolchain, &config.node)?);
+        toolchain.node = Some(NodeTool::new(&toolchain, &workspace_config.node)?);
 
         Ok(toolchain)
     }
 
     pub async fn create(
         root_dir: &Path,
-        config: &WorkspaceConfig,
+        workspace_config: &WorkspaceConfig,
     ) -> Result<Toolchain, ToolchainError> {
         Toolchain::create_from_dir(
             &get_home_dir().ok_or(ToolchainError::MissingHomeDir)?,
             root_dir,
-            config,
+            workspace_config,
         )
         .await
     }

--- a/crates/utils/src/regex.rs
+++ b/crates/utils/src/regex.rs
@@ -17,7 +17,7 @@ lazy_static! {
 
     pub static ref TOKEN_FUNC_PATTERN: Regex = Regex::new(&format!("^@([a-z]+)\\({}\\)$", *TOKEN_GROUP)).unwrap();
     pub static ref TOKEN_FUNC_ANYWHERE_PATTERN: Regex = Regex::new(&format!("@([a-z]+)\\({}\\)", *TOKEN_GROUP)).unwrap();
-    pub static ref TOKEN_VAR_PATTERN: Regex = Regex::new("\\$([a-zA-Z]+)").unwrap();
+    pub static ref TOKEN_VAR_PATTERN: Regex = Regex::new("\\$(language|projectRoot|projectSource|projectType|project|target|taskType|task|workspaceRoot)").unwrap();
 }
 
 pub fn create_regex(value: &str) -> Result<Regex, MoonError> {

--- a/crates/vcs/src/loader.rs
+++ b/crates/vcs/src/loader.rs
@@ -9,10 +9,10 @@ pub struct VcsLoader {}
 
 impl VcsLoader {
     pub fn load(
-        config: &WorkspaceConfig,
         working_dir: &Path,
+        workspace_config: &WorkspaceConfig,
     ) -> Result<Box<dyn Vcs + Send + Sync>, VcsError> {
-        let vcs_config = &config.vcs;
+        let vcs_config = &workspace_config.vcs;
         let manager = &vcs_config.manager;
         let default_branch = &vcs_config.default_branch;
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -164,9 +164,8 @@ impl Workspace {
         // Setup components
         let cache = CacheEngine::create(&root_dir).await?;
         let toolchain = Toolchain::create(&root_dir, &config).await?;
-        let projects =
-            ProjectGraph::create(&root_dir, project_config, &config.projects, &cache).await?;
-        let vcs = VcsLoader::load(&config, &root_dir)?;
+        let projects = ProjectGraph::create(&root_dir, &config, project_config, &cache).await?;
+        let vcs = VcsLoader::load(&root_dir, &config)?;
 
         Ok(Workspace {
             cache,

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added `--language` and `--type` filter options to `moon query projects`.
 - Added `$language`, `$projectType`, and `$taskType` token variables.
 - Added `dev` as a non-CI task identifier (alongside `start` and `serve`).
+- Token variables can now be used within task `inputs`.
 
 ## 0.6.0
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Added `$language`, `$projectType`, and `$taskType` token variables.
 - Added `dev` as a non-CI task identifier (alongside `start` and `serve`).
 - Token variables can now be used within task `inputs`.
+- Multiple token variables can now be used within the same string.
 
 ## 0.6.0
 

--- a/website/docs/concepts/token.mdx
+++ b/website/docs/concepts/token.mdx
@@ -295,7 +295,7 @@ tasks:
 
 ## Variables
 
-> Usable in `args` only.
+> Usable in `args` and `inputs` only.
 
 A token variable is a value that starts with `$` and is substituted to a value derived from the
 current workspace, project, and task. And unlike token functions, token variables can be placed

--- a/website/docs/concepts/token.mdx
+++ b/website/docs/concepts/token.mdx
@@ -299,7 +299,7 @@ tasks:
 
 A token variable is a value that starts with `$` and is substituted to a value derived from the
 current workspace, project, and task. And unlike token functions, token variables can be placed
-_within_ content when necessary.
+_within_ content when necessary, and supports multiple variables within the same content.
 
 ### `$language`
 

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -16,6 +16,30 @@ the workspace development environment.
 
 Configures aspects of the action runner.
 
+### `implicitInputs`
+
+> string[]
+
+Defines task [`inputs`](./project#inputs) that are implicit inherited by _all_ tasks within the
+workspace. This is extremely useful for the "changes to these files should always trigger a task"
+scenario.
+
+Like `inputs`, values defined here are relative from the inheriting project.
+[Project and workspace relative file patterns](../concepts/file-pattern#project-relative) are
+supported and encouraged.
+
+```yaml title=".moon/workspace.yml" {2}
+actionRunner:
+  implicitInputs:
+    - 'package.json'
+    - '/.moon/project.yml'
+    - '/.moon/workspace.yml'
+```
+
+> When not defined, this setting defaults to the list in the example above. When this setting _is
+> defined_, that list will be overwritten, so be sure to explicitly define them if you would like to
+> retain that functionality.
+
 ### `inheritColorsForPipedTasks`
 
 > `boolean`


### PR DESCRIPTION
This adds a new setting, `actionRunner.implicitInputs` to `.moon/workspace.yml`, that defines inputs that are inherited by all tasks. This replaces the hard-coded "globally affected" logic.