### PR TITLE
new: Support different dependency version formats with `node.dependencyVersionFormat`.

### DIFF
--- a/crates/action/src/sync_node_project.rs
+++ b/crates/action/src/sync_node_project.rs
@@ -99,7 +99,7 @@ pub async fn sync_node_project(
 
     for dep_id in project.get_dependencies() {
         let dep_project = workspace.projects.load(&dep_id)?;
-        let dep_relative_path = path::to_string(
+        let dep_relative_path = path::to_virtual_string(
             path::relative_from(&dep_project.root, &project.root).unwrap_or_default(),
         )?;
 

--- a/crates/action/src/sync_node_project.rs
+++ b/crates/action/src/sync_node_project.rs
@@ -7,6 +7,7 @@ use moon_logger::{color, debug};
 use moon_project::Project;
 use moon_utils::{fs, is_ci, path, string_vec};
 use moon_workspace::Workspace;
+use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -71,52 +72,6 @@ fn sync_root_tsconfig(
     false
 }
 
-fn sync_project_dependency(
-    base_project: &Project,
-    dep_project: &Project,
-    dep_relative_path: &str,
-    format: &NodeVersionFormat,
-) -> Result<bool, ActionError> {
-    if let Some(dep_package_json) = PackageJson::read(&dep_project.root)? {
-        let version_prefix = format.get_prefix();
-        let dep_version = match format {
-            NodeVersionFormat::File | NodeVersionFormat::Link => {
-                format!("{}{}", version_prefix, dep_relative_path)
-            }
-            NodeVersionFormat::Version
-            | NodeVersionFormat::VersionCaret
-            | NodeVersionFormat::VersionTilde => format!(
-                "{}{}",
-                version_prefix,
-                dep_package_json.version.unwrap_or_default()
-            ),
-            _ => version_prefix,
-        };
-
-        PackageJson::sync(&base_project.root, |package_json| {
-            if package_json.add_dependency(
-                &dep_package_json.name.unwrap_or_default(),
-                &dep_version,
-                true,
-            ) {
-                debug!(
-                    target: LOG_TARGET,
-                    "Syncing {} as a dependency to {}'s {}",
-                    color::id(&dep_project.id),
-                    color::id(&base_project.id),
-                    color::file("package.json")
-                );
-            }
-
-            Ok(())
-        })?;
-
-        return Ok(true);
-    }
-
-    Ok(false)
-}
-
 pub async fn sync_node_project(
     _action: &mut Action,
     _context: &ActionContext,
@@ -127,71 +82,108 @@ pub async fn sync_node_project(
     let workspace = workspace.read().await;
     let node_config = &workspace.config.node;
     let typescript_config = &workspace.config.typescript;
+    let tsconfig_branch_name = &typescript_config.project_config_file_name;
     let project = workspace.projects.load(project_id)?;
 
     // Auto-create a `tsconfig.json` if configured and applicable
     if typescript_config.create_missing_config
         && typescript_config.sync_project_references
-        && !project
-            .root
-            .join(&typescript_config.project_config_file_name)
-            .exists()
+        && !project.root.join(&tsconfig_branch_name).exists()
     {
         create_missing_tsconfig(&project, typescript_config, &workspace.root).await?;
     }
 
     // Sync each dependency to `tsconfig.json` and `package.json`
+    let mut package_prod_deps: BTreeMap<String, String> = BTreeMap::new();
+    let mut tsconfig_project_refs: HashSet<String> = HashSet::new();
+
     for dep_id in project.get_dependencies() {
         let dep_project = workspace.projects.load(&dep_id)?;
         let dep_relative_path = path::to_string(
             path::relative_from(&dep_project.root, &project.root).unwrap_or_default(),
         )?;
 
-        // Update `dependencies` within this project's `package.json`.
+        // Update dependencies within this project's `package.json`.
         // Only add if the dependent project has a `package.json`,
         // and this `package.json` has not already declared the dep.
-        if node_config.sync_project_workspace_dependencies
-            && sync_project_dependency(
-                &project,
-                &dep_project,
-                &dep_relative_path,
-                &node_config.dependency_version_format,
-            )?
-        {
-            mutated_files = true;
+        if node_config.sync_project_workspace_dependencies {
+            let format = &node_config.dependency_version_format;
+
+            if let Some(dep_package_json) = PackageJson::read(&dep_project.root)? {
+                if let Some(dep_package_name) = &dep_package_json.name {
+                    let version_prefix = format.get_prefix();
+                    let dep_version = match format {
+                        NodeVersionFormat::File | NodeVersionFormat::Link => {
+                            format!("{}{}", version_prefix, dep_relative_path)
+                        }
+                        NodeVersionFormat::Version
+                        | NodeVersionFormat::VersionCaret
+                        | NodeVersionFormat::VersionTilde => format!(
+                            "{}{}",
+                            version_prefix,
+                            dep_package_json.version.unwrap_or_default()
+                        ),
+                        _ => version_prefix,
+                    };
+
+                    package_prod_deps.insert(dep_package_name.to_owned(), dep_version);
+
+                    debug!(
+                        target: LOG_TARGET,
+                        "Syncing {} as a dependency to {}'s {}",
+                        color::id(&dep_project.id),
+                        color::id(&project.id),
+                        color::file("package.json")
+                    );
+                }
+            }
         }
 
         // Update `references` within this project's `tsconfig.json`.
         // Only add if the dependent project has a `tsconfig.json`,
         // and this `tsconfig.json` has not already declared the dep.
-        if typescript_config.sync_project_references {
-            let tsconfig_branch_name = &typescript_config.project_config_file_name;
+        if typescript_config.sync_project_references
+            && dep_project.root.join(&tsconfig_branch_name).exists()
+        {
+            tsconfig_project_refs.insert(dep_relative_path);
 
-            if dep_project.root.join(tsconfig_branch_name).exists() {
-                TsConfigJson::sync_with_name(
-                    &project.root,
-                    &tsconfig_branch_name,
-                    |tsconfig_json| {
-                        if tsconfig_json.add_project_ref(&dep_relative_path, tsconfig_branch_name) {
-                            mutated_files = true;
-
-                            debug!(
-                                target: LOG_TARGET,
-                                "Syncing {} as a project reference to {}'s {}",
-                                color::id(&dep_id),
-                                color::id(project_id),
-                                color::file(tsconfig_branch_name)
-                            );
-                        }
-
-                        Ok(())
-                    },
-                )?;
-            }
+            debug!(
+                target: LOG_TARGET,
+                "Syncing {} as a project reference to {}'s {}",
+                color::id(&dep_id),
+                color::id(project_id),
+                color::file(tsconfig_branch_name)
+            );
         }
     }
 
-    // Sync to the root `tsconfig.json` (only if the project has a tsconfig)
+    // Sync to the project's `package.json`
+    if !package_prod_deps.is_empty() {
+        PackageJson::sync(&project.root, |package_json| {
+            for (name, version) in package_prod_deps {
+                if package_json.add_dependency(&name, &version, true) {
+                    mutated_files = true;
+                }
+            }
+
+            Ok(())
+        })?;
+    }
+
+    // Sync to the project's `tsconfig.json`
+    if !tsconfig_project_refs.is_empty() {
+        TsConfigJson::sync_with_name(&project.root, &tsconfig_branch_name, |tsconfig_json| {
+            for ref_path in tsconfig_project_refs {
+                if tsconfig_json.add_project_ref(&ref_path, tsconfig_branch_name) {
+                    mutated_files = true;
+                }
+            }
+
+            Ok(())
+        })?;
+    }
+
+    // Sync to the root `tsconfig.json`
     if typescript_config.sync_project_references {
         TsConfigJson::sync_with_name(
             &workspace.root,

--- a/crates/action/src/sync_node_project.rs
+++ b/crates/action/src/sync_node_project.rs
@@ -1,7 +1,7 @@
 use crate::action::{Action, ActionStatus};
 use crate::context::ActionContext;
 use crate::errors::ActionError;
-use moon_config::{NodeVersionProtocol, TypeScriptConfig};
+use moon_config::{NodeVersionFormat, TypeScriptConfig};
 use moon_lang_node::{package::PackageJson, tsconfig::TsConfigJson};
 use moon_logger::{color, debug};
 use moon_project::Project;
@@ -75,17 +75,17 @@ fn sync_project_dependency(
     base_project: &Project,
     dep_project: &Project,
     dep_relative_path: &str,
-    protocol: &NodeVersionProtocol,
+    format: &NodeVersionFormat,
 ) -> Result<bool, ActionError> {
     if let Some(dep_package_json) = PackageJson::read(&dep_project.root)? {
-        let version_prefix = protocol.get_prefix();
-        let dep_version = match protocol {
-            NodeVersionProtocol::File | NodeVersionProtocol::Link => {
+        let version_prefix = format.get_prefix();
+        let dep_version = match format {
+            NodeVersionFormat::File | NodeVersionFormat::Link => {
                 format!("{}{}", version_prefix, dep_relative_path)
             }
-            NodeVersionProtocol::Version
-            | NodeVersionProtocol::VersionCaret
-            | NodeVersionProtocol::VersionTilde => format!(
+            NodeVersionFormat::Version
+            | NodeVersionFormat::VersionCaret
+            | NodeVersionFormat::VersionTilde => format!(
                 "{}{}",
                 version_prefix,
                 dep_package_json.version.unwrap_or_default()
@@ -155,7 +155,7 @@ pub async fn sync_node_project(
                 &project,
                 &dep_project,
                 &dep_relative_path,
-                &node_config.dependency_version_protocol,
+                &node_config.dependency_version_format,
             )?
         {
             mutated_files = true;

--- a/crates/cli/tests/run_node_test.rs
+++ b/crates/cli/tests/run_node_test.rs
@@ -419,13 +419,15 @@ mod version_manager {
 mod sync_depends_on {
     use super::*;
 
-    #[test]
-    fn syncs_as_dependency_to_package_json() {
+    fn test_depends_on_format(format: &str) {
         let fixture = create_sandbox_with_git("cases");
 
         append_workspace_config(
             &fixture.path().join(".moon/workspace.yml"),
-            "  syncProjectWorkspaceDependencies: true",
+            &format!(
+                "  syncProjectWorkspaceDependencies: true\n  dependencyVersionFormat: {}",
+                format
+            ),
         );
 
         create_moon_command(fixture.path())
@@ -434,7 +436,55 @@ mod sync_depends_on {
             .assert();
 
         // deps-c does not have a `package.json` on purpose
-        assert_snapshot!(read_to_string(fixture.path().join("depends-on/package.json")).unwrap());
+        assert_snapshot!(
+            format!("format_{}", format),
+            read_to_string(fixture.path().join("depends-on/package.json")).unwrap()
+        );
+    }
+
+    #[test]
+    fn syncs_as_file_dependency() {
+        test_depends_on_format("file");
+    }
+
+    #[test]
+    fn syncs_as_link_dependency() {
+        test_depends_on_format("link");
+    }
+
+    #[test]
+    fn syncs_as_star_dependency() {
+        test_depends_on_format("star");
+    }
+
+    #[test]
+    fn syncs_as_version_dependency() {
+        test_depends_on_format("version");
+    }
+
+    #[test]
+    fn syncs_as_version_caret_dependency() {
+        test_depends_on_format("version-caret");
+    }
+
+    #[test]
+    fn syncs_as_version_tilde_dependency() {
+        test_depends_on_format("version-tilde");
+    }
+
+    #[test]
+    fn syncs_as_workspace_dependency() {
+        test_depends_on_format("workspace");
+    }
+
+    #[test]
+    fn syncs_as_workspace_caret_dependency() {
+        test_depends_on_format("workspace-caret");
+    }
+
+    #[test]
+    fn syncs_as_workspace_tilde_dependency() {
+        test_depends_on_format("workspace-tilde");
     }
 
     #[test]

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
@@ -40,8 +40,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
@@ -40,8 +40,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
@@ -40,8 +40,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
@@ -40,8 +40,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/cli/tests/snapshots/init_test__node__infers_version_from_nodenv.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_version_from_nodenv.snap
@@ -39,8 +39,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/cli/tests/snapshots/init_test__node__infers_version_from_nvm.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_version_from_nvm.snap
@@ -39,8 +39,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm.snap
@@ -39,8 +39,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm_from_package.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm_from_package.snap
@@ -43,8 +43,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm.snap
@@ -43,8 +43,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm_from_package.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm_from_package.snap
@@ -43,8 +43,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn.snap
@@ -43,8 +43,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn_from_package.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn_from_package.snap
@@ -43,8 +43,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_file.snap
+++ b/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_file.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli/tests/run_node_test.rs
+assertion_line: 439
+expression: "read_to_string(fixture.path().join(\"depends-on/package.json\")).unwrap()"
+---
+{
+  "name": "test-cases-depends-on",
+  "dependencies": {
+    "react": "17.0.0",
+    "test-cases-deps-a": "file:../deps-a",
+    "test-cases-deps-b": "file:../deps-b"
+  }
+}
+

--- a/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_link.snap
+++ b/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_link.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli/tests/run_node_test.rs
+assertion_line: 439
+expression: "read_to_string(fixture.path().join(\"depends-on/package.json\")).unwrap()"
+---
+{
+  "name": "test-cases-depends-on",
+  "dependencies": {
+    "react": "17.0.0",
+    "test-cases-deps-a": "link:../deps-a",
+    "test-cases-deps-b": "link:../deps-b"
+  }
+}
+

--- a/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_star.snap
+++ b/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_star.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli/tests/run_node_test.rs
+assertion_line: 439
+expression: "read_to_string(fixture.path().join(\"depends-on/package.json\")).unwrap()"
+---
+{
+  "name": "test-cases-depends-on",
+  "dependencies": {
+    "react": "17.0.0",
+    "test-cases-deps-a": "*",
+    "test-cases-deps-b": "*"
+  }
+}
+

--- a/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_version-caret.snap
+++ b/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_version-caret.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli/tests/run_node_test.rs
+assertion_line: 439
+expression: "read_to_string(fixture.path().join(\"depends-on/package.json\")).unwrap()"
+---
+{
+  "name": "test-cases-depends-on",
+  "dependencies": {
+    "react": "17.0.0",
+    "test-cases-deps-a": "^1.2.3",
+    "test-cases-deps-b": "^4.5.6"
+  }
+}
+

--- a/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_version-tilde.snap
+++ b/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_version-tilde.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/cli/tests/run_node_test.rs
-assertion_line: 437
+assertion_line: 439
 expression: "read_to_string(fixture.path().join(\"depends-on/package.json\")).unwrap()"
 ---
 {
   "name": "test-cases-depends-on",
   "dependencies": {
     "react": "17.0.0",
-    "test-cases-deps-a": "workspace:^",
-    "test-cases-deps-b": "workspace:^"
+    "test-cases-deps-a": "~1.2.3",
+    "test-cases-deps-b": "~4.5.6"
   }
 }
 

--- a/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_version.snap
+++ b/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_version.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli/tests/run_node_test.rs
+assertion_line: 439
+expression: "read_to_string(fixture.path().join(\"depends-on/package.json\")).unwrap()"
+---
+{
+  "name": "test-cases-depends-on",
+  "dependencies": {
+    "react": "17.0.0",
+    "test-cases-deps-a": "1.2.3",
+    "test-cases-deps-b": "4.5.6"
+  }
+}
+

--- a/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_workspace-caret.snap
+++ b/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_workspace-caret.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli/tests/run_node_test.rs
+assertion_line: 439
+expression: "read_to_string(fixture.path().join(\"depends-on/package.json\")).unwrap()"
+---
+{
+  "name": "test-cases-depends-on",
+  "dependencies": {
+    "react": "17.0.0",
+    "test-cases-deps-a": "workspace:^",
+    "test-cases-deps-b": "workspace:^"
+  }
+}
+

--- a/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_workspace-tilde.snap
+++ b/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_workspace-tilde.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli/tests/run_node_test.rs
+assertion_line: 439
+expression: "read_to_string(fixture.path().join(\"depends-on/package.json\")).unwrap()"
+---
+{
+  "name": "test-cases-depends-on",
+  "dependencies": {
+    "react": "17.0.0",
+    "test-cases-deps-a": "workspace:~",
+    "test-cases-deps-b": "workspace:~"
+  }
+}
+

--- a/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_workspace.snap
+++ b/crates/cli/tests/snapshots/run_node_test__sync_depends_on__format_workspace.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli/tests/run_node_test.rs
+assertion_line: 439
+expression: "read_to_string(fixture.path().join(\"depends-on/package.json\")).unwrap()"
+---
+{
+  "name": "test-cases-depends-on",
+  "dependencies": {
+    "react": "17.0.0",
+    "test-cases-deps-a": "workspace:*",
+    "test-cases-deps-b": "workspace:*"
+  }
+}
+

--- a/crates/cli/tests/snapshots/run_node_test__sync_depends_on__syncs_as_dependency_to_package_json.snap
+++ b/crates/cli/tests/snapshots/run_node_test__sync_depends_on__syncs_as_dependency_to_package_json.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/cli/tests/run_node_test.rs
-assertion_line: 469
+assertion_line: 437
 expression: "read_to_string(fixture.path().join(\"depends-on/package.json\")).unwrap()"
 ---
 {
   "name": "test-cases-depends-on",
   "dependencies": {
     "react": "17.0.0",
-    "test-cases-deps-a": "*",
-    "test-cases-deps-b": "*"
+    "test-cases-deps-a": "workspace:^",
+    "test-cases-deps-b": "workspace:^"
   }
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -12,9 +12,7 @@ pub use project::task::*;
 pub use project::*;
 pub use types::*;
 pub use validator::ValidationErrors;
-pub use workspace::node::{
-    default_node_version, default_npm_version, default_pnpm_version, default_yarn_version,
-};
+pub use workspace::node::*;
 pub use workspace::*;
 
 pub fn load_workspace_config_template() -> &'static str {

--- a/crates/config/src/workspace/mod.rs
+++ b/crates/config/src/workspace/mod.rs
@@ -14,7 +14,7 @@ use figment::{
     Error as FigmentError, Figment,
 };
 use moon_utils::string_vec;
-pub use node::{NodeConfig, NodePackageManager, NpmConfig, PnpmConfig, YarnConfig};
+use node::NodeConfig;
 use schemars::gen::SchemaGenerator;
 use schemars::schema::Schema;
 use schemars::{schema_for, JsonSchema};
@@ -455,6 +455,7 @@ node:
 
     mod node {
         use super::*;
+        use crate::workspace::node::NodePackageManager;
 
         #[test]
         fn loads_defaults() {

--- a/crates/config/src/workspace/node.rs
+++ b/crates/config/src/workspace/node.rs
@@ -43,6 +43,35 @@ fn validate_yarn_version(value: &str) -> Result<(), ValidationError> {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NodeVersionProtocol {
+    File,         // file:..
+    Link,         // link:..
+    Version,      // 0.0.0
+    VersionCaret, // ^0.0.0
+    VersionTilde, // ~0.0.0
+    Workspace,    // workspace:*
+    #[default]
+    WorkspaceCaret, // workspace:^
+    WorkspaceTilde, // workspace:~
+}
+
+impl NodeVersionProtocol {
+    pub fn get_prefix(&self) -> String {
+        match self {
+            NodeVersionProtocol::File => String::from("file:"),
+            NodeVersionProtocol::Link => String::from("link:"),
+            NodeVersionProtocol::Version => String::from(""),
+            NodeVersionProtocol::VersionCaret => String::from("^"),
+            NodeVersionProtocol::VersionTilde => String::from("~"),
+            NodeVersionProtocol::Workspace => String::from("workspace:*"),
+            NodeVersionProtocol::WorkspaceCaret => String::from("workspace:^"),
+            NodeVersionProtocol::WorkspaceTilde => String::from("workspace:~"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum NodePackageManager {
     #[default]

--- a/crates/config/src/workspace/node.rs
+++ b/crates/config/src/workspace/node.rs
@@ -51,8 +51,8 @@ pub enum NodeVersionFormat {
     Version,      // 0.0.0
     VersionCaret, // ^0.0.0
     VersionTilde, // ~0.0.0
-    Workspace,    // workspace:*
     #[default]
+    Workspace, // workspace:*
     WorkspaceCaret, // workspace:^
     WorkspaceTilde, // workspace:~
 }

--- a/crates/config/src/workspace/node.rs
+++ b/crates/config/src/workspace/node.rs
@@ -47,6 +47,7 @@ fn validate_yarn_version(value: &str) -> Result<(), ValidationError> {
 pub enum NodeVersionProtocol {
     File,         // file:..
     Link,         // link:..
+    Star,         // *
     Version,      // 0.0.0
     VersionCaret, // ^0.0.0
     VersionTilde, // ~0.0.0
@@ -61,6 +62,7 @@ impl NodeVersionProtocol {
         match self {
             NodeVersionProtocol::File => String::from("file:"),
             NodeVersionProtocol::Link => String::from("link:"),
+            NodeVersionProtocol::Star => String::from("*"),
             NodeVersionProtocol::Version => String::from(""),
             NodeVersionProtocol::VersionCaret => String::from("^"),
             NodeVersionProtocol::VersionTilde => String::from("~"),
@@ -147,6 +149,8 @@ pub struct NodeConfig {
 
     pub dedupe_on_lockfile_change: bool,
 
+    pub dependency_version_protocol: NodeVersionProtocol,
+
     pub infer_tasks_from_scripts: bool,
 
     #[validate]
@@ -173,6 +177,7 @@ impl Default for NodeConfig {
         NodeConfig {
             add_engines_constraint: true,
             dedupe_on_lockfile_change: true,
+            dependency_version_protocol: NodeVersionProtocol::WorkspaceCaret,
             infer_tasks_from_scripts: false,
             npm: NpmConfig::default(),
             package_manager: NodePackageManager::default(),

--- a/crates/config/src/workspace/node.rs
+++ b/crates/config/src/workspace/node.rs
@@ -44,7 +44,7 @@ fn validate_yarn_version(value: &str) -> Result<(), ValidationError> {
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum NodeVersionProtocol {
+pub enum NodeVersionFormat {
     File,         // file:..
     Link,         // link:..
     Star,         // *
@@ -57,18 +57,18 @@ pub enum NodeVersionProtocol {
     WorkspaceTilde, // workspace:~
 }
 
-impl NodeVersionProtocol {
+impl NodeVersionFormat {
     pub fn get_prefix(&self) -> String {
         match self {
-            NodeVersionProtocol::File => String::from("file:"),
-            NodeVersionProtocol::Link => String::from("link:"),
-            NodeVersionProtocol::Star => String::from("*"),
-            NodeVersionProtocol::Version => String::from(""),
-            NodeVersionProtocol::VersionCaret => String::from("^"),
-            NodeVersionProtocol::VersionTilde => String::from("~"),
-            NodeVersionProtocol::Workspace => String::from("workspace:*"),
-            NodeVersionProtocol::WorkspaceCaret => String::from("workspace:^"),
-            NodeVersionProtocol::WorkspaceTilde => String::from("workspace:~"),
+            NodeVersionFormat::File => String::from("file:"),
+            NodeVersionFormat::Link => String::from("link:"),
+            NodeVersionFormat::Star => String::from("*"),
+            NodeVersionFormat::Version => String::from(""),
+            NodeVersionFormat::VersionCaret => String::from("^"),
+            NodeVersionFormat::VersionTilde => String::from("~"),
+            NodeVersionFormat::Workspace => String::from("workspace:*"),
+            NodeVersionFormat::WorkspaceCaret => String::from("workspace:^"),
+            NodeVersionFormat::WorkspaceTilde => String::from("workspace:~"),
         }
     }
 }
@@ -149,7 +149,7 @@ pub struct NodeConfig {
 
     pub dedupe_on_lockfile_change: bool,
 
-    pub dependency_version_protocol: NodeVersionProtocol,
+    pub dependency_version_format: NodeVersionFormat,
 
     pub infer_tasks_from_scripts: bool,
 
@@ -177,7 +177,7 @@ impl Default for NodeConfig {
         NodeConfig {
             add_engines_constraint: true,
             dedupe_on_lockfile_change: true,
-            dependency_version_protocol: NodeVersionProtocol::WorkspaceCaret,
+            dependency_version_format: NodeVersionFormat::WorkspaceCaret,
             infer_tasks_from_scripts: false,
             npm: NpmConfig::default(),
             package_manager: NodePackageManager::default(),

--- a/crates/config/templates/workspace.yml
+++ b/crates/config/templates/workspace.yml
@@ -46,8 +46,7 @@ node:
   # not a 1:1 in functionality, so please refer to the documentation.
   inferTasksFromScripts: true
 
-  # Sync a project's `dependsOn` as normal dependencies within the project's
-  # `package.json`. Will use "workspace:*" ranges when available in the package manager.
+  # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
 
   # Sync `node.version` to a 3rd-party version manager's config file.

--- a/crates/toolchain/src/pms/npm.rs
+++ b/crates/toolchain/src/pms/npm.rs
@@ -264,10 +264,6 @@ impl PackageManager<NodeTool> for NpmTool {
         String::from(NPM.manifest_filename)
     }
 
-    fn get_workspace_dependency_range(&self) -> String {
-        String::from("*") // Doesn't support "workspace:*"
-    }
-
     async fn install_dependencies(&self, toolchain: &Toolchain) -> Result<(), ToolchainError> {
         let mut args = vec!["install"];
 

--- a/crates/toolchain/src/pms/pnpm.rs
+++ b/crates/toolchain/src/pms/pnpm.rs
@@ -198,11 +198,6 @@ impl PackageManager<NodeTool> for PnpmTool {
         String::from(PNPM.manifest_filename)
     }
 
-    fn get_workspace_dependency_range(&self) -> String {
-        // https://pnpm.io/workspaces#workspace-protocol-workspace
-        String::from("workspace:*")
-    }
-
     async fn install_dependencies(&self, toolchain: &Toolchain) -> Result<(), ToolchainError> {
         let mut args = vec!["install"];
         let lockfile = toolchain.workspace_root.join(self.get_lock_filename());

--- a/crates/toolchain/src/pms/yarn.rs
+++ b/crates/toolchain/src/pms/yarn.rs
@@ -255,15 +255,6 @@ impl PackageManager<NodeTool> for YarnTool {
         String::from(YARN.manifest_filename)
     }
 
-    fn get_workspace_dependency_range(&self) -> String {
-        if self.is_v1() {
-            String::from("*")
-        } else {
-            // https://yarnpkg.com/features/workspaces/#workspace-ranges-workspace
-            String::from("workspace:*")
-        }
-    }
-
     async fn install_dependencies(&self, toolchain: &Toolchain) -> Result<(), ToolchainError> {
         let mut args = vec!["install"];
 

--- a/crates/toolchain/src/traits.rs
+++ b/crates/toolchain/src/traits.rs
@@ -246,9 +246,6 @@ pub trait PackageManager<T: Send + Sync>:
     /// Return the name of the manifest.
     fn get_manifest_filename(&self) -> String;
 
-    /// Return the dependency range to use when linking local workspace packages.
-    fn get_workspace_dependency_range(&self) -> String;
-
     /// Install dependencies for a defined manifest.
     async fn install_dependencies(&self, toolchain: &Toolchain) -> Result<(), ToolchainError>;
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -15,6 +15,8 @@ previous builds are no longer valid and can be removed.
 - Added `batch` as a supported value for the project `language` setting (Windows counter-part to
   `bash`).
 - Added a `cache` option to tasks, which will disable smart hashing and output caching.
+- Added a `node.dependencyVersionFormat` setting to `.moon/workspace.yml`, to customize the version
+  format when syncing dependencies.
 - Added environment variable support to task `inputs` and `actionRunner.implicitInputs`, in the
   format of `$ENV_VAR`.
 

--- a/tests/fixtures/cases/deps-a/package.json
+++ b/tests/fixtures/cases/deps-a/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "test-cases-deps-a"
+  "name": "test-cases-deps-a",
+  "version": "1.2.3"
 }

--- a/tests/fixtures/cases/deps-b/package.json
+++ b/tests/fixtures/cases/deps-b/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "test-cases-deps-b"
+  "name": "test-cases-deps-b",
+  "version": "4.5.6"
 }

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -241,6 +241,32 @@ node:
   dedupeOnLockfileChange: true
 ```
 
+### `dependencyVersionFormat`
+
+> `NodeVersionFormat`
+
+When [syncing project dependencies](#syncprojectworkspacedependencies), customize the format that
+will be used for the dependency version range. The following formats are supported (but use the one
+most applicable to your chosen package manager):
+
+- `file` - Uses `file:../relative/path` and copies package contents.
+- `link` - Uses `link:../relative/path` and symlinks package contents.
+- `star` - Uses an explicit `*`.
+- `version` - Uses the explicit version from the dependent project's `package.json`, e.g., "1.2.3".
+- `version-caret` - Uses the version from the dependent project's `package.json` as a caret range,
+  e.g., "^1.2.3".
+- `version-tilde` - Uses the version from the dependent project's `package.json` as a tilde range,
+  e.g., "~1.2.3".
+- `workspace` - Uses `workspace:*`, which resolves to "1.2.3". Requires package workspaces.
+- `workspace-caret` (default) - Uses `workspace:^`, which resolves to "^1.2.3". Requires package
+  workspaces.
+- `workspace-tilde` - Uses `workspace:~`, which resolves to "~1.2.3". Requires package workspaces.
+
+```yaml title=".moon/workspace.yml" {2}
+node:
+  dependencyVersionFormat: 'link'
+```
+
 ### `inferTasksFromScripts`
 
 > `boolean`
@@ -279,9 +305,9 @@ this feature, especially in regards to `runInCI`, as it may be inaccurate!
 > `boolean`
 
 Will sync a project's [`dependsOn`](./project#dependson) setting as normal dependencies within the
-project's `package.json`, using `workspace:*` or `*` version ranges (depending on what the package
-manager supports). If a dependent project does not have a `package.json`, or if a dependency of the
-same name has an explicit version already defined, the sync will be skipped. Defaults to `true`.
+project's `package.json`. If a dependent project does not have a `package.json`, or if a dependency
+of the same name has an explicit version already defined, the sync will be skipped. Defaults to
+`true`.
 
 ```yaml title=".moon/workspace.yml" {2}
 node:
@@ -296,7 +322,8 @@ dependsOn:
   - 'reactHooks'
 ```
 
-Would result in the following `dependencies` within a project's `package.json`.
+Would result in the following `dependencies` within a project's `package.json`. The version format
+can be customized with [`node.dependencyVersionFormat`](#dependencyversionformat).
 
 ```json title="package.json"
 {

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -257,9 +257,9 @@ most applicable to your chosen package manager):
   e.g., "^1.2.3".
 - `version-tilde` - Uses the version from the dependent project's `package.json` as a tilde range,
   e.g., "~1.2.3".
-- `workspace` - Uses `workspace:*`, which resolves to "1.2.3". Requires package workspaces.
-- `workspace-caret` (default) - Uses `workspace:^`, which resolves to "^1.2.3". Requires package
+- `workspace` (default) - Uses `workspace:*`, which resolves to "1.2.3". Requires package
   workspaces.
+- `workspace-caret` - Uses `workspace:^`, which resolves to "^1.2.3". Requires package workspaces.
 - `workspace-tilde` - Uses `workspace:~`, which resolves to "~1.2.3". Requires package workspaces.
 
 ```yaml title=".moon/workspace.yml" {2}

--- a/website/docs/guides/ci.mdx
+++ b/website/docs/guides/ci.mdx
@@ -1,5 +1,5 @@
 ---
-title: Continuous integration
+title: Continuous integration (CI)
 ---
 
 import Tabs from '@theme/Tabs';

--- a/website/static/schemas/global-project.json
+++ b/website/static/schemas/global-project.json
@@ -115,6 +115,12 @@
     "TaskOptionsConfig": {
       "type": "object",
       "properties": {
+        "cache": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "mergeArgs": {
           "anyOf": [
             {

--- a/website/static/schemas/project.json
+++ b/website/static/schemas/project.json
@@ -221,6 +221,12 @@
     "TaskOptionsConfig": {
       "type": "object",
       "properties": {
+        "cache": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "mergeArgs": {
           "anyOf": [
             {

--- a/website/static/schemas/workspace.json
+++ b/website/static/schemas/workspace.json
@@ -31,6 +31,7 @@
       "default": {
         "addEnginesConstraint": true,
         "dedupeOnLockfileChange": true,
+        "dependencyVersionFormat": "workspace-caret",
         "inferTasksFromScripts": false,
         "npm": {
           "version": "inherit"
@@ -128,6 +129,14 @@
           "default": true,
           "type": "boolean"
         },
+        "dependencyVersionFormat": {
+          "default": "workspace-caret",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NodeVersionFormat"
+            }
+          ]
+        },
         "inferTasksFromScripts": {
           "default": false,
           "type": "boolean"
@@ -199,6 +208,20 @@
         "npm",
         "pnpm",
         "yarn"
+      ]
+    },
+    "NodeVersionFormat": {
+      "type": "string",
+      "enum": [
+        "file",
+        "link",
+        "star",
+        "version",
+        "version-caret",
+        "version-tilde",
+        "workspace",
+        "workspace-caret",
+        "workspace-tilde"
       ]
     },
     "NodeVersionManager": {


### PR DESCRIPTION
Keep everything in sync with the version format of your choice!