### PR TITLE
fix: Fix file hashing cache being busted.

### DIFF
--- a/crates/action/src/target/hasher.rs
+++ b/crates/action/src/target/hasher.rs
@@ -75,7 +75,10 @@ pub async fn create_target_hasher(
 
     // For input files, hash them with the vcs layer first
     if !task.input_paths.is_empty() {
-        let files = convert_paths_to_strings(&task.input_paths, &workspace.root)?;
+        let mut files = convert_paths_to_strings(&task.input_paths, &workspace.root)?;
+
+        // Sort for deterministic caching within the vcs layer
+        files.sort();
 
         if !files.is_empty() {
             hasher.hash_inputs(vcs.get_file_hashes(&files).await?);
@@ -101,7 +104,7 @@ pub async fn create_target_hasher(
 
     if !local_files.all.is_empty() {
         // Only hash files that are within the task's inputs
-        let files = local_files
+        let mut files = local_files
             .all
             .into_iter()
             .filter(|f| {
@@ -110,6 +113,9 @@ pub async fn create_target_hasher(
                     && globset.matches(&workspace.root.join(f)).unwrap_or(false)
             })
             .collect::<Vec<String>>();
+
+        // Sort for deterministic caching within the vcs layer
+        files.sort();
 
         if !files.is_empty() {
             hasher.hash_inputs(vcs.get_file_hashes(&files).await?);

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,10 @@
   `project.yml` tasks.
 - Added a `moon sync` command for manually syncing all projects in the workspace to a healthy state.
 
+#### 🐞 Fixes
+
+- Fixed an issue where files being hashed with git were not being cached accordingly.
+
 #### ⚙️ Internal
 
 - Runfiles are no longer cleaned up when running tasks.


### PR DESCRIPTION
Noticed that calls to `git hash-object` were not being cached correctly because the order of files in the input kept changing, so this sorts them.