### PR TITLE
internal: Refactor language config caching.

### DIFF
--- a/crates/action/src/install_node_deps.rs
+++ b/crates/action/src/install_node_deps.rs
@@ -74,6 +74,8 @@ pub async fn install_node_deps(
     PackageJson::sync(workspace.root.join("package.json"), |package_json| {
         add_package_manager(&workspace, package_json);
         add_engines_constraint(&workspace, package_json);
+
+        Ok(())
     })
     .await?;
 

--- a/crates/action/src/install_node_deps.rs
+++ b/crates/action/src/install_node_deps.rs
@@ -66,108 +66,97 @@ pub async fn install_node_deps(
     context: &ActionContext,
     workspace: Arc<RwLock<Workspace>>,
 ) -> Result<ActionStatus, ActionError> {
-    // Writes root `package.json`
-    {
-        let workspace = workspace.write().await;
-        let mut root_package_json = PackageJson::read(workspace.root.join("package.json")).await?;
+    let workspace = workspace.read().await;
+    let node_config = &workspace.config.node;
+    let mut cache = workspace.cache.cache_workspace_state().await?;
 
-        if let Some(root_package_json_mut) = &mut root_package_json {
-            let added_manager = add_package_manager(&workspace, root_package_json_mut);
-            let added_engines = add_engines_constraint(&workspace, root_package_json_mut);
+    // Sync values to root `package.json`
+    PackageJson::sync(workspace.root.join("package.json"), |package_json| {
+        add_package_manager(&workspace, package_json);
+        add_engines_constraint(&workspace, package_json);
+    })
+    .await?;
 
-            if added_manager || added_engines {
-                root_package_json_mut.save().await?;
-            }
-        }
-    }
+    // Create nvm/nodenv version file
+    if let Some(version_manager) = &node_config.sync_version_manager_config {
+        let rc_name = version_manager.get_config_filename();
+        let rc_path = workspace.root.join(&rc_name);
 
-    // Read only
-    {
-        let workspace = workspace.read().await;
-        let mut cache = workspace.cache.cache_workspace_state().await?;
-        let manager = workspace.toolchain.get_node().get_package_manager();
-        let node_config = &workspace.config.node;
-
-        // Create nvm/nodenv config file
-        if let Some(version_manager) = &node_config.sync_version_manager_config {
-            let rc_name = version_manager.get_config_filename();
-            let rc_path = workspace.root.join(&rc_name);
-
-            fs::write(&rc_path, &node_config.version).await?;
-
-            debug!(
-                target: LOG_TARGET,
-                "Syncing Node.js version to root {}",
-                color::file(&rc_name)
-            );
-        }
-
-        // Get the last modified time of the root lockfile
-        let lockfile_name = manager.get_lock_filename();
-        let lockfile = workspace.root.join(&lockfile_name);
-        let mut last_modified = 0;
-
-        if lockfile.exists() {
-            let lockfile_metadata = fs::metadata(&lockfile).await?;
-
-            last_modified = cache.to_millis(
-                lockfile_metadata
-                    .modified()
-                    .map_err(|e| map_io_to_fs_error(e, lockfile.clone()))?,
-            );
-        }
-
-        // If a package.json has been modified manually, we should account for that
-        let has_modified_manifests = context
-            .touched_files
-            .iter()
-            .any(|f| f.ends_with(&NPM.manifest_filename) || f.ends_with(&lockfile_name));
-
-        // Install deps if the lockfile has been modified
-        // since the last time dependencies were installed!
-        if has_modified_manifests
-            || last_modified == 0
-            || last_modified > cache.item.last_node_install_time
-        {
-            debug!(target: LOG_TARGET, "Installing Node.js dependencies");
-
-            if is_offline() {
-                warn!(
-                    target: LOG_TARGET,
-                    "No internet connection, assuming offline and skipping install"
-                );
-
-                return Ok(ActionStatus::Skipped);
-            }
-
-            let install_command = match workspace.config.node.package_manager {
-                PackageManager::Npm => "npm install",
-                PackageManager::Pnpm => "pnpm install",
-                PackageManager::Yarn => "yarn install",
-            };
-
-            println!("{}", label_checkpoint(install_command, Checkpoint::Pass));
-
-            manager.install_dependencies(&workspace.toolchain).await?;
-
-            if node_config.dedupe_on_lockfile_change {
-                debug!(target: LOG_TARGET, "Dedupeing dependencies");
-
-                manager.dedupe_dependencies(&workspace.toolchain).await?;
-            }
-
-            // Update the cache with the timestamp
-            cache.item.last_node_install_time = cache.now_millis();
-            cache.save().await?;
-
-            return Ok(ActionStatus::Passed);
-        }
+        fs::write(&rc_path, &node_config.version).await?;
 
         debug!(
             target: LOG_TARGET,
-            "Lockfile has not changed since last install, skipping Node.js dependencies",
+            "Syncing Node.js version to root {}",
+            color::file(&rc_name)
         );
     }
+
+    // Get the last modified time of the root lockfile
+    let manager = workspace.toolchain.get_node().get_package_manager();
+    let lockfile_name = manager.get_lock_filename();
+    let lockfile = workspace.root.join(&lockfile_name);
+    let mut last_modified = 0;
+
+    if lockfile.exists() {
+        let lockfile_metadata = fs::metadata(&lockfile).await?;
+
+        last_modified = cache.to_millis(
+            lockfile_metadata
+                .modified()
+                .map_err(|e| map_io_to_fs_error(e, lockfile.clone()))?,
+        );
+    }
+
+    // If a `package.json` has been modified manually, we should account for that
+    let has_modified_manifests = context
+        .touched_files
+        .iter()
+        .any(|f| f.ends_with(&NPM.manifest_filename) || f.ends_with(&lockfile_name));
+
+    // Install deps if the lockfile has been modified
+    // since the last time dependencies were installed!
+    if has_modified_manifests
+        || last_modified == 0
+        || last_modified > cache.item.last_node_install_time
+    {
+        debug!(target: LOG_TARGET, "Installing Node.js dependencies");
+
+        if is_offline() {
+            warn!(
+                target: LOG_TARGET,
+                "No internet connection, assuming offline and skipping install"
+            );
+
+            return Ok(ActionStatus::Skipped);
+        }
+
+        let install_command = match workspace.config.node.package_manager {
+            PackageManager::Npm => "npm install",
+            PackageManager::Pnpm => "pnpm install",
+            PackageManager::Yarn => "yarn install",
+        };
+
+        println!("{}", label_checkpoint(install_command, Checkpoint::Pass));
+
+        manager.install_dependencies(&workspace.toolchain).await?;
+
+        if node_config.dedupe_on_lockfile_change {
+            debug!(target: LOG_TARGET, "Dedupeing dependencies");
+
+            manager.dedupe_dependencies(&workspace.toolchain).await?;
+        }
+
+        // Update the cache with the timestamp
+        cache.item.last_node_install_time = cache.now_millis();
+        cache.save().await?;
+
+        return Ok(ActionStatus::Passed);
+    }
+
+    debug!(
+        target: LOG_TARGET,
+        "Lockfile has not changed since last install, skipping Node.js dependencies",
+    );
 
     Ok(ActionStatus::Skipped)
 }

--- a/crates/action/src/sync_node_project.rs
+++ b/crates/action/src/sync_node_project.rs
@@ -80,124 +80,114 @@ pub async fn sync_node_project(
     project_id: &str,
 ) -> Result<ActionStatus, ActionError> {
     let mut mutated_files = false;
+    let workspace = workspace.read().await;
+    let node_config = &workspace.config.node;
+    let typescript_config = &workspace.config.typescript;
+    let project = workspace.projects.load(project_id)?;
 
-    // Read-only for thread safe actions
+    // Load project configs
+    let mut project_package_json = PackageJson::read(project.root.join("package.json")).await?;
+
+    let mut project_tsconfig_json = TsConfigJson::read(
+        project
+            .root
+            .join(&typescript_config.project_config_file_name),
+    )
+    .await?;
+
+    // Auto-create a `tsconfig.json` if configured and applicable
+    if typescript_config.create_missing_config
+        && typescript_config.sync_project_references
+        && !project
+            .root
+            .join(&typescript_config.project_config_file_name)
+            .exists()
     {
-        let workspace = workspace.read().await;
-        let node_config = &workspace.config.node;
-        let typescript_config = &workspace.config.typescript;
-        let project = workspace.projects.load(project_id)?;
+        project_tsconfig_json =
+            create_missing_tsconfig(&project, typescript_config, &workspace.root).await?;
+    }
 
-        // Load project configs
-        let mut project_package_json = PackageJson::read(project.root.join("package.json")).await?;
+    // Sync each dependency to `tsconfig.json` and `package.json`
+    let dep_version_range = workspace
+        .toolchain
+        .get_node()
+        .get_package_manager()
+        .get_workspace_dependency_range();
 
-        let mut project_tsconfig_json = TsConfigJson::read(
-            project
-                .root
-                .join(&typescript_config.project_config_file_name),
-        )
-        .await?;
+    for dep_id in project.get_dependencies() {
+        let dep_project = workspace.projects.load(&dep_id)?;
 
-        // Auto-create a `tsconfig.json` if configured and applicable
-        if project_tsconfig_json.is_none()
-            && typescript_config.create_missing_config
-            && typescript_config.sync_project_references
-        {
-            project_tsconfig_json =
-                create_missing_tsconfig(&project, typescript_config, &workspace.root).await?;
-        }
+        // Update `dependencies` within this project's `package.json`
+        if node_config.sync_project_workspace_dependencies {
+            if let Some(project_package_json_mut) = &mut project_package_json {
+                let dep_package_json =
+                    PackageJson::read(dep_project.root.join("package.json")).await?;
 
-        // Sync each dependency to `tsconfig.json` and `package.json`
-        let dep_version_range = workspace
-            .toolchain
-            .get_node()
-            .get_package_manager()
-            .get_workspace_dependency_range();
+                // Only add if the dependent project has a `package.json`,
+                // and this `package.json` has not already declared the dep.
+                if dep_package_json.is_some()
+                    && project_package_json_mut.add_dependency(
+                        &dep_package_json.unwrap().name.unwrap_or_default(),
+                        &dep_version_range,
+                        true,
+                    )
+                {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Syncing {} as a dependency to {}'s {}",
+                        color::id(&dep_id),
+                        color::id(project_id),
+                        color::file("package.json")
+                    );
 
-        for dep_id in project.get_dependencies() {
-            let dep_project = workspace.projects.load(&dep_id)?;
-
-            // Update `dependencies` within this project's `package.json`
-            if node_config.sync_project_workspace_dependencies {
-                if let Some(project_package_json_mut) = &mut project_package_json {
-                    let dep_package_json =
-                        PackageJson::read(dep_project.root.join("package.json")).await?;
-
-                    // Only add if the dependent project has a `package.json`,
-                    // and this `package.json` has not already declared the dep.
-                    if dep_package_json.is_some()
-                        && project_package_json_mut.add_dependency(
-                            &dep_package_json.unwrap().name.unwrap_or_default(),
-                            &dep_version_range,
-                            true,
-                        )
-                    {
-                        debug!(
-                            target: LOG_TARGET,
-                            "Syncing {} as a dependency to {}'s {}",
-                            color::id(&dep_id),
-                            color::id(project_id),
-                            color::file("package.json")
-                        );
-
-                        project_package_json_mut.save().await?;
-                        mutated_files = true;
-                    }
+                    project_package_json_mut.save().await?;
+                    mutated_files = true;
                 }
             }
+        }
 
-            // Update `references` within this project's `tsconfig.json`
-            if typescript_config.sync_project_references {
-                if let Some(project_tsconfig_json_mut) = &mut project_tsconfig_json {
-                    let tsconfig_branch_name = &typescript_config.project_config_file_name;
-                    let dep_ref_path = path::to_string(
-                        path::relative_from(&dep_project.root, &project.root).unwrap_or_default(),
-                    )?;
+        // Update `references` within this project's `tsconfig.json`
+        if typescript_config.sync_project_references {
+            if let Some(project_tsconfig_json_mut) = &mut project_tsconfig_json {
+                let tsconfig_branch_name = &typescript_config.project_config_file_name;
+                let dep_ref_path = path::to_string(
+                    path::relative_from(&dep_project.root, &project.root).unwrap_or_default(),
+                )?;
 
-                    // Only add if the dependent project has a `tsconfig.json`,
-                    // and this `tsconfig.json` has not already declared the dep.
-                    if dep_project.root.join(tsconfig_branch_name).exists()
-                        && project_tsconfig_json_mut
-                            .add_project_ref(&dep_ref_path, tsconfig_branch_name)
-                    {
-                        debug!(
-                            target: LOG_TARGET,
-                            "Syncing {} as a project reference to {}'s {}",
-                            color::id(&dep_id),
-                            color::id(project_id),
-                            color::file(tsconfig_branch_name)
-                        );
+                // Only add if the dependent project has a `tsconfig.json`,
+                // and this `tsconfig.json` has not already declared the dep.
+                if dep_project.root.join(tsconfig_branch_name).exists()
+                    && project_tsconfig_json_mut
+                        .add_project_ref(&dep_ref_path, tsconfig_branch_name)
+                {
+                    debug!(
+                        target: LOG_TARGET,
+                        "Syncing {} as a project reference to {}'s {}",
+                        color::id(&dep_id),
+                        color::id(project_id),
+                        color::file(tsconfig_branch_name)
+                    );
 
-                        project_tsconfig_json_mut.save().await?;
-                        mutated_files = true;
-                    }
+                    project_tsconfig_json_mut.save().await?;
+                    mutated_files = true;
                 }
             }
         }
     }
 
-    // Acquire a write lock to avoid race conditions
-    {
-        let workspace = workspace.write().await;
-        let typescript_config = &workspace.config.typescript;
-        let project = workspace.projects.load(project_id)?;
-
-        let mut root_tsconfig_json = TsConfigJson::read(
+    // Sync to the root `tsconfig.json` (only if the project has a tsconfig)
+    if typescript_config.sync_project_references {
+        TsConfigJson::sync(
             workspace
                 .root
                 .join(&typescript_config.root_config_file_name),
-        )
-        .await?;
-
-        // Sync to the root `tsconfig.json` (only if the project has a tsconfig)
-        if typescript_config.sync_project_references {
-            if let Some(root_tsconfig_json_mut) = &mut root_tsconfig_json {
-                if sync_root_tsconfig(root_tsconfig_json_mut, typescript_config, &project) {
-                    root_tsconfig_json_mut.save().await?;
+            |tsconfig_json| {
+                if sync_root_tsconfig(tsconfig_json, typescript_config, &project) {
                     mutated_files = true;
                 }
-            }
-        }
+            },
+        )
+        .await?;
     }
 
     if mutated_files {

--- a/crates/lang-node/src/package.rs
+++ b/crates/lang-node/src/package.rs
@@ -178,6 +178,11 @@ impl PackageJson {
     pub fn add_dependency<T: AsRef<str>>(&mut self, name: T, range: T, if_missing: bool) -> bool {
         let name = name.as_ref();
         let range = range.as_ref();
+
+        if name.is_empty() {
+            return false;
+        }
+
         let mut dependencies = match &self.dependencies {
             Some(deps) => deps.clone(),
             None => BTreeMap::new(),

--- a/crates/lang-node/src/package.rs
+++ b/crates/lang-node/src/package.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-config_cache!(PackageJson);
+config_cache!(PackageJson, write_preserved_json);
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/lang-node/src/tsconfig.rs
+++ b/crates/lang-node/src/tsconfig.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-config_cache!(TsConfigJson);
+config_cache!(TsConfigJson, write_preserved_json);
 
 // This implementation is forked from the wonderful crate "tsconfig", as we need full control for
 // integration with the rest of the crates. We also can't wait for upsteam for new updates.

--- a/crates/lang/src/config.rs
+++ b/crates/lang/src/config.rs
@@ -1,14 +1,8 @@
 #[macro_export]
 macro_rules! config_cache {
-    ($struct:ident) => {
-
-        #[cached(result = true)]
-        async fn load_config(path: PathBuf) -> Result<Option<$struct>, MoonError> {
+    ($struct:ident, $writer:ident) => {
+        async fn load_json(path: &Path) -> Result<$struct, MoonError> {
             use moon_logger::{color, trace};
-
-            if !path.exists() {
-                return Ok(None);
-            }
 
             trace!(
                 target: "moon:lang:config",
@@ -17,31 +11,87 @@ macro_rules! config_cache {
             );
 
             let mut cfg: $struct = fs::read_json(&path).await?;
-            cfg.path = path;
+            cfg.path = path.to_path_buf();
 
-            Ok(Some(cfg))
+            Ok(cfg)
+        }
+
+        // This merely exists to create the global cache!
+        #[cached(sync_writes = true, result = true)]
+        async fn load_config(path: PathBuf) -> Result<$struct, MoonError> {
+            load_json(&path).await
         }
 
         impl $struct {
+            /// Read the config file from the cache. If not cached, and the file exists
+            /// load it and store in the cache, otherwise return none.
+            #[track_caller]
             pub async fn read(path: PathBuf) -> Result<Option<$struct>, MoonError> {
-                load_config(path).await
+                if path.exists() {
+                    Ok(Some(load_config(path).await?))
+                } else {
+                    Ok(None)
+                }
             }
 
+            #[track_caller]
+            pub async fn sync<F>(path: PathBuf, func: F) -> Result<bool, MoonError>
+            where
+                F: FnOnce(&mut $struct)
+            {
+                use cached::Cached;
+                use moon_logger::{color, trace};
+
+                // Abort early and dont acquire a lock if the config doesnt exist
+                if !path.exists() {
+                    return Ok(false);
+                }
+
+                let mut cache = LOAD_CONFIG.lock().await;
+                let mut cfg: $struct;
+
+                if let Some(item) = cache.cache_get(&path) {
+                    cfg = item.clone();
+                } else {
+                    cfg = load_json(&path).await?;
+                }
+
+                func(&mut cfg);
+
+                trace!(
+                    target: "moon:lang:config",
+                    "Syncing {} with changes",
+                    color::path(&path),
+                );
+
+                // Write to the file system
+                $writer(&path, &cfg).await?;
+
+                // And store in the cache
+                cache.cache_set(path, cfg);
+
+                Ok(true)
+            }
+
+            /// Write (or overwrite) the value directly into the cache.
             #[track_caller]
             pub async fn write(value: $struct) -> Result<(), MoonError> {
                 use cached::Cached;
                 use moon_logger::{color, trace};
 
                 let mut cache = LOAD_CONFIG.lock().await;
-                let data = value.clone();
 
                 trace!(
                     target: "moon:lang:config",
-                    "Updating {}",
-                    color::path(&data.path),
+                    "Writing {} to cache",
+                    color::path(&value.path),
                 );
 
-                cache.cache_set(data.path, Some(value));
+                // Write to the file system
+                $writer(&value.path, &value).await?;
+
+                // And store in the cache
+                cache.cache_set(value.path.clone(), value);
 
                 Ok(())
             }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### ⚙️ Internal
 
 - Runfiles are no longer cleaned up when running tasks.
+- Reworked `package.json` and `tsconfig.json` handling to avoid race conditions.
 
 ## 0.7.0
 


### PR DESCRIPTION
I would still see random race conditions, so this solves it with a new method that locks the cache and syncs with the file system. Ideally this is rather quick and doesn't run into deadlocks.