### PR TITLE
new: Add `noop` (no operation) command support to tasks.

### DIFF
--- a/crates/action/src/run_target.rs
+++ b/crates/action/src/run_target.rs
@@ -116,6 +116,23 @@ pub async fn run_target(
     let project = workspace.projects.load(&project_id)?;
     let task = project.get_task(&task_id)?;
 
+    // Abort early if a no operation
+    if task.is_no_op() {
+        debug!(
+            target: LOG_TARGET,
+            "Target {} is a no operation, skipping",
+            color::id(target_id),
+        );
+
+        println!(
+            "{} {}",
+            label_checkpoint(target_id, Checkpoint::Pass),
+            color::muted("(no op)")
+        );
+
+        return Ok(ActionStatus::Passed);
+    }
+
     // Abort early if this build has already been cached/hashed
     let hasher =
         create_target_hasher(&workspace, &project, task, &context.passthrough_args).await?;

--- a/crates/cli/tests/dep_graph_test.rs
+++ b/crates/cli/tests/dep_graph_test.rs
@@ -7,7 +7,7 @@ fn all_by_default() {
     let dot = get_assert_output(&assert);
 
     // Snapshot is not deterministic
-    assert_eq!(dot.split('\n').count(), 229);
+    assert_eq!(dot.split('\n').count(), 238);
 }
 
 #[test]

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -248,7 +248,7 @@ mod caching {
         assert_eq!(state.item.target, "node:standard");
         assert_eq!(
             state.item.hash,
-            "eaa3c43c707b54fbff25b11ebc7528716c8a893d559f7898b1aac3f46767c361"
+            "c13bc7d3651071215a0d431732546fe15a80488ae2eebbd6d3a48f4308767486"
         );
     }
 }
@@ -795,5 +795,32 @@ mod outputs {
             .join(&hash)
             .join("esm/two.js")
             .exists());
+    }
+}
+
+mod noop {
+    use super::*;
+
+    #[test]
+    fn runs_noop() {
+        let fixture = create_fixtures_sandbox("cases");
+
+        let assert = create_moon_command_in(fixture.path())
+            .arg("run")
+            .arg("noop:noop")
+            .assert();
+
+        assert_snapshot!(get_assert_output(&assert));
+    }
+    #[test]
+    fn runs_noop_deps() {
+        let fixture = create_fixtures_sandbox("cases");
+
+        let assert = create_moon_command_in(fixture.path())
+            .arg("run")
+            .arg("noop:noopWithDeps")
+            .assert();
+
+        assert_snapshot!(get_assert_output(&assert));
     }
 }

--- a/crates/cli/tests/snapshots/run_test__caching__creates_run_state_cache.snap
+++ b/crates/cli/tests/snapshots/run_test__caching__creates_run_state_cache.snap
@@ -11,7 +11,7 @@ expression: "read_to_string(fixture.path().join(format!(\".moon/cache/hashes/{}.
   "deps": [],
   "envVars": {},
   "inputHashes": {
-    ".moon/workspace.yml": "7ca1e0fd35ca95465b01f5551df5e5beab704116",
+    ".moon/workspace.yml": "b3e0a424922dbe1770e26bb2d62878ab27001328",
     "node/cjsFile.cjs": "91382f667258361b9397214d0aec54d8d576ae19",
     "node/cwd.js": "47d4aa44cd6363251821ab9c59f4c68df455445c",
     "node/envVars.js": "44b0fda6bce364122223fbfc67b65ecbc52aec91",

--- a/crates/cli/tests/snapshots/run_test__noop__runs_noop.snap
+++ b/crates/cli/tests/snapshots/run_test__noop__runs_noop.snap
@@ -1,0 +1,13 @@
+---
+source: crates/cli/tests/run_test.rs
+assertion_line: 813
+expression: get_assert_output(&assert)
+---
+▪▪▪▪ npm install
+▪▪▪▪ noop:noop (no op)
+
+Tasks: 1 completed
+ Time: 100ms
+
+
+

--- a/crates/cli/tests/snapshots/run_test__noop__runs_noop_deps.snap
+++ b/crates/cli/tests/snapshots/run_test__noop__runs_noop_deps.snap
@@ -1,0 +1,25 @@
+---
+source: crates/cli/tests/run_test.rs
+assertion_line: 824
+expression: get_assert_output(&assert)
+---
+▪▪▪▪ npm install
+▪▪▪▪ depsC:dependencyOrder
+▪▪▪▪ depsC:dependencyOrder (100ms)
+deps=c
+
+▪▪▪▪ depsB:dependencyOrder
+▪▪▪▪ depsB:dependencyOrder (100ms)
+deps=b
+
+▪▪▪▪ depsA:dependencyOrder
+▪▪▪▪ depsA:dependencyOrder (100ms)
+deps=a
+
+▪▪▪▪ noop:noopWithDeps (no op)
+
+Tasks: 4 completed
+ Time: 100ms
+
+
+

--- a/crates/project/src/task.rs
+++ b/crates/project/src/task.rs
@@ -321,6 +321,11 @@ impl Task {
         Ok(false)
     }
 
+    /// Return true if the task is a "no operation" and does nothing.
+    pub fn is_no_op(&self) -> bool {
+        self.command == "nop" || self.command == "noop" || self.command == "no-op"
+    }
+
     pub fn merge(&mut self, config: &TaskConfig) {
         // Merge options first incase the merge strategy has changed
         self.options.merge(&config.options);

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added a special `noop` command for tasks.
+
 ## 0.7.0
 
 #### 💥 Breaking

--- a/tests/fixtures/cases/.moon/workspace.yml
+++ b/tests/fixtures/cases/.moon/workspace.yml
@@ -6,6 +6,7 @@ projects:
   depsB: 'deps-b'
   depsC: 'deps-c'
   dependsOn: 'depends-on'
+  noop: 'noop'
 
   # Target scopes
   targetScopeA: 'target-scope-a'

--- a/tests/fixtures/cases/noop/project.yml
+++ b/tests/fixtures/cases/noop/project.yml
@@ -1,0 +1,9 @@
+language: javascript
+
+tasks:
+  noop:
+    command: noop
+  noopWithDeps:
+    command: noop
+    deps:
+      - 'depsA:dependencyOrder'

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -186,6 +186,8 @@ tasks:
 
 For interoperability reasons, the following commands have special handling.
 
+- `noop`, `no-op`, `nop` - Marks the task as a "no operation". Will not execute a command in the
+  action runner but can define dependencies.
 - When `type` is "node":
   - `node`, `npm`, `pnpm`, `yarn` - Uses the binaries from the toolchain.
 - When `type` is "system":


### PR DESCRIPTION
Useful for grouping tasks in parallel, but not actually executing anything.