### PR TITLE
fix: Fix pnpm/yarn crash when version not explicitly set.

### DIFF
--- a/.yarn/versions/98a21dcd.yml
+++ b/.yarn/versions/98a21dcd.yml
@@ -1,0 +1,7 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/action/src/install_node_deps.rs
+++ b/crates/action/src/install_node_deps.rs
@@ -20,11 +20,21 @@ fn add_package_manager(workspace: &Workspace, package_json: &mut PackageJson) ->
         PackageManager::Npm => format!("npm@{}", workspace.config.node.npm.version),
         PackageManager::Pnpm => format!(
             "pnpm@{}",
-            workspace.config.node.pnpm.as_ref().unwrap().version
+            match &workspace.config.node.pnpm {
+                Some(pnpm) => pnpm.version.clone(),
+                None => {
+                    return false;
+                }
+            }
         ),
         PackageManager::Yarn => format!(
             "yarn@{}",
-            workspace.config.node.yarn.as_ref().unwrap().version
+            match &workspace.config.node.yarn {
+                Some(yarn) => yarn.version.clone(),
+                None => {
+                    return false;
+                }
+            }
         ),
     };
 

--- a/crates/toolchain/src/pms/pnpm.rs
+++ b/crates/toolchain/src/pms/pnpm.rs
@@ -22,12 +22,12 @@ pub struct PnpmTool {
 }
 
 impl PnpmTool {
-    pub fn new(node: &NodeTool, config: &PnpmConfig) -> Result<PnpmTool, ToolchainError> {
+    pub fn new(node: &NodeTool, config: &Option<PnpmConfig>) -> Result<PnpmTool, ToolchainError> {
         let install_dir = node.get_install_dir()?.clone();
 
         Ok(PnpmTool {
             bin_path: node::find_package_manager_bin(&install_dir, "pnpm"),
-            config: config.to_owned(),
+            config: config.to_owned().unwrap_or_default(),
             install_dir,
             log_target: String::from("moon:toolchain:pnpm"),
         })

--- a/crates/toolchain/src/pms/yarn.rs
+++ b/crates/toolchain/src/pms/yarn.rs
@@ -22,12 +22,12 @@ pub struct YarnTool {
 }
 
 impl YarnTool {
-    pub fn new(node: &NodeTool, config: &YarnConfig) -> Result<YarnTool, ToolchainError> {
+    pub fn new(node: &NodeTool, config: &Option<YarnConfig>) -> Result<YarnTool, ToolchainError> {
         let install_dir = node.get_install_dir()?.clone();
 
         Ok(YarnTool {
             bin_path: node::find_package_manager_bin(&install_dir, "yarn"),
-            config: config.to_owned(),
+            config: config.to_owned().unwrap_or_default(),
             install_dir,
             log_target: String::from("moon:toolchain:yarn"),
         })

--- a/crates/toolchain/src/tools/node.rs
+++ b/crates/toolchain/src/tools/node.rs
@@ -8,7 +8,7 @@ use crate::pms::yarn::YarnTool;
 use crate::traits::{Downloadable, Executable, Installable, Lifecycle, PackageManager, Tool};
 use crate::Toolchain;
 use async_trait::async_trait;
-use moon_config::NodeConfig;
+use moon_config::{NodeConfig, PackageManager as NodePackageManager};
 use moon_error::map_io_to_fs_error;
 use moon_lang::LangError;
 use moon_lang_node::node;
@@ -84,13 +84,15 @@ impl NodeTool {
 
         node.npm = Some(NpmTool::new(&node, &config.npm)?);
 
-        if let Some(pnpm_config) = &config.pnpm {
-            node.pnpm = Some(PnpmTool::new(&node, pnpm_config)?);
-        }
-
-        if let Some(yarn_config) = &config.yarn {
-            node.yarn = Some(YarnTool::new(&node, yarn_config)?);
-        }
+        match config.package_manager {
+            NodePackageManager::Pnpm => {
+                node.pnpm = Some(PnpmTool::new(&node, &config.pnpm)?);
+            }
+            NodePackageManager::Yarn => {
+                node.yarn = Some(YarnTool::new(&node, &config.yarn)?);
+            }
+            _ => {}
+        };
 
         Ok(node)
     }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed a crash when `node.packageManager` was set to "pnpm" or "yarn" but `node.pnpm` or
+  `node.yarn` fields were not set.
+
 ## 0.8.0
 
 This release was largely focused on interoperability with the Node.js ecosystem, specifically


### PR DESCRIPTION
Most of our tests explicitly set the version, but using the defaults should be acceptable.