### PR TITLE
new: Store task outputs as `.tar.gz` files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,7 @@ dependencies = [
  "moon_vcs",
  "moon_workspace",
  "predicates",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "moon_archive"
+version = "0.1.0"
+dependencies = [
+ "flate2",
+ "moon_error",
+ "moon_logger",
+ "moon_utils",
+ "tar",
+ "zip",
+]
+
+[[package]]
 name = "moon_cache"
 version = "0.1.0"
 dependencies = [
@@ -1554,8 +1566,8 @@ version = "0.1.0"
 dependencies = [
  "assert_fs",
  "async-trait",
- "flate2",
  "mockito",
+ "moon_archive",
  "moon_config",
  "moon_constants",
  "moon_error",
@@ -1566,10 +1578,8 @@ dependencies = [
  "predicates",
  "reqwest",
  "sha2",
- "tar",
  "thiserror",
  "tokio",
- "zip",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,7 @@ dependencies = [
  "moon_logger",
  "moon_utils",
  "tar",
+ "thiserror",
  "zip",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,7 @@ version = "0.1.0"
 dependencies = [
  "assert_fs",
  "filetime",
+ "moon_archive",
  "moon_constants",
  "moon_error",
  "moon_logger",

--- a/crates/action-runner/src/dep_graph.rs
+++ b/crates/action-runner/src/dep_graph.rs
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet};
 
 pub use petgraph::graph::NodeIndex;
 
-const TARGET: &str = "moon:dep-graph";
+const LOG_TARGET: &str = "moon:dep-graph";
 
 fn get_lang_from_project(project: &Project) -> SupportedLanguage {
     match &project.config.language {
@@ -38,7 +38,7 @@ pub struct DepGraph {
 
 impl DepGraph {
     pub fn default() -> Self {
-        debug!(target: TARGET, "Creating dependency graph",);
+        debug!(target: LOG_TARGET, "Creating dependency graph",);
 
         let mut graph: DepGraphType = Graph::new();
         let setup_toolchain_index = graph.add_node(Node::SetupToolchain);
@@ -76,7 +76,11 @@ impl DepGraph {
             return *index;
         }
 
-        trace!(target: TARGET, "Installing {} dependencies", lang.label());
+        trace!(
+            target: LOG_TARGET,
+            "Installing {} dependencies",
+            lang.label()
+        );
 
         let setup_toolchain_index = self.get_or_insert_node(Node::SetupToolchain);
         let install_deps_index = self.get_or_insert_node(node);
@@ -150,7 +154,7 @@ impl DepGraph {
         projects: &ProjectGraph,
     ) -> Result<(), DepGraphError> {
         trace!(
-            target: TARGET,
+            target: LOG_TARGET,
             "Adding dependents to run for target {}",
             color::target(&target.id),
         );
@@ -254,7 +258,7 @@ impl DepGraph {
         }
 
         trace!(
-            target: TARGET,
+            target: LOG_TARGET,
             "Syncing project {} configs and dependencies",
             color::id(project_id),
         );
@@ -346,7 +350,7 @@ impl DepGraph {
         if let Some(touched) = touched_files {
             if !project.get_task(task_id)?.is_affected(touched)? {
                 trace!(
-                    target: TARGET,
+                    target: LOG_TARGET,
                     "Project {} task {} not affected based on touched files, skipping",
                     color::id(project_id),
                     color::id(task_id),
@@ -357,7 +361,7 @@ impl DepGraph {
         }
 
         trace!(
-            target: TARGET,
+            target: LOG_TARGET,
             "Target {} does not exist in the dependency graph, inserting",
             color::target(&target_id),
         );
@@ -377,7 +381,7 @@ impl DepGraph {
 
         if !task.deps.is_empty() {
             trace!(
-                target: TARGET,
+                target: LOG_TARGET,
                 "Adding dependencies {} from target {}",
                 map_list(&task.deps, |f| color::symbol(f)),
                 color::target(&target_id),

--- a/crates/action/src/run_target.rs
+++ b/crates/action/src/run_target.rs
@@ -53,12 +53,6 @@ pub async fn run_target(
         };
 
         if let Some(cache_location) = runner.is_cached(common_hasher, platform_hasher).await? {
-            debug!(
-                target: LOG_TARGET,
-                "Hash exists for {}, using cache",
-                color::id(target_id),
-            );
-
             // Only hydrate when the hash is different from the previous build,
             // as we can assume the outputs from the previous build still exist?
             if matches!(cache_location, CacheLocation::Local) {

--- a/crates/action/src/run_target.rs
+++ b/crates/action/src/run_target.rs
@@ -59,6 +59,7 @@ pub async fn run_target(
                 color::id(target_id),
             );
 
+            runner.hydrate_outputs().await?;
             runner.print_checkpoint(Checkpoint::Pass, "(cached)");
             runner.print_cache_item();
 

--- a/crates/action/src/run_target.rs
+++ b/crates/action/src/run_target.rs
@@ -1,7 +1,7 @@
 use crate::action::{Action, ActionStatus};
 use crate::context::ActionContext;
 use crate::errors::ActionError;
-use crate::target::{node, system, CacheLocation, TargetRunner};
+use crate::target::{node, system, HydrateFrom, TargetRunner};
 use moon_config::PlatformType;
 use moon_logger::{color, debug};
 use moon_task::Target;
@@ -55,7 +55,7 @@ pub async fn run_target(
         if let Some(cache_location) = runner.is_cached(common_hasher, platform_hasher).await? {
             // Only hydrate when the hash is different from the previous build,
             // as we can assume the outputs from the previous build still exist?
-            if matches!(cache_location, CacheLocation::Local) {
+            if matches!(cache_location, HydrateFrom::LocalCache) {
                 runner.hydrate_outputs().await?;
             }
 

--- a/crates/action/src/target/runner.rs
+++ b/crates/action/src/target/runner.rs
@@ -54,12 +54,10 @@ impl<'a> TargetRunner<'a> {
         let hash = &self.cache.item.hash;
 
         if !hash.is_empty() {
-            for output_path in &self.task.output_paths {
-                self.workspace
-                    .cache
-                    .copy_output_to_out(hash, &self.project.root, output_path)
-                    .await?;
-            }
+            self.workspace
+                .cache
+                .create_hash_archive(hash, &self.project.root, &self.task.outputs)
+                .await?;
         }
 
         Ok(())
@@ -202,7 +200,7 @@ impl<'a> TargetRunner<'a> {
 
         self.workspace
             .cache
-            .save_hash(&hash, &(common_hasher, platform_hasher))
+            .create_hash_manifest(&hash, &(common_hasher, platform_hasher))
             .await?;
 
         self.cache.item.hash = hash;

--- a/crates/action/src/target/runner.rs
+++ b/crates/action/src/target/runner.rs
@@ -218,6 +218,12 @@ impl<'a> TargetRunner<'a> {
         // Hash is the same as the previous build, so simply abort!
         // However, ensure the outputs also exist, otherwise we should hydrate.
         if self.cache.item.hash == hash && self.has_outputs() {
+            debug!(
+                target: LOG_TARGET,
+                "Cache hit for hash {}, reusing previous build",
+                color::symbol(&hash),
+            );
+
             return Ok(Some(CacheLocation::Previous));
         }
 
@@ -231,8 +237,20 @@ impl<'a> TargetRunner<'a> {
 
         // Hash exists in the cache, so hydrate from it
         if self.workspace.cache.is_hash_cached(&hash) {
+            debug!(
+                target: LOG_TARGET,
+                "Cache hit for hash {}, hydrating from local cache",
+                color::symbol(&hash),
+            );
+
             return Ok(Some(CacheLocation::Local));
         }
+
+        debug!(
+            target: LOG_TARGET,
+            "Cache miss for hash {}, continuing run",
+            color::symbol(&hash),
+        );
 
         Ok(None)
     }

--- a/crates/action/src/target/runner.rs
+++ b/crates/action/src/target/runner.rs
@@ -53,10 +53,25 @@ impl<'a> TargetRunner<'a> {
     pub async fn cache_outputs(&self) -> Result<(), ActionError> {
         let hash = &self.cache.item.hash;
 
-        if !hash.is_empty() {
+        if !hash.is_empty() && !self.task.outputs.is_empty() {
             self.workspace
                 .cache
                 .create_hash_archive(hash, &self.project.root, &self.task.outputs)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// If we are cached (hash match), hydrate the project with the
+    /// cached task outputs found in the hashed archive.
+    pub async fn hydrate_outputs(&self) -> Result<(), ActionError> {
+        let hash = &self.cache.item.hash;
+
+        if !hash.is_empty() {
+            self.workspace
+                .cache
+                .hydrate_from_hash_archive(hash, &self.project.root)
                 .await?;
         }
 

--- a/crates/action/src/target/runner.rs
+++ b/crates/action/src/target/runner.rs
@@ -79,6 +79,9 @@ impl<'a> TargetRunner<'a> {
                 .cache
                 .hydrate_from_hash_archive(hash, &self.project.root)
                 .await?;
+
+            // Update the run state with the new hash
+            self.cache.save().await?;
         }
 
         Ok(())

--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -6,10 +6,8 @@ edition = "2021"
 [dependencies]
 moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }
+moon_utils = { path = "../utils" }
 flate2 = "1.0.24"
 tar = "0.4.38"
 thiserror = "1.0.31"
 zip = "0.6.2"
-
-[dev-dependencies]
-moon_utils = { path = "../utils" }

--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -8,6 +8,7 @@ moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }
 flate2 = "1.0.24"
 tar = "0.4.38"
+thiserror = "1.0.31"
 zip = "0.6.2"
 
 [dev-dependencies]

--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "moon_archive"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+moon_error = { path = "../error" }
+moon_logger = { path = "../logger" }
+flate2 = "1.0.24"
+tar = "0.4.38"
+zip = "0.6.2"
+
+[dev-dependencies]
+moon_utils = { path = "../utils" }

--- a/crates/archive/src/errors.rs
+++ b/crates/archive/src/errors.rs
@@ -1,0 +1,15 @@
+use moon_error::MoonError;
+use thiserror::Error;
+use zip::result::ZipError;
+
+#[derive(Error, Debug)]
+pub enum ArchiveError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Moon(#[from] MoonError),
+
+    #[error(transparent)]
+    Zip(#[from] ZipError),
+}

--- a/crates/archive/src/helpers.rs
+++ b/crates/archive/src/helpers.rs
@@ -1,6 +1,7 @@
 use moon_error::{map_io_to_fs_error, MoonError};
+use moon_utils::path;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub fn ensure_dir(dir: &Path) -> Result<(), MoonError> {
     if !dir.exists() {
@@ -12,8 +13,12 @@ pub fn ensure_dir(dir: &Path) -> Result<(), MoonError> {
 
 pub fn prepend_name(name: &str, prefix: &str) -> String {
     if prefix.is_empty() {
-        name.to_owned()
-    } else {
-        format!("{}/{}", prefix, name)
+        return name.to_owned();
     }
+
+    // Use native path utils to join the paths, so we can ensure
+    // the parts are joined correctly within the archive!
+    let parts: PathBuf = [prefix, name].iter().collect();
+
+    path::normalize(parts).to_string_lossy().to_string()
 }

--- a/crates/archive/src/helpers.rs
+++ b/crates/archive/src/helpers.rs
@@ -1,3 +1,15 @@
+use moon_error::{map_io_to_fs_error, MoonError};
+use std::fs;
+use std::path::Path;
+
+pub fn ensure_dir(dir: &Path) -> Result<(), MoonError> {
+    if !dir.exists() {
+        fs::create_dir_all(dir).map_err(|e| map_io_to_fs_error(e, dir.to_path_buf()))?;
+    }
+
+    Ok(())
+}
+
 pub fn prepend_name(name: &str, prefix: &str) -> String {
     if prefix.is_empty() {
         name.to_owned()

--- a/crates/archive/src/helpers.rs
+++ b/crates/archive/src/helpers.rs
@@ -1,0 +1,7 @@
+pub fn prepend_name(name: &str, prefix: &str) -> String {
+    if prefix.is_empty() {
+        name.to_owned()
+    } else {
+        format!("{}/{}", prefix, name)
+    }
+}

--- a/crates/archive/src/lib.rs
+++ b/crates/archive/src/lib.rs
@@ -1,3 +1,4 @@
+mod helpers;
 mod tar;
 mod zip;
 

--- a/crates/archive/src/lib.rs
+++ b/crates/archive/src/lib.rs
@@ -1,0 +1,5 @@
+mod tar;
+mod zip;
+
+pub use crate::tar::*;
+pub use crate::zip::*;

--- a/crates/archive/src/lib.rs
+++ b/crates/archive/src/lib.rs
@@ -1,6 +1,8 @@
+mod errors;
 mod helpers;
 mod tar;
 mod zip;
 
 pub use crate::tar::*;
 pub use crate::zip::*;
+pub use errors::ArchiveError;

--- a/crates/archive/src/tar.rs
+++ b/crates/archive/src/tar.rs
@@ -2,10 +2,12 @@ use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use moon_error::{map_io_to_fs_error, MoonError};
-use moon_logger::{color, trace};
+use moon_logger::{color, debug, trace};
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use tar::{Archive, Builder};
+
+const TARGET: &str = "moon:archive:tar";
 
 #[track_caller]
 pub fn tar<I: AsRef<Path>, O: AsRef<Path>>(
@@ -16,8 +18,8 @@ pub fn tar<I: AsRef<Path>, O: AsRef<Path>>(
     let input_src = input_src.as_ref();
     let output_file = output_file.as_ref();
 
-    trace!(
-        target: "moon:archive:tar",
+    debug!(
+        target: TARGET,
         "Packing tar archive with {} to {}",
         color::path(input_src),
         color::path(output_file),
@@ -45,6 +47,8 @@ pub fn tar<I: AsRef<Path>, O: AsRef<Path>>(
             },
             &mut file,
         )?;
+
+        trace!(target: TARGET, "Packing file {}", color::path(&input_src));
     } else {
         archive.append_dir_all(base_prefix.unwrap_or("."), input_src)?;
     }
@@ -63,8 +67,8 @@ pub fn untar<I: AsRef<Path>, O: AsRef<Path>>(
     let input_file = input_file.as_ref();
     let output_dir = output_dir.as_ref();
 
-    trace!(
-        target: "moon:archive:tar",
+    debug!(
+        target: TARGET,
         "Unpacking tar archive {} to {}",
         color::path(input_file),
         color::path(output_dir),
@@ -107,6 +111,12 @@ pub fn untar<I: AsRef<Path>, O: AsRef<Path>>(
         }
 
         entry.unpack(&output_path)?;
+
+        trace!(
+            target: TARGET,
+            "Unpacking file {}",
+            color::path(&output_path)
+        );
     }
 
     Ok(())

--- a/crates/archive/src/tar.rs
+++ b/crates/archive/src/tar.rs
@@ -8,7 +8,7 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use tar::{Archive, Builder};
 
-const TARGET: &str = "moon:archive:tar";
+const LOG_TARGET: &str = "moon:archive:tar";
 
 #[track_caller]
 pub fn tar<I: AsRef<Path>, O: AsRef<Path>>(
@@ -21,7 +21,7 @@ pub fn tar<I: AsRef<Path>, O: AsRef<Path>>(
     let output_file = output_file.as_ref();
 
     debug!(
-        target: TARGET,
+        target: LOG_TARGET,
         "Packing tar archive from {} with {} to {}",
         color::path(input_root),
         map_list(files, |f| color::file(f)),
@@ -48,7 +48,11 @@ pub fn tar<I: AsRef<Path>, O: AsRef<Path>>(
             .unwrap_or_default();
 
         if input_src.is_file() {
-            trace!(target: TARGET, "Packing file {}", color::path(&input_src));
+            trace!(
+                target: LOG_TARGET,
+                "Packing file {}",
+                color::path(&input_src)
+            );
 
             let mut file = File::open(&input_src)
                 .map_err(|e| map_io_to_fs_error(e, input_src.to_path_buf()))?;
@@ -56,7 +60,7 @@ pub fn tar<I: AsRef<Path>, O: AsRef<Path>>(
             archive.append_file(prepend_name(name, prefix), &mut file)?;
         } else {
             trace!(
-                target: TARGET,
+                target: LOG_TARGET,
                 "Packing directory {}",
                 color::path(&input_src)
             );
@@ -80,7 +84,7 @@ pub fn untar<I: AsRef<Path>, O: AsRef<Path>>(
     let output_dir = output_dir.as_ref();
 
     debug!(
-        target: TARGET,
+        target: LOG_TARGET,
         "Unpacking tar archive {} to {}",
         color::path(input_file),
         color::path(output_dir),
@@ -119,7 +123,7 @@ pub fn untar<I: AsRef<Path>, O: AsRef<Path>>(
         entry.unpack(&output_path)?;
 
         trace!(
-            target: TARGET,
+            target: LOG_TARGET,
             "Unpacking file {}",
             color::path(&output_path)
         );

--- a/crates/archive/src/tar.rs
+++ b/crates/archive/src/tar.rs
@@ -1,0 +1,111 @@
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use moon_error::{map_io_to_fs_error, MoonError};
+use moon_logger::{color, trace};
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use tar::{Archive, Builder};
+
+#[track_caller]
+pub fn tar<I: AsRef<Path>, O: AsRef<Path>>(
+    input_src: I,
+    output_file: O,
+    base_prefix: Option<&str>,
+) -> Result<(), MoonError> {
+    let input_src = input_src.as_ref();
+    let output_file = output_file.as_ref();
+
+    trace!(
+        target: "moon:archive:tar",
+        "Packing tar archive with {} to {}",
+        color::path(input_src),
+        color::path(output_file),
+    );
+
+    // Create .tar
+    let tar =
+        File::create(output_file).map_err(|e| map_io_to_fs_error(e, output_file.to_path_buf()))?;
+
+    // Compress to .tar.gz
+    let tar_gz = GzEncoder::new(tar, Compression::fast());
+
+    // Add the files to the archive
+    let mut archive = Builder::new(tar_gz);
+
+    if input_src.is_file() {
+        let mut file =
+            File::open(input_src).map_err(|e| map_io_to_fs_error(e, input_src.to_path_buf()))?;
+        let file_name = input_src.file_name().unwrap().to_str().unwrap();
+
+        archive.append_file(
+            match base_prefix {
+                Some(prefix) => format!("{}/{}", prefix, file_name),
+                None => file_name.to_owned(),
+            },
+            &mut file,
+        )?;
+    } else {
+        archive.append_dir_all(base_prefix.unwrap_or("."), input_src)?;
+    }
+
+    archive.finish()?;
+
+    Ok(())
+}
+
+#[track_caller]
+pub fn untar<I: AsRef<Path>, O: AsRef<Path>>(
+    input_file: I,
+    output_dir: O,
+    remove_prefix: Option<&str>,
+) -> Result<(), MoonError> {
+    let input_file = input_file.as_ref();
+    let output_dir = output_dir.as_ref();
+
+    trace!(
+        target: "moon:archive:tar",
+        "Unpacking tar archive {} to {}",
+        color::path(input_file),
+        color::path(output_dir),
+    );
+
+    if !output_dir.exists() {
+        fs::create_dir_all(output_dir)
+            .map_err(|e| map_io_to_fs_error(e, output_dir.to_path_buf()))?;
+    }
+
+    // Open .tar.gz file
+    let tar_gz =
+        File::open(input_file).map_err(|e| map_io_to_fs_error(e, input_file.to_path_buf()))?;
+
+    // Decompress to .tar
+    let tar = GzDecoder::new(tar_gz);
+
+    // Unpack the archive into the output dir
+    let mut archive = Archive::new(tar);
+
+    for entry_result in archive.entries()? {
+        let mut entry = entry_result?;
+        let mut path: PathBuf = entry.path()?.to_owned().to_path_buf();
+
+        // Remove the prefix
+        if let Some(prefix) = remove_prefix {
+            if path.starts_with(prefix) {
+                path = path.strip_prefix(&prefix).unwrap().to_owned();
+            }
+        }
+
+        let output_path = output_dir.join(path);
+
+        // Create parent dirs
+        if let Some(parent_dir) = output_path.parent() {
+            fs::create_dir_all(parent_dir)
+                .map_err(|e| map_io_to_fs_error(e, parent_dir.to_path_buf()))?;
+        }
+
+        entry.unpack(&output_path)?;
+    }
+
+    Ok(())
+}

--- a/crates/archive/src/tar.rs
+++ b/crates/archive/src/tar.rs
@@ -1,8 +1,9 @@
+use crate::errors::ArchiveError;
 use crate::helpers::{ensure_dir, prepend_name};
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use moon_error::{map_io_to_fs_error, MoonError};
+use moon_error::map_io_to_fs_error;
 use moon_logger::{color, debug, map_list, trace};
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -16,7 +17,7 @@ pub fn tar<I: AsRef<Path>, O: AsRef<Path>>(
     files: &[String],
     output_file: O,
     base_prefix: Option<&str>,
-) -> Result<(), MoonError> {
+) -> Result<(), ArchiveError> {
     let input_root = input_root.as_ref();
     let output_file = output_file.as_ref();
 
@@ -79,7 +80,7 @@ pub fn untar<I: AsRef<Path>, O: AsRef<Path>>(
     input_file: I,
     output_dir: O,
     remove_prefix: Option<&str>,
-) -> Result<(), MoonError> {
+) -> Result<(), ArchiveError> {
     let input_file = input_file.as_ref();
     let output_dir = output_dir.as_ref();
 

--- a/crates/archive/src/tar.rs
+++ b/crates/archive/src/tar.rs
@@ -100,8 +100,10 @@ pub fn untar<I: AsRef<Path>, O: AsRef<Path>>(
 
         // Create parent dirs
         if let Some(parent_dir) = output_path.parent() {
-            fs::create_dir_all(parent_dir)
-                .map_err(|e| map_io_to_fs_error(e, parent_dir.to_path_buf()))?;
+            if !parent_dir.exists() {
+                fs::create_dir_all(parent_dir)
+                    .map_err(|e| map_io_to_fs_error(e, parent_dir.to_path_buf()))?;
+            }
         }
 
         entry.unpack(&output_path)?;

--- a/crates/archive/src/tar.rs
+++ b/crates/archive/src/tar.rs
@@ -42,11 +42,6 @@ pub fn tar<I: AsRef<Path>, O: AsRef<Path>>(
 
     for file in files {
         let input_src = input_root.join(file);
-        let name = input_src
-            .file_name()
-            .unwrap_or_default()
-            .to_str()
-            .unwrap_or_default();
 
         if input_src.is_file() {
             trace!(
@@ -55,10 +50,10 @@ pub fn tar<I: AsRef<Path>, O: AsRef<Path>>(
                 color::path(&input_src)
             );
 
-            let mut file = File::open(&input_src)
+            let mut fh = File::open(&input_src)
                 .map_err(|e| map_io_to_fs_error(e, input_src.to_path_buf()))?;
 
-            archive.append_file(prepend_name(name, prefix), &mut file)?;
+            archive.append_file(prepend_name(file, prefix), &mut fh)?;
         } else {
             trace!(
                 target: LOG_TARGET,
@@ -66,7 +61,7 @@ pub fn tar<I: AsRef<Path>, O: AsRef<Path>>(
                 color::path(&input_src)
             );
 
-            archive.append_dir_all(prepend_name(name, prefix), input_src)?;
+            archive.append_dir_all(prepend_name(file, prefix), input_src)?;
         }
     }
 

--- a/crates/archive/src/zip.rs
+++ b/crates/archive/src/zip.rs
@@ -1,0 +1,1 @@
+pub fn test() {}

--- a/crates/archive/src/zip.rs
+++ b/crates/archive/src/zip.rs
@@ -1,1 +1,147 @@
-pub fn test() {}
+use moon_error::{map_io_to_fs_error, MoonError};
+use moon_logger::{color, trace};
+use std::fs::{self, File};
+use std::io;
+use std::io::prelude::*;
+use std::path::Path;
+use zip::write::FileOptions;
+use zip::{CompressionMethod, ZipArchive, ZipWriter};
+
+fn zip_file(
+    archive: &mut ZipWriter<File>,
+    file: &Path,
+    base_prefix: &Option<&str>,
+) -> Result<(), MoonError> {
+    let file_name = file.file_name().unwrap().to_str().unwrap();
+    let options = FileOptions::default()
+        .compression_method(CompressionMethod::Stored)
+        .unix_permissions(0o755);
+
+    archive
+        .start_file(
+            match base_prefix {
+                Some(prefix) => format!("{}/{}", prefix, file_name),
+                None => file_name.to_owned(),
+            },
+            options,
+        )
+        .unwrap();
+
+    archive.write_all(&fs::read(file)?).unwrap();
+
+    Ok(())
+}
+
+// fn zip_dir(dir: &Path) -> Result<(), MoonError> {
+//     for entry in fs::read_dir(dir)? {}
+
+//     Ok(())
+// }
+
+#[track_caller]
+pub fn zip<I: AsRef<Path>, O: AsRef<Path>>(
+    input_src: I,
+    output_file: O,
+    base_prefix: Option<&str>,
+) -> Result<(), MoonError> {
+    let input_src = input_src.as_ref();
+    let output_file = output_file.as_ref();
+
+    trace!(
+        target: "moon:archive:zip",
+        "Packing zip archive with {} to {}",
+        color::path(input_src),
+        color::path(output_file),
+    );
+
+    // Create .zip
+    let zip =
+        File::create(output_file).map_err(|e| map_io_to_fs_error(e, output_file.to_path_buf()))?;
+
+    // Add the files to the archive
+    let mut archive = ZipWriter::new(zip);
+
+    if input_src.is_file() {
+        zip_file(&mut archive, input_src, &base_prefix)?;
+    } else {
+    }
+
+    archive.finish().unwrap();
+
+    Ok(())
+}
+
+#[track_caller]
+pub fn unzip<I: AsRef<Path>, O: AsRef<Path>>(
+    input_file: I,
+    output_dir: O,
+    remove_prefix: Option<&str>,
+) -> Result<(), MoonError> {
+    let input_file = input_file.as_ref();
+    let output_dir = output_dir.as_ref();
+
+    trace!(
+        target: "moon:archive:zip",
+        "Unzipping zip archive {} to {}",
+        color::path(input_file),
+        color::path(output_dir),
+    );
+
+    if !output_dir.exists() {
+        fs::create_dir_all(output_dir)
+            .map_err(|e| map_io_to_fs_error(e, output_dir.to_path_buf()))?;
+    }
+
+    // Open .zip file
+    let zip =
+        File::open(input_file).map_err(|e| map_io_to_fs_error(e, input_file.to_path_buf()))?;
+
+    // Unpack the archive into the output dir
+    let mut archive = ZipArchive::new(zip).unwrap();
+
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i).unwrap();
+        let mut path = match file.enclosed_name() {
+            Some(path) => path.to_owned(),
+            None => continue,
+        };
+
+        // Remove the prefix
+        if let Some(prefix) = remove_prefix {
+            if path.starts_with(prefix) {
+                path = path.strip_prefix(&prefix).unwrap().to_owned();
+            }
+        }
+
+        let output_path = output_dir.join(&path);
+        let handle_error = |e: io::Error| map_io_to_fs_error(e, output_path.to_path_buf());
+
+        // Create parent dirs
+        if let Some(parent_dir) = output_path.parent() {
+            if !parent_dir.exists() {
+                fs::create_dir_all(parent_dir)
+                    .map_err(|e| map_io_to_fs_error(e, parent_dir.to_path_buf()))?;
+            }
+        }
+
+        // If a file, copy it to the output dir
+        if file.is_file() {
+            let mut out = File::create(&output_path).map_err(handle_error)?;
+
+            io::copy(&mut file, &mut out).map_err(handle_error)?;
+        }
+
+        // Update permissions when on a nix machine
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            if let Some(mode) = file.unix_mode() {
+                fs::set_permissions(&output_path, fs::Permissions::from_mode(mode))
+                    .map_err(handle_error)?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/archive/src/zip.rs
+++ b/crates/archive/src/zip.rs
@@ -82,7 +82,7 @@ pub fn zip<I: AsRef<Path>, O: AsRef<Path>>(
     for file in files {
         let input_src = input_root.join(file);
 
-        zip_contents(&mut archive, &input_src, &input_root, prefix)?;
+        zip_contents(&mut archive, &input_src, input_root, prefix)?;
     }
 
     archive.finish()?;

--- a/crates/archive/src/zip.rs
+++ b/crates/archive/src/zip.rs
@@ -1,4 +1,4 @@
-use crate::helpers::prepend_name;
+use crate::helpers::{ensure_dir, prepend_name};
 use moon_error::{map_io_to_fs_error, MoonError};
 use moon_logger::{color, debug, trace};
 use std::fs::{self, File};
@@ -112,10 +112,7 @@ pub fn unzip<I: AsRef<Path>, O: AsRef<Path>>(
         color::path(output_dir),
     );
 
-    if !output_dir.exists() {
-        fs::create_dir_all(output_dir)
-            .map_err(|e| map_io_to_fs_error(e, output_dir.to_path_buf()))?;
-    }
+    ensure_dir(output_dir)?;
 
     // Open .zip file
     let zip =
@@ -144,15 +141,12 @@ pub fn unzip<I: AsRef<Path>, O: AsRef<Path>>(
 
         // Create parent dirs
         if let Some(parent_dir) = &output_path.parent() {
-            if !parent_dir.exists() {
-                fs::create_dir_all(parent_dir)
-                    .map_err(|e| map_io_to_fs_error(e, parent_dir.to_path_buf()))?;
-            }
+            ensure_dir(parent_dir)?;
         }
 
         // If a folder, create the dir
-        if file.is_dir() && !output_path.exists() {
-            fs::create_dir_all(&output_path).map_err(handle_error)?;
+        if file.is_dir() {
+            ensure_dir(&output_path)?;
         }
 
         // If a file, copy it to the output dir

--- a/crates/archive/src/zip.rs
+++ b/crates/archive/src/zip.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use zip::write::FileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
 
-const TARGET: &str = "moon:archive:zip";
+const LOG_TARGET: &str = "moon:archive:zip";
 
 fn zip_contents<P: AsRef<str>>(
     archive: &mut ZipWriter<File>,
@@ -30,7 +30,7 @@ fn zip_contents<P: AsRef<str>>(
             options = options.unix_permissions(path.metadata()?.permissions().mode());
         }
 
-        trace!(target: TARGET, "Zipping file {}", color::path(&path));
+        trace!(target: LOG_TARGET, "Zipping file {}", color::path(&path));
 
         archive
             .start_file(prepend_name(name, prefix), options)
@@ -66,7 +66,7 @@ pub fn zip<I: AsRef<Path>, O: AsRef<Path>>(
     let output_file = output_file.as_ref();
 
     debug!(
-        target: TARGET,
+        target: LOG_TARGET,
         "Zipping archive from {} with {} to {}",
         color::path(input_root),
         map_list(files, |f| color::file(f)),
@@ -102,7 +102,7 @@ pub fn unzip<I: AsRef<Path>, O: AsRef<Path>>(
     let output_dir = output_dir.as_ref();
 
     debug!(
-        target: TARGET,
+        target: LOG_TARGET,
         "Unzipping archive {} to {}",
         color::path(input_file),
         color::path(output_dir),
@@ -152,7 +152,7 @@ pub fn unzip<I: AsRef<Path>, O: AsRef<Path>>(
             io::copy(&mut file, &mut out).map_err(handle_error)?;
 
             trace!(
-                target: TARGET,
+                target: LOG_TARGET,
                 "Unzipping file {}",
                 color::path(&output_path)
             );

--- a/crates/archive/tests/tar_test.rs
+++ b/crates/archive/tests/tar_test.rs
@@ -1,0 +1,185 @@
+use moon_archive::{tar, untar};
+use moon_utils::test::create_sandbox;
+use std::fs;
+use std::path::Path;
+
+fn file_contents_match(a: &Path, b: &Path) -> bool {
+    fs::read_to_string(a).unwrap() == fs::read_to_string(b).unwrap()
+}
+
+#[test]
+fn archives_file() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path().join("file.txt");
+    let archive = fixture.path().join("out.tar.gz");
+
+    tar(&input, &archive, None).unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    untar(&archive, &output, None).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("file.txt").exists());
+
+    // Compare
+    assert!(file_contents_match(&input, &output.join("file.txt")));
+}
+
+#[test]
+fn archives_file_with_prefix() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path().join("file.txt");
+    let archive = fixture.path().join("out.tar.gz");
+
+    tar(&input, &archive, Some("some/prefix")).unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    untar(&archive, &output, None).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("some/prefix/file.txt").exists());
+
+    // Compare
+    assert!(file_contents_match(
+        &input,
+        &output.join("some/prefix/file.txt")
+    ));
+}
+
+#[test]
+fn archives_file_with_prefix_thats_removed() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path().join("file.txt");
+    let archive = fixture.path().join("out.tar.gz");
+
+    tar(&input, &archive, Some("some/prefix")).unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    untar(&archive, &output, Some("some/prefix")).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("file.txt").exists());
+
+    // Compare
+    assert!(file_contents_match(&input, &output.join("file.txt")));
+}
+
+#[test]
+fn archives_dir() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path().join("folder");
+    let archive = fixture.path().join("out.tar.gz");
+
+    tar(&input, &archive, None).unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    untar(&archive, &output, None).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("file.js").exists());
+    assert!(output.join("nested/other.js").exists());
+
+    // Compare
+    assert!(file_contents_match(
+        &input.join("file.js"),
+        &output.join("file.js")
+    ));
+    assert!(file_contents_match(
+        &input.join("nested/other.js"),
+        &output.join("nested/other.js")
+    ));
+}
+
+#[test]
+fn archives_dir_with_prefix() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path().join("folder");
+    let archive = fixture.path().join("out.tar.gz");
+
+    tar(&input, &archive, Some("some/prefix")).unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    untar(&archive, &output, None).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("some/prefix/file.js").exists());
+    assert!(output.join("some/prefix/nested/other.js").exists());
+
+    // Compare
+    assert!(file_contents_match(
+        &input.join("file.js"),
+        &output.join("some/prefix/file.js")
+    ));
+    assert!(file_contents_match(
+        &input.join("nested/other.js"),
+        &output.join("some/prefix/nested/other.js")
+    ));
+}
+
+#[test]
+fn archives_dir_with_prefix_thats_removed() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path().join("folder");
+    let archive = fixture.path().join("out.tar.gz");
+
+    tar(&input, &archive, Some("some/prefix")).unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    untar(&archive, &output, Some("some/prefix")).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("file.js").exists());
+    assert!(output.join("nested/other.js").exists());
+
+    // Compare
+    assert!(file_contents_match(
+        &input.join("file.js"),
+        &output.join("file.js")
+    ));
+    assert!(file_contents_match(
+        &input.join("nested/other.js"),
+        &output.join("nested/other.js")
+    ));
+}

--- a/crates/archive/tests/tar_test.rs
+++ b/crates/archive/tests/tar_test.rs
@@ -8,7 +8,7 @@ fn file_contents_match(a: &Path, b: &Path) -> bool {
 }
 
 #[test]
-fn archives_file() {
+fn tars_file() {
     let fixture = create_sandbox("archives");
 
     // Pack
@@ -33,7 +33,7 @@ fn archives_file() {
 }
 
 #[test]
-fn archives_file_with_prefix() {
+fn tars_file_with_prefix() {
     let fixture = create_sandbox("archives");
 
     // Pack
@@ -61,7 +61,7 @@ fn archives_file_with_prefix() {
 }
 
 #[test]
-fn archives_file_with_prefix_thats_removed() {
+fn tars_file_with_prefix_thats_removed() {
     let fixture = create_sandbox("archives");
 
     // Pack
@@ -86,7 +86,7 @@ fn archives_file_with_prefix_thats_removed() {
 }
 
 #[test]
-fn archives_dir() {
+fn tars_dir() {
     let fixture = create_sandbox("archives");
 
     // Pack
@@ -119,7 +119,7 @@ fn archives_dir() {
 }
 
 #[test]
-fn archives_dir_with_prefix() {
+fn tars_dir_with_prefix() {
     let fixture = create_sandbox("archives");
 
     // Pack
@@ -152,7 +152,7 @@ fn archives_dir_with_prefix() {
 }
 
 #[test]
-fn archives_dir_with_prefix_thats_removed() {
+fn tars_dir_with_prefix_thats_removed() {
     let fixture = create_sandbox("archives");
 
     // Pack

--- a/crates/archive/tests/tar_test.rs
+++ b/crates/archive/tests/tar_test.rs
@@ -105,6 +105,80 @@ fn tars_file_with_prefix_thats_removed() {
 }
 
 #[test]
+fn tars_nested_file_and_preserves_path() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path();
+    let archive = fixture.path().join("out.tar.gz");
+
+    tar(
+        &input,
+        &string_vec!["folder/nested/other.js"],
+        &archive,
+        None,
+    )
+    .unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    untar(&archive, &output, None).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("folder/nested/other.js").exists());
+
+    // Compare
+    assert!(file_contents_match(
+        &input.join("folder/nested/other.js"),
+        &output.join("folder/nested/other.js")
+    ));
+}
+
+#[test]
+fn tars_file_and_dir_explicitly() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path();
+    let archive = fixture.path().join("out.tar.gz");
+
+    tar(
+        &input,
+        &string_vec!["folder/nested", "file.txt"],
+        &archive,
+        None,
+    )
+    .unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    untar(&archive, &output, None).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("file.txt").exists());
+    assert!(output.join("folder/nested/other.js").exists());
+    assert!(!output.join("folder/file.js").exists()); // Should not exist!
+
+    // Compare
+    assert!(file_contents_match(
+        &input.join("file.txt"),
+        &output.join("file.txt")
+    ));
+    assert!(file_contents_match(
+        &input.join("folder/nested/other.js"),
+        &output.join("folder/nested/other.js")
+    ));
+}
+
+#[test]
 fn tars_dir() {
     let fixture = create_sandbox("archives");
 

--- a/crates/archive/tests/tar_test.rs
+++ b/crates/archive/tests/tar_test.rs
@@ -1,4 +1,5 @@
 use moon_archive::{tar, untar};
+use moon_utils::string_vec;
 use moon_utils::test::create_sandbox;
 use std::fs;
 use std::path::Path;
@@ -12,10 +13,10 @@ fn tars_file() {
     let fixture = create_sandbox("archives");
 
     // Pack
-    let input = fixture.path().join("file.txt");
+    let input = fixture.path();
     let archive = fixture.path().join("out.tar.gz");
 
-    tar(&input, &archive, None).unwrap();
+    tar(&input, &string_vec!["file.txt"], &archive, None).unwrap();
 
     assert!(archive.exists());
     assert_ne!(archive.metadata().unwrap().len(), 0);
@@ -29,7 +30,10 @@ fn tars_file() {
     assert!(output.join("file.txt").exists());
 
     // Compare
-    assert!(file_contents_match(&input, &output.join("file.txt")));
+    assert!(file_contents_match(
+        &input.join("file.txt"),
+        &output.join("file.txt")
+    ));
 }
 
 #[test]
@@ -37,10 +41,16 @@ fn tars_file_with_prefix() {
     let fixture = create_sandbox("archives");
 
     // Pack
-    let input = fixture.path().join("file.txt");
+    let input = fixture.path();
     let archive = fixture.path().join("out.tar.gz");
 
-    tar(&input, &archive, Some("some/prefix")).unwrap();
+    tar(
+        &input,
+        &string_vec!["file.txt"],
+        &archive,
+        Some("some/prefix"),
+    )
+    .unwrap();
 
     assert!(archive.exists());
     assert_ne!(archive.metadata().unwrap().len(), 0);
@@ -55,7 +65,7 @@ fn tars_file_with_prefix() {
 
     // Compare
     assert!(file_contents_match(
-        &input,
+        &input.join("file.txt"),
         &output.join("some/prefix/file.txt")
     ));
 }
@@ -65,10 +75,16 @@ fn tars_file_with_prefix_thats_removed() {
     let fixture = create_sandbox("archives");
 
     // Pack
-    let input = fixture.path().join("file.txt");
+    let input = fixture.path();
     let archive = fixture.path().join("out.tar.gz");
 
-    tar(&input, &archive, Some("some/prefix")).unwrap();
+    tar(
+        &input,
+        &string_vec!["file.txt"],
+        &archive,
+        Some("some/prefix"),
+    )
+    .unwrap();
 
     assert!(archive.exists());
     assert_ne!(archive.metadata().unwrap().len(), 0);
@@ -82,7 +98,10 @@ fn tars_file_with_prefix_thats_removed() {
     assert!(output.join("file.txt").exists());
 
     // Compare
-    assert!(file_contents_match(&input, &output.join("file.txt")));
+    assert!(file_contents_match(
+        &input.join("file.txt"),
+        &output.join("file.txt")
+    ));
 }
 
 #[test]
@@ -90,10 +109,10 @@ fn tars_dir() {
     let fixture = create_sandbox("archives");
 
     // Pack
-    let input = fixture.path().join("folder");
+    let input = fixture.path();
     let archive = fixture.path().join("out.tar.gz");
 
-    tar(&input, &archive, None).unwrap();
+    tar(&input, &string_vec!["folder"], &archive, None).unwrap();
 
     assert!(archive.exists());
     assert_ne!(archive.metadata().unwrap().len(), 0);
@@ -104,17 +123,17 @@ fn tars_dir() {
     untar(&archive, &output, None).unwrap();
 
     assert!(output.exists());
-    assert!(output.join("file.js").exists());
-    assert!(output.join("nested/other.js").exists());
+    assert!(output.join("folder/file.js").exists());
+    assert!(output.join("folder/nested/other.js").exists());
 
     // Compare
     assert!(file_contents_match(
-        &input.join("file.js"),
-        &output.join("file.js")
+        &input.join("folder/file.js"),
+        &output.join("folder/file.js")
     ));
     assert!(file_contents_match(
-        &input.join("nested/other.js"),
-        &output.join("nested/other.js")
+        &input.join("folder/nested/other.js"),
+        &output.join("folder/nested/other.js")
     ));
 }
 
@@ -123,10 +142,16 @@ fn tars_dir_with_prefix() {
     let fixture = create_sandbox("archives");
 
     // Pack
-    let input = fixture.path().join("folder");
+    let input = fixture.path();
     let archive = fixture.path().join("out.tar.gz");
 
-    tar(&input, &archive, Some("some/prefix")).unwrap();
+    tar(
+        &input,
+        &string_vec!["folder"],
+        &archive,
+        Some("some/prefix"),
+    )
+    .unwrap();
 
     assert!(archive.exists());
     assert_ne!(archive.metadata().unwrap().len(), 0);
@@ -137,17 +162,17 @@ fn tars_dir_with_prefix() {
     untar(&archive, &output, None).unwrap();
 
     assert!(output.exists());
-    assert!(output.join("some/prefix/file.js").exists());
-    assert!(output.join("some/prefix/nested/other.js").exists());
+    assert!(output.join("some/prefix/folder/file.js").exists());
+    assert!(output.join("some/prefix/folder/nested/other.js").exists());
 
     // Compare
     assert!(file_contents_match(
-        &input.join("file.js"),
-        &output.join("some/prefix/file.js")
+        &input.join("folder/file.js"),
+        &output.join("some/prefix/folder/file.js")
     ));
     assert!(file_contents_match(
-        &input.join("nested/other.js"),
-        &output.join("some/prefix/nested/other.js")
+        &input.join("folder/nested/other.js"),
+        &output.join("some/prefix/folder/nested/other.js")
     ));
 }
 
@@ -156,10 +181,16 @@ fn tars_dir_with_prefix_thats_removed() {
     let fixture = create_sandbox("archives");
 
     // Pack
-    let input = fixture.path().join("folder");
+    let input = fixture.path();
     let archive = fixture.path().join("out.tar.gz");
 
-    tar(&input, &archive, Some("some/prefix")).unwrap();
+    tar(
+        &input,
+        &string_vec!["folder"],
+        &archive,
+        Some("some/prefix"),
+    )
+    .unwrap();
 
     assert!(archive.exists());
     assert_ne!(archive.metadata().unwrap().len(), 0);
@@ -170,16 +201,16 @@ fn tars_dir_with_prefix_thats_removed() {
     untar(&archive, &output, Some("some/prefix")).unwrap();
 
     assert!(output.exists());
-    assert!(output.join("file.js").exists());
-    assert!(output.join("nested/other.js").exists());
+    assert!(output.join("folder/file.js").exists());
+    assert!(output.join("folder/nested/other.js").exists());
 
     // Compare
     assert!(file_contents_match(
-        &input.join("file.js"),
-        &output.join("file.js")
+        &input.join("folder/file.js"),
+        &output.join("folder/file.js")
     ));
     assert!(file_contents_match(
-        &input.join("nested/other.js"),
-        &output.join("nested/other.js")
+        &input.join("folder/nested/other.js"),
+        &output.join("folder/nested/other.js")
     ));
 }

--- a/crates/archive/tests/zip_test.rs
+++ b/crates/archive/tests/zip_test.rs
@@ -105,6 +105,80 @@ fn zips_file_with_prefix_thats_removed() {
 }
 
 #[test]
+fn zips_nested_file_and_preserves_path() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path();
+    let archive = fixture.path().join("out.zip");
+
+    zip(
+        &input,
+        &string_vec!["folder/nested/other.js"],
+        &archive,
+        None,
+    )
+    .unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    unzip(&archive, &output, None).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("folder/nested/other.js").exists());
+
+    // Compare
+    assert!(file_contents_match(
+        &input.join("folder/nested/other.js"),
+        &output.join("folder/nested/other.js")
+    ));
+}
+
+#[test]
+fn zips_file_and_dir_explicitly() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path();
+    let archive = fixture.path().join("out.zip");
+
+    zip(
+        &input,
+        &string_vec!["folder/nested", "file.txt"],
+        &archive,
+        None,
+    )
+    .unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    unzip(&archive, &output, None).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("file.txt").exists());
+    assert!(output.join("folder/nested/other.js").exists());
+    assert!(!output.join("folder/file.js").exists()); // Should not exist!
+
+    // Compare
+    assert!(file_contents_match(
+        &input.join("file.txt"),
+        &output.join("file.txt")
+    ));
+    assert!(file_contents_match(
+        &input.join("folder/nested/other.js"),
+        &output.join("folder/nested/other.js")
+    ));
+}
+
+#[test]
 fn zips_dir() {
     let fixture = create_sandbox("archives");
 

--- a/crates/archive/tests/zip_test.rs
+++ b/crates/archive/tests/zip_test.rs
@@ -41,10 +41,16 @@ fn zips_file_with_prefix() {
     let fixture = create_sandbox("archives");
 
     // Pack
-    let input = fixture.path().join("file.txt");
+    let input = fixture.path();
     let archive = fixture.path().join("out.zip");
 
-    zip(&input, &archive, Some("some/prefix")).unwrap();
+    zip(
+        &input,
+        &string_vec!["file.txt"],
+        &archive,
+        Some("some/prefix"),
+    )
+    .unwrap();
 
     assert!(archive.exists());
     assert_ne!(archive.metadata().unwrap().len(), 0);
@@ -59,7 +65,7 @@ fn zips_file_with_prefix() {
 
     // Compare
     assert!(file_contents_match(
-        &input,
+        &input.join("file.txt"),
         &output.join("some/prefix/file.txt")
     ));
 }
@@ -69,10 +75,16 @@ fn zips_file_with_prefix_thats_removed() {
     let fixture = create_sandbox("archives");
 
     // Pack
-    let input = fixture.path().join("file.txt");
+    let input = fixture.path();
     let archive = fixture.path().join("out.zip");
 
-    zip(&input, &archive, Some("some/prefix")).unwrap();
+    zip(
+        &input,
+        &string_vec!["file.txt"],
+        &archive,
+        Some("some/prefix"),
+    )
+    .unwrap();
 
     assert!(archive.exists());
     assert_ne!(archive.metadata().unwrap().len(), 0);
@@ -86,7 +98,10 @@ fn zips_file_with_prefix_thats_removed() {
     assert!(output.join("file.txt").exists());
 
     // Compare
-    assert!(file_contents_match(&input, &output.join("file.txt")));
+    assert!(file_contents_match(
+        &input.join("file.txt"),
+        &output.join("file.txt")
+    ));
 }
 
 #[test]
@@ -94,10 +109,10 @@ fn zips_dir() {
     let fixture = create_sandbox("archives");
 
     // Pack
-    let input = fixture.path().join("folder");
+    let input = fixture.path();
     let archive = fixture.path().join("out.zip");
 
-    zip(&input, &archive, None).unwrap();
+    zip(&input, &string_vec!["folder"], &archive, None).unwrap();
 
     assert!(archive.exists());
     assert_ne!(archive.metadata().unwrap().len(), 0);
@@ -108,17 +123,17 @@ fn zips_dir() {
     unzip(&archive, &output, None).unwrap();
 
     assert!(output.exists());
-    assert!(output.join("file.js").exists());
-    assert!(output.join("nested/other.js").exists());
+    assert!(output.join("folder/file.js").exists());
+    assert!(output.join("folder/nested/other.js").exists());
 
     // Compare
     assert!(file_contents_match(
-        &input.join("file.js"),
-        &output.join("file.js")
+        &input.join("folder/file.js"),
+        &output.join("folder/file.js")
     ));
     assert!(file_contents_match(
-        &input.join("nested/other.js"),
-        &output.join("nested/other.js")
+        &input.join("folder/nested/other.js"),
+        &output.join("folder/nested/other.js")
     ));
 }
 
@@ -127,10 +142,16 @@ fn zips_dir_with_prefix() {
     let fixture = create_sandbox("archives");
 
     // Pack
-    let input = fixture.path().join("folder");
+    let input = fixture.path();
     let archive = fixture.path().join("out.zip");
 
-    zip(&input, &archive, Some("some/prefix")).unwrap();
+    zip(
+        &input,
+        &string_vec!["folder"],
+        &archive,
+        Some("some/prefix"),
+    )
+    .unwrap();
 
     assert!(archive.exists());
     assert_ne!(archive.metadata().unwrap().len(), 0);
@@ -141,17 +162,17 @@ fn zips_dir_with_prefix() {
     unzip(&archive, &output, None).unwrap();
 
     assert!(output.exists());
-    assert!(output.join("some/prefix/file.js").exists());
-    assert!(output.join("some/prefix/nested/other.js").exists());
+    assert!(output.join("some/prefix/folder/file.js").exists());
+    assert!(output.join("some/prefix/folder/nested/other.js").exists());
 
     // Compare
     assert!(file_contents_match(
-        &input.join("file.js"),
-        &output.join("some/prefix/file.js")
+        &input.join("folder/file.js"),
+        &output.join("some/prefix/folder/file.js")
     ));
     assert!(file_contents_match(
-        &input.join("nested/other.js"),
-        &output.join("some/prefix/nested/other.js")
+        &input.join("folder/nested/other.js"),
+        &output.join("some/prefix/folder/nested/other.js")
     ));
 }
 
@@ -160,10 +181,16 @@ fn zips_dir_with_prefix_thats_removed() {
     let fixture = create_sandbox("archives");
 
     // Pack
-    let input = fixture.path().join("folder");
+    let input = fixture.path();
     let archive = fixture.path().join("out.zip");
 
-    zip(&input, &archive, Some("some/prefix")).unwrap();
+    zip(
+        &input,
+        &string_vec!["folder"],
+        &archive,
+        Some("some/prefix"),
+    )
+    .unwrap();
 
     assert!(archive.exists());
     assert_ne!(archive.metadata().unwrap().len(), 0);
@@ -174,16 +201,16 @@ fn zips_dir_with_prefix_thats_removed() {
     unzip(&archive, &output, Some("some/prefix")).unwrap();
 
     assert!(output.exists());
-    assert!(output.join("file.js").exists());
-    assert!(output.join("nested/other.js").exists());
+    assert!(output.join("folder/file.js").exists());
+    assert!(output.join("folder/nested/other.js").exists());
 
     // Compare
     assert!(file_contents_match(
-        &input.join("file.js"),
-        &output.join("file.js")
+        &input.join("folder/file.js"),
+        &output.join("folder/file.js")
     ));
     assert!(file_contents_match(
-        &input.join("nested/other.js"),
-        &output.join("nested/other.js")
+        &input.join("folder/nested/other.js"),
+        &output.join("folder/nested/other.js")
     ));
 }

--- a/crates/archive/tests/zip_test.rs
+++ b/crates/archive/tests/zip_test.rs
@@ -25,8 +25,6 @@ fn zips_file() {
 
     unzip(&archive, &output, None).unwrap();
 
-    moon_utils::test::debug_sandbox_files(fixture.path());
-
     assert!(output.exists());
     assert!(output.join("file.txt").exists());
 
@@ -85,4 +83,103 @@ fn zips_file_with_prefix_thats_removed() {
 
     // Compare
     assert!(file_contents_match(&input, &output.join("file.txt")));
+}
+
+#[test]
+fn zips_dir() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path().join("folder");
+    let archive = fixture.path().join("out.zip");
+
+    zip(&input, &archive, None).unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    unzip(&archive, &output, None).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("file.js").exists());
+    assert!(output.join("nested/other.js").exists());
+
+    // Compare
+    assert!(file_contents_match(
+        &input.join("file.js"),
+        &output.join("file.js")
+    ));
+    assert!(file_contents_match(
+        &input.join("nested/other.js"),
+        &output.join("nested/other.js")
+    ));
+}
+
+#[test]
+fn zips_dir_with_prefix() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path().join("folder");
+    let archive = fixture.path().join("out.zip");
+
+    zip(&input, &archive, Some("some/prefix")).unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    unzip(&archive, &output, None).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("some/prefix/file.js").exists());
+    assert!(output.join("some/prefix/nested/other.js").exists());
+
+    // Compare
+    assert!(file_contents_match(
+        &input.join("file.js"),
+        &output.join("some/prefix/file.js")
+    ));
+    assert!(file_contents_match(
+        &input.join("nested/other.js"),
+        &output.join("some/prefix/nested/other.js")
+    ));
+}
+
+#[test]
+fn zips_dir_with_prefix_thats_removed() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path().join("folder");
+    let archive = fixture.path().join("out.zip");
+
+    zip(&input, &archive, Some("some/prefix")).unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    unzip(&archive, &output, Some("some/prefix")).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("file.js").exists());
+    assert!(output.join("nested/other.js").exists());
+
+    // Compare
+    assert!(file_contents_match(
+        &input.join("file.js"),
+        &output.join("file.js")
+    ));
+    assert!(file_contents_match(
+        &input.join("nested/other.js"),
+        &output.join("nested/other.js")
+    ));
 }

--- a/crates/archive/tests/zip_test.rs
+++ b/crates/archive/tests/zip_test.rs
@@ -1,4 +1,5 @@
 use moon_archive::{unzip, zip};
+use moon_utils::string_vec;
 use moon_utils::test::create_sandbox;
 use std::fs;
 use std::path::Path;
@@ -12,10 +13,10 @@ fn zips_file() {
     let fixture = create_sandbox("archives");
 
     // Pack
-    let input = fixture.path().join("file.txt");
+    let input = fixture.path();
     let archive = fixture.path().join("out.zip");
 
-    zip(&input, &archive, None).unwrap();
+    zip(&input, &string_vec!["file.txt"], &archive, None).unwrap();
 
     assert!(archive.exists());
     assert_ne!(archive.metadata().unwrap().len(), 0);
@@ -29,7 +30,10 @@ fn zips_file() {
     assert!(output.join("file.txt").exists());
 
     // Compare
-    assert!(file_contents_match(&input, &output.join("file.txt")));
+    assert!(file_contents_match(
+        &input.join("file.txt"),
+        &output.join("file.txt")
+    ));
 }
 
 #[test]

--- a/crates/archive/tests/zip_test.rs
+++ b/crates/archive/tests/zip_test.rs
@@ -1,0 +1,88 @@
+use moon_archive::{unzip, zip};
+use moon_utils::test::create_sandbox;
+use std::fs;
+use std::path::Path;
+
+fn file_contents_match(a: &Path, b: &Path) -> bool {
+    fs::read_to_string(a).unwrap() == fs::read_to_string(b).unwrap()
+}
+
+#[test]
+fn zips_file() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path().join("file.txt");
+    let archive = fixture.path().join("out.zip");
+
+    zip(&input, &archive, None).unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    unzip(&archive, &output, None).unwrap();
+
+    moon_utils::test::debug_sandbox_files(fixture.path());
+
+    assert!(output.exists());
+    assert!(output.join("file.txt").exists());
+
+    // Compare
+    assert!(file_contents_match(&input, &output.join("file.txt")));
+}
+
+#[test]
+fn zips_file_with_prefix() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path().join("file.txt");
+    let archive = fixture.path().join("out.zip");
+
+    zip(&input, &archive, Some("some/prefix")).unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    unzip(&archive, &output, None).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("some/prefix/file.txt").exists());
+
+    // Compare
+    assert!(file_contents_match(
+        &input,
+        &output.join("some/prefix/file.txt")
+    ));
+}
+
+#[test]
+fn zips_file_with_prefix_thats_removed() {
+    let fixture = create_sandbox("archives");
+
+    // Pack
+    let input = fixture.path().join("file.txt");
+    let archive = fixture.path().join("out.zip");
+
+    zip(&input, &archive, Some("some/prefix")).unwrap();
+
+    assert!(archive.exists());
+    assert_ne!(archive.metadata().unwrap().len(), 0);
+
+    // Unpack
+    let output = fixture.path().join("out");
+
+    unzip(&archive, &output, Some("some/prefix")).unwrap();
+
+    assert!(output.exists());
+    assert!(output.join("file.txt").exists());
+
+    // Compare
+    assert!(file_contents_match(&input, &output.join("file.txt")));
+}

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+moon_archive = { path = "../archive" }
 moon_constants = { path = "../constants" }
 moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }

--- a/crates/cache/src/engine.rs
+++ b/crates/cache/src/engine.rs
@@ -174,6 +174,12 @@ impl CacheEngine {
         self.runs_dir.join(path)
     }
 
+    /// Check to see if a build with the provided hash has been cached.
+    /// We only check for the archive, as the manifest is purely for local debugging!
+    pub fn is_hash_cached(&self, hash: &str) -> bool {
+        self.get_hash_archive_path(hash).exists()
+    }
+
     pub async fn hydrate_from_hash_archive(
         &self,
         hash: &str,

--- a/crates/cache/src/engine.rs
+++ b/crates/cache/src/engine.rs
@@ -107,12 +107,6 @@ impl CacheEngine {
                 None,
             )
             .map_err(|e| MoonError::Generic(e.to_string()))?;
-
-            trace!(
-                target: LOG_TARGET,
-                "Archiving outputs for {}",
-                color::symbol(hash)
-            );
         }
 
         Ok(())

--- a/crates/cache/src/engine.rs
+++ b/crates/cache/src/engine.rs
@@ -104,7 +104,8 @@ impl CacheEngine {
                 outputs,
                 self.get_hash_archive_path(hash),
                 None,
-            )?;
+            )
+            .map_err(|e| MoonError::Generic(e.to_string()))?;
 
             trace!(
                 target: LOG_TARGET,

--- a/crates/cache/src/engine.rs
+++ b/crates/cache/src/engine.rs
@@ -1,6 +1,7 @@
 use crate::helpers::{is_writable, LOG_TARGET};
 use crate::items::{CacheItem, ProjectsState, RunTargetState, WorkspaceState};
 use crate::runfiles::CacheRunfile;
+use moon_archive::tar;
 use moon_constants::CONFIG_DIRNAME;
 use moon_error::MoonError;
 use moon_logger::{color, debug, trace};
@@ -14,13 +15,13 @@ pub struct CacheEngine {
     /// Contains cached items pertaining to runs and processes.
     pub dir: PathBuf,
 
-    /// The `.moon/cache/hashes` directory. Stores hash contents.
+    /// The `.moon/cache/hashes` directory. Stores hash manifests.
     pub hashes_dir: PathBuf,
 
     /// The `.moon/cache/runs` directory. Stores run states and runfiles.
     pub runs_dir: PathBuf,
 
-    /// The `.moon/cache/out` directory. Stores task output.
+    /// The `.moon/cache/out` directory. Stores task outputs as hashed archives.
     pub outputs_dir: PathBuf,
 }
 
@@ -82,6 +83,58 @@ impl CacheEngine {
         .await
     }
 
+    pub async fn create_hash_archive(
+        &self,
+        hash: &str,
+        project_root: &Path,
+        outputs: &[String],
+    ) -> Result<(), MoonError> {
+        if is_writable() {
+            // Old implementation would copy files to a hashed folder,
+            // so if we encounter that folder, let's just remove it!
+            let old_hash_folder = self.outputs_dir.join(hash);
+
+            if old_hash_folder.exists() && old_hash_folder.is_dir() {
+                fs::remove_dir_all(old_hash_folder).await?;
+            }
+
+            // New implementation uses tar archives! Very cool.
+            tar(
+                project_root,
+                outputs,
+                self.get_hash_archive_path(hash),
+                None,
+            )?;
+
+            trace!(
+                target: LOG_TARGET,
+                "Archiving outputs for {}",
+                color::symbol(hash)
+            );
+        }
+
+        Ok(())
+    }
+
+    pub async fn create_hash_manifest<T>(&self, hash: &str, hasher: &T) -> Result<(), MoonError>
+    where
+        T: ?Sized + Serialize,
+    {
+        if is_writable() {
+            let path = self.get_hash_manifest_path(hash);
+
+            trace!(
+                target: LOG_TARGET,
+                "Writing hash manifest {}",
+                color::path(&path)
+            );
+
+            fs::write_json(&path, &hasher, true).await?;
+        }
+
+        Ok(())
+    }
+
     pub async fn create_runfile<T: DeserializeOwned + Serialize>(
         &self,
         project_id: &str,
@@ -92,26 +145,21 @@ impl CacheEngine {
 
     pub async fn delete_hash(&self, hash: &str) -> Result<(), MoonError> {
         if is_writable() {
-            let path = self.get_hash_path(hash);
+            trace!(target: LOG_TARGET, "Deleting hash {}", color::symbol(hash));
 
-            trace!(target: "moon:cache:hash", "Deleting hash {}", color::path(&path));
-
-            // Remove the hash file itself
-            fs::remove_file(&path).await?;
-
-            // And the output with the hash
-            fs::remove_dir_all(&self.get_hash_output_dir(hash)).await?;
+            fs::remove_file(self.get_hash_manifest_path(hash)).await?;
+            fs::remove_file(self.get_hash_archive_path(hash)).await?;
         }
 
         Ok(())
     }
 
-    pub fn get_hash_path(&self, hash: &str) -> PathBuf {
-        self.hashes_dir.join(format!("{}.json", hash))
+    pub fn get_hash_archive_path(&self, hash: &str) -> PathBuf {
+        self.outputs_dir.join(format!("{}.tar.gz", hash))
     }
 
-    pub fn get_hash_output_dir(&self, hash: &str) -> PathBuf {
-        self.outputs_dir.join(hash)
+    pub fn get_hash_manifest_path(&self, hash: &str) -> PathBuf {
+        self.hashes_dir.join(format!("{}.json", hash))
     }
 
     pub fn get_project_dir(&self, project_id: &str) -> PathBuf {
@@ -122,632 +170,5 @@ impl CacheEngine {
         let path: PathBuf = [&target_id.replace(':', "/")].iter().collect();
 
         self.runs_dir.join(path)
-    }
-
-    pub async fn copy_output_to_out(
-        &self,
-        hash: &str,
-        source_root: &Path,
-        output_path: &Path,
-    ) -> Result<(), MoonError> {
-        if is_writable() {
-            let dest_root = self.get_hash_output_dir(hash);
-
-            fs::create_dir_all(&dest_root).await?;
-
-            trace!(
-                target: LOG_TARGET,
-                "Copying output {} to {}",
-                color::path(output_path),
-                color::path(&dest_root)
-            );
-
-            if output_path.is_file() {
-                fs::copy_file(
-                    output_path,
-                    dest_root.join(output_path.strip_prefix(source_root).unwrap()),
-                )
-                .await?;
-            } else {
-                fs::copy_dir_all(source_root, output_path, &dest_root).await?;
-            }
-        }
-
-        Ok(())
-    }
-
-    pub async fn save_hash<T>(&self, hash: &str, hasher: &T) -> Result<(), MoonError>
-    where
-        T: ?Sized + Serialize,
-    {
-        if is_writable() {
-            let path = self.get_hash_path(hash);
-
-            trace!(target: "moon:cache:hash", "Writing hash {}", color::path(&path));
-
-            fs::write_json(&path, &hasher, true).await?;
-        }
-
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::helpers::{run_with_env, to_millis};
-    use assert_fs::prelude::*;
-    use serial_test::serial;
-    use std::fs;
-
-    mod create {
-        use super::*;
-
-        #[tokio::test]
-        #[serial]
-        async fn creates_dirs() {
-            let dir = assert_fs::TempDir::new().unwrap();
-
-            CacheEngine::create(dir.path()).await.unwrap();
-
-            assert!(dir.path().join(".moon/cache").exists());
-            assert!(dir.path().join(".moon/cache/hashes").exists());
-            assert!(dir.path().join(".moon/cache/runs").exists());
-            assert!(dir.path().join(".moon/cache/out").exists());
-
-            dir.close().unwrap();
-        }
-    }
-
-    mod delete_hash {
-        use super::*;
-
-        #[tokio::test]
-        #[serial]
-        async fn deletes_files() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-
-            dir.child(".moon/cache/hashes/abc123.json")
-                .write_str("{}")
-                .unwrap();
-
-            dir.child(".moon/cache/out/abc123/file.js")
-                .write_str("")
-                .unwrap();
-
-            let hash_file = cache.hashes_dir.join("abc123.json");
-            let out_file = cache.outputs_dir.join("abc123/file.js");
-
-            assert!(hash_file.exists());
-            assert!(out_file.exists());
-
-            cache.delete_hash("abc123").await.unwrap();
-
-            assert!(!hash_file.exists());
-            assert!(!out_file.exists());
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn doesnt_delete_if_cache_off() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-
-            dir.child(".moon/cache/hashes/abc123.json")
-                .write_str("{}")
-                .unwrap();
-
-            dir.child(".moon/cache/out/abc123/file.js")
-                .write_str("")
-                .unwrap();
-
-            let hash_file = cache.hashes_dir.join("abc123.json");
-            let out_file = cache.outputs_dir.join("abc123/file.js");
-
-            assert!(hash_file.exists());
-            assert!(out_file.exists());
-
-            run_with_env("off", || cache.delete_hash("abc123"))
-                .await
-                .unwrap();
-
-            assert!(hash_file.exists());
-            assert!(out_file.exists());
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn doesnt_delete_if_cache_readonly() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-
-            dir.child(".moon/cache/hashes/abc123.json")
-                .write_str("{}")
-                .unwrap();
-
-            dir.child(".moon/cache/out/abc123/file.js")
-                .write_str("")
-                .unwrap();
-
-            let hash_file = cache.hashes_dir.join("abc123.json");
-            let out_file = cache.outputs_dir.join("abc123/file.js");
-
-            assert!(hash_file.exists());
-            assert!(out_file.exists());
-
-            run_with_env("read", || cache.delete_hash("abc123"))
-                .await
-                .unwrap();
-
-            assert!(hash_file.exists());
-            assert!(out_file.exists());
-
-            dir.close().unwrap();
-        }
-    }
-
-    mod create_runfile {
-        use super::*;
-
-        #[tokio::test]
-        #[serial]
-        async fn creates_runfile_on_call() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let runfile = cache
-                .create_runfile("123", &"content".to_owned())
-                .await
-                .unwrap();
-
-            assert!(runfile.path.exists());
-
-            assert_eq!(
-                fs::read_to_string(dir.path().join(".moon/cache/runs/123/runfile.json")).unwrap(),
-                "\"content\""
-            );
-
-            dir.close().unwrap();
-        }
-    }
-
-    mod cache_run_target_state {
-        use super::*;
-
-        #[tokio::test]
-        #[serial]
-        async fn creates_parent_dir_on_call() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = cache.cache_run_target_state("foo:bar").await.unwrap();
-
-            assert!(!item.path.exists());
-            assert!(item.path.parent().unwrap().exists());
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn loads_cache_if_it_exists() {
-            let dir = assert_fs::TempDir::new().unwrap();
-
-            dir.child(".moon/cache/runs/foo/bar/lastRunState.json")
-                .write_str(r#"{"exitCode":123,"hash":"","lastRunTime":0,"stderr":"","stdout":"","target":"foo:bar"}"#)
-                .unwrap();
-
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = cache.cache_run_target_state("foo:bar").await.unwrap();
-
-            assert_eq!(
-                item.item,
-                RunTargetState {
-                    exit_code: 123,
-                    target: String::from("foo:bar"),
-                    ..RunTargetState::default()
-                }
-            );
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn loads_cache_if_it_exists_and_cache_is_readonly() {
-            let dir = assert_fs::TempDir::new().unwrap();
-
-            dir.child(".moon/cache/runs/foo/bar/lastRunState.json")
-                .write_str(r#"{"exitCode":123,"hash":"","lastRunTime":0,"stderr":"","stdout":"","target":"foo:bar"}"#)
-                .unwrap();
-
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = run_with_env("read", || cache.cache_run_target_state("foo:bar"))
-                .await
-                .unwrap();
-
-            assert_eq!(
-                item.item,
-                RunTargetState {
-                    exit_code: 123,
-                    target: String::from("foo:bar"),
-                    ..RunTargetState::default()
-                }
-            );
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn doesnt_load_if_it_exists_but_cache_is_off() {
-            let dir = assert_fs::TempDir::new().unwrap();
-
-            dir.child(".moon/cache/runs/foo/bar/lastRunState.json")
-                .write_str(r#"{"exitCode":123,"hash":"","lastRunTime":0,"stderr":"","stdout":"","target":"foo:bar"}"#)
-                .unwrap();
-
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = run_with_env("off", || cache.cache_run_target_state("foo:bar"))
-                .await
-                .unwrap();
-
-            assert_eq!(
-                item.item,
-                RunTargetState {
-                    target: String::from("foo:bar"),
-                    ..RunTargetState::default()
-                }
-            );
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn saves_to_cache() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let mut item = cache.cache_run_target_state("foo:bar").await.unwrap();
-
-            item.item.exit_code = 123;
-
-            run_with_env("", || item.save()).await.unwrap();
-
-            assert_eq!(
-                fs::read_to_string(item.path).unwrap(),
-                r#"{"exitCode":123,"hash":"","lastRunTime":0,"stderr":"","stdout":"","target":"foo:bar"}"#
-            );
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn doesnt_save_if_cache_off() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let mut item = cache.cache_run_target_state("foo:bar").await.unwrap();
-
-            item.item.exit_code = 123;
-
-            run_with_env("off", || item.save()).await.unwrap();
-
-            assert!(!item.path.exists());
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn doesnt_save_if_cache_readonly() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let mut item = cache.cache_run_target_state("foo:bar").await.unwrap();
-
-            item.item.exit_code = 123;
-
-            run_with_env("read", || item.save()).await.unwrap();
-
-            assert!(!item.path.exists());
-
-            dir.close().unwrap();
-        }
-    }
-
-    mod cache_workspace_state {
-        use super::*;
-
-        #[tokio::test]
-        #[serial]
-        async fn creates_parent_dir_on_call() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = cache.cache_workspace_state().await.unwrap();
-
-            assert!(!item.path.exists());
-            assert!(item.path.parent().unwrap().exists());
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn loads_cache_if_it_exists() {
-            let dir = assert_fs::TempDir::new().unwrap();
-
-            dir.child(".moon/cache/workspaceState.json")
-                .write_str(r#"{"lastNodeInstallTime":123}"#)
-                .unwrap();
-
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = cache.cache_workspace_state().await.unwrap();
-
-            assert_eq!(
-                item.item,
-                WorkspaceState {
-                    last_node_install_time: 123,
-                    last_version_check_time: 0,
-                }
-            );
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn loads_cache_if_it_exists_and_cache_is_readonly() {
-            let dir = assert_fs::TempDir::new().unwrap();
-
-            dir.child(".moon/cache/workspaceState.json")
-                .write_str(r#"{"lastNodeInstallTime":123}"#)
-                .unwrap();
-
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = run_with_env("read", || cache.cache_workspace_state())
-                .await
-                .unwrap();
-
-            assert_eq!(
-                item.item,
-                WorkspaceState {
-                    last_node_install_time: 123,
-                    last_version_check_time: 0,
-                }
-            );
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn doesnt_load_if_it_exists_but_cache_is_off() {
-            let dir = assert_fs::TempDir::new().unwrap();
-
-            dir.child(".moon/cache/workspaceState.json")
-                .write_str(r#"{"lastNodeInstallTime":123}"#)
-                .unwrap();
-
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = run_with_env("off", || cache.cache_workspace_state())
-                .await
-                .unwrap();
-
-            assert_eq!(item.item, WorkspaceState::default());
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn saves_to_cache() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let mut item = cache.cache_workspace_state().await.unwrap();
-
-            item.item.last_node_install_time = 123;
-
-            run_with_env("", || item.save()).await.unwrap();
-
-            assert_eq!(
-                fs::read_to_string(item.path).unwrap(),
-                r#"{"lastNodeInstallTime":123,"lastVersionCheckTime":0}"#
-            );
-
-            dir.close().unwrap();
-        }
-    }
-
-    mod cache_projects_state {
-        use super::*;
-        use filetime::{set_file_mtime, FileTime};
-        use moon_utils::string_vec;
-        use std::collections::HashMap;
-        use std::time::SystemTime;
-
-        #[tokio::test]
-        #[serial]
-        async fn creates_parent_dir_on_call() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = cache.cache_projects_state().await.unwrap();
-
-            assert!(!item.path.exists());
-            assert!(item.path.parent().unwrap().exists());
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn loads_cache_if_it_exists() {
-            let dir = assert_fs::TempDir::new().unwrap();
-
-            dir.child(".moon/cache/projectsState.json")
-                .write_str(r#"{"globs":["**/*"],"projects":{"foo":"bar"}}"#)
-                .unwrap();
-
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = cache.cache_projects_state().await.unwrap();
-
-            assert_eq!(
-                item.item,
-                ProjectsState {
-                    globs: string_vec!["**/*"],
-                    projects: HashMap::from([("foo".to_owned(), "bar".to_owned())]),
-                }
-            );
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn loads_cache_if_it_exists_and_cache_is_readonly() {
-            let dir = assert_fs::TempDir::new().unwrap();
-
-            dir.child(".moon/cache/projectsState.json")
-                .write_str(r#"{"globs":["**/*"],"projects":{"foo":"bar"}}"#)
-                .unwrap();
-
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = run_with_env("read", || cache.cache_projects_state())
-                .await
-                .unwrap();
-
-            assert_eq!(
-                item.item,
-                ProjectsState {
-                    globs: string_vec!["**/*"],
-                    projects: HashMap::from([("foo".to_owned(), "bar".to_owned())]),
-                }
-            );
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn doesnt_load_if_it_exists_but_cache_is_off() {
-            let dir = assert_fs::TempDir::new().unwrap();
-
-            dir.child(".moon/cache/projectsState.json")
-                .write_str(r#"{"globs":[],"projects":{"foo":"bar"}}"#)
-                .unwrap();
-
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = run_with_env("off", || cache.cache_projects_state())
-                .await
-                .unwrap();
-
-            assert_eq!(item.item, ProjectsState::default());
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn doesnt_load_if_it_exists_but_cache_is_stale() {
-            let dir = assert_fs::TempDir::new().unwrap();
-
-            dir.child(".moon/cache/projectsState.json")
-                .write_str(r#"{"globs":[],"projects":{"foo":"bar"}}"#)
-                .unwrap();
-
-            let now = to_millis(SystemTime::now()) - 100000;
-
-            set_file_mtime(
-                dir.path().join(".moon/cache/projectsState.json"),
-                FileTime::from_unix_time((now / 1000) as i64, 0),
-            )
-            .unwrap();
-
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let item = cache.cache_projects_state().await.unwrap();
-
-            assert_eq!(item.item, ProjectsState::default());
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn saves_to_cache() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let mut item = cache.cache_projects_state().await.unwrap();
-
-            item.item
-                .projects
-                .insert("foo".to_owned(), "bar".to_owned());
-
-            run_with_env("", || item.save()).await.unwrap();
-
-            assert_eq!(
-                fs::read_to_string(item.path).unwrap(),
-                r#"{"globs":[],"projects":{"foo":"bar"}}"#
-            );
-
-            dir.close().unwrap();
-        }
-    }
-
-    mod save_hash {
-        use super::*;
-        use serde::Deserialize;
-
-        #[derive(Default, Deserialize, Serialize)]
-        struct TestHasher {
-            field: String,
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn creates_hash_file() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let hasher = TestHasher::default();
-
-            cache.save_hash("abc123", &hasher).await.unwrap();
-
-            assert!(cache.hashes_dir.join("abc123.json").exists());
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn doesnt_create_if_cache_off() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let hasher = TestHasher::default();
-
-            run_with_env("off", || cache.save_hash("abc123", &hasher))
-                .await
-                .unwrap();
-
-            assert!(!cache.hashes_dir.join("abc123.json").exists());
-
-            dir.close().unwrap();
-        }
-
-        #[tokio::test]
-        #[serial]
-        async fn doesnt_create_if_cache_readonly() {
-            let dir = assert_fs::TempDir::new().unwrap();
-            let cache = CacheEngine::create(dir.path()).await.unwrap();
-            let hasher = TestHasher::default();
-
-            run_with_env("read", || cache.save_hash("abc123", &hasher))
-                .await
-                .unwrap();
-
-            assert!(!cache.hashes_dir.join("abc123.json").exists());
-
-            dir.close().unwrap();
-        }
     }
 }

--- a/crates/cache/src/helpers.rs
+++ b/crates/cache/src/helpers.rs
@@ -43,22 +43,3 @@ pub fn to_millis(time: SystemTime) -> u128 {
         Err(_) => 0,
     }
 }
-
-#[cfg(test)]
-pub async fn run_with_env<T, F, Fut>(env: &str, callback: F) -> T
-where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = T>,
-{
-    if env.is_empty() {
-        env::remove_var("MOON_CACHE");
-    } else {
-        env::set_var("MOON_CACHE", env);
-    }
-
-    let result = callback().await;
-
-    env::remove_var("MOON_CACHE");
-
-    result
-}

--- a/crates/cache/tests/engine_test.rs
+++ b/crates/cache/tests/engine_test.rs
@@ -55,12 +55,12 @@ mod delete_hash {
             .write_str("{}")
             .unwrap();
 
-        dir.child(".moon/cache/out/abc123/file.js")
+        dir.child(".moon/cache/out/abc123.tar.gz")
             .write_str("")
             .unwrap();
 
         let hash_file = cache.hashes_dir.join("abc123.json");
-        let out_file = cache.outputs_dir.join("abc123/file.js");
+        let out_file = cache.outputs_dir.join("abc123.tar.gz");
 
         assert!(hash_file.exists());
         assert!(out_file.exists());
@@ -83,12 +83,12 @@ mod delete_hash {
             .write_str("{}")
             .unwrap();
 
-        dir.child(".moon/cache/out/abc123/file.js")
+        dir.child(".moon/cache/out/abc123.tar.gz")
             .write_str("")
             .unwrap();
 
         let hash_file = cache.hashes_dir.join("abc123.json");
-        let out_file = cache.outputs_dir.join("abc123/file.js");
+        let out_file = cache.outputs_dir.join("abc123.tar.gz");
 
         assert!(hash_file.exists());
         assert!(out_file.exists());
@@ -113,12 +113,12 @@ mod delete_hash {
             .write_str("{}")
             .unwrap();
 
-        dir.child(".moon/cache/out/abc123/file.js")
+        dir.child(".moon/cache/out/abc123.tar.gz")
             .write_str("")
             .unwrap();
 
         let hash_file = cache.hashes_dir.join("abc123.json");
-        let out_file = cache.outputs_dir.join("abc123/file.js");
+        let out_file = cache.outputs_dir.join("abc123.tar.gz");
 
         assert!(hash_file.exists());
         assert!(out_file.exists());

--- a/crates/cache/tests/engine_test.rs
+++ b/crates/cache/tests/engine_test.rs
@@ -1,0 +1,595 @@
+use assert_fs::prelude::*;
+use moon_cache::{to_millis, CacheEngine, ProjectsState, RunTargetState, WorkspaceState};
+use serde::Serialize;
+use serial_test::serial;
+use std::env;
+use std::fs;
+
+async fn run_with_env<T, F, Fut>(env: &str, callback: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = T>,
+{
+    if env.is_empty() {
+        env::remove_var("MOON_CACHE");
+    } else {
+        env::set_var("MOON_CACHE", env);
+    }
+
+    let result = callback().await;
+
+    env::remove_var("MOON_CACHE");
+
+    result
+}
+
+mod create {
+    use super::*;
+
+    #[tokio::test]
+    #[serial]
+    async fn creates_dirs() {
+        let dir = assert_fs::TempDir::new().unwrap();
+
+        CacheEngine::create(dir.path()).await.unwrap();
+
+        assert!(dir.path().join(".moon/cache").exists());
+        assert!(dir.path().join(".moon/cache/hashes").exists());
+        assert!(dir.path().join(".moon/cache/runs").exists());
+        assert!(dir.path().join(".moon/cache/out").exists());
+
+        dir.close().unwrap();
+    }
+}
+
+mod delete_hash {
+    use super::*;
+
+    #[tokio::test]
+    #[serial]
+    async fn deletes_files() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+
+        dir.child(".moon/cache/hashes/abc123.json")
+            .write_str("{}")
+            .unwrap();
+
+        dir.child(".moon/cache/out/abc123/file.js")
+            .write_str("")
+            .unwrap();
+
+        let hash_file = cache.hashes_dir.join("abc123.json");
+        let out_file = cache.outputs_dir.join("abc123/file.js");
+
+        assert!(hash_file.exists());
+        assert!(out_file.exists());
+
+        cache.delete_hash("abc123").await.unwrap();
+
+        assert!(!hash_file.exists());
+        assert!(!out_file.exists());
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn doesnt_delete_if_cache_off() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+
+        dir.child(".moon/cache/hashes/abc123.json")
+            .write_str("{}")
+            .unwrap();
+
+        dir.child(".moon/cache/out/abc123/file.js")
+            .write_str("")
+            .unwrap();
+
+        let hash_file = cache.hashes_dir.join("abc123.json");
+        let out_file = cache.outputs_dir.join("abc123/file.js");
+
+        assert!(hash_file.exists());
+        assert!(out_file.exists());
+
+        run_with_env("off", || cache.delete_hash("abc123"))
+            .await
+            .unwrap();
+
+        assert!(hash_file.exists());
+        assert!(out_file.exists());
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn doesnt_delete_if_cache_readonly() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+
+        dir.child(".moon/cache/hashes/abc123.json")
+            .write_str("{}")
+            .unwrap();
+
+        dir.child(".moon/cache/out/abc123/file.js")
+            .write_str("")
+            .unwrap();
+
+        let hash_file = cache.hashes_dir.join("abc123.json");
+        let out_file = cache.outputs_dir.join("abc123/file.js");
+
+        assert!(hash_file.exists());
+        assert!(out_file.exists());
+
+        run_with_env("read", || cache.delete_hash("abc123"))
+            .await
+            .unwrap();
+
+        assert!(hash_file.exists());
+        assert!(out_file.exists());
+
+        dir.close().unwrap();
+    }
+}
+
+mod create_runfile {
+    use super::*;
+
+    #[tokio::test]
+    #[serial]
+    async fn creates_runfile_on_call() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let runfile = cache
+            .create_runfile("123", &"content".to_owned())
+            .await
+            .unwrap();
+
+        assert!(runfile.path.exists());
+
+        assert_eq!(
+            fs::read_to_string(dir.path().join(".moon/cache/runs/123/runfile.json")).unwrap(),
+            "\"content\""
+        );
+
+        dir.close().unwrap();
+    }
+}
+
+mod cache_run_target_state {
+    use super::*;
+
+    #[tokio::test]
+    #[serial]
+    async fn creates_parent_dir_on_call() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = cache.cache_run_target_state("foo:bar").await.unwrap();
+
+        assert!(!item.path.exists());
+        assert!(item.path.parent().unwrap().exists());
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn loads_cache_if_it_exists() {
+        let dir = assert_fs::TempDir::new().unwrap();
+
+        dir.child(".moon/cache/runs/foo/bar/lastRunState.json")
+                .write_str(r#"{"exitCode":123,"hash":"","lastRunTime":0,"stderr":"","stdout":"","target":"foo:bar"}"#)
+                .unwrap();
+
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = cache.cache_run_target_state("foo:bar").await.unwrap();
+
+        assert_eq!(
+            item.item,
+            RunTargetState {
+                exit_code: 123,
+                target: String::from("foo:bar"),
+                ..RunTargetState::default()
+            }
+        );
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn loads_cache_if_it_exists_and_cache_is_readonly() {
+        let dir = assert_fs::TempDir::new().unwrap();
+
+        dir.child(".moon/cache/runs/foo/bar/lastRunState.json")
+                .write_str(r#"{"exitCode":123,"hash":"","lastRunTime":0,"stderr":"","stdout":"","target":"foo:bar"}"#)
+                .unwrap();
+
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = run_with_env("read", || cache.cache_run_target_state("foo:bar"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            item.item,
+            RunTargetState {
+                exit_code: 123,
+                target: String::from("foo:bar"),
+                ..RunTargetState::default()
+            }
+        );
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn doesnt_load_if_it_exists_but_cache_is_off() {
+        let dir = assert_fs::TempDir::new().unwrap();
+
+        dir.child(".moon/cache/runs/foo/bar/lastRunState.json")
+                .write_str(r#"{"exitCode":123,"hash":"","lastRunTime":0,"stderr":"","stdout":"","target":"foo:bar"}"#)
+                .unwrap();
+
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = run_with_env("off", || cache.cache_run_target_state("foo:bar"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            item.item,
+            RunTargetState {
+                target: String::from("foo:bar"),
+                ..RunTargetState::default()
+            }
+        );
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn saves_to_cache() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let mut item = cache.cache_run_target_state("foo:bar").await.unwrap();
+
+        item.item.exit_code = 123;
+
+        run_with_env("", || item.save()).await.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(item.path).unwrap(),
+            r#"{"exitCode":123,"hash":"","lastRunTime":0,"stderr":"","stdout":"","target":"foo:bar"}"#
+        );
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn doesnt_save_if_cache_off() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let mut item = cache.cache_run_target_state("foo:bar").await.unwrap();
+
+        item.item.exit_code = 123;
+
+        run_with_env("off", || item.save()).await.unwrap();
+
+        assert!(!item.path.exists());
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn doesnt_save_if_cache_readonly() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let mut item = cache.cache_run_target_state("foo:bar").await.unwrap();
+
+        item.item.exit_code = 123;
+
+        run_with_env("read", || item.save()).await.unwrap();
+
+        assert!(!item.path.exists());
+
+        dir.close().unwrap();
+    }
+}
+
+mod cache_workspace_state {
+    use super::*;
+
+    #[tokio::test]
+    #[serial]
+    async fn creates_parent_dir_on_call() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = cache.cache_workspace_state().await.unwrap();
+
+        assert!(!item.path.exists());
+        assert!(item.path.parent().unwrap().exists());
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn loads_cache_if_it_exists() {
+        let dir = assert_fs::TempDir::new().unwrap();
+
+        dir.child(".moon/cache/workspaceState.json")
+            .write_str(r#"{"lastNodeInstallTime":123}"#)
+            .unwrap();
+
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = cache.cache_workspace_state().await.unwrap();
+
+        assert_eq!(
+            item.item,
+            WorkspaceState {
+                last_node_install_time: 123,
+                last_version_check_time: 0,
+            }
+        );
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn loads_cache_if_it_exists_and_cache_is_readonly() {
+        let dir = assert_fs::TempDir::new().unwrap();
+
+        dir.child(".moon/cache/workspaceState.json")
+            .write_str(r#"{"lastNodeInstallTime":123}"#)
+            .unwrap();
+
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = run_with_env("read", || cache.cache_workspace_state())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            item.item,
+            WorkspaceState {
+                last_node_install_time: 123,
+                last_version_check_time: 0,
+            }
+        );
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn doesnt_load_if_it_exists_but_cache_is_off() {
+        let dir = assert_fs::TempDir::new().unwrap();
+
+        dir.child(".moon/cache/workspaceState.json")
+            .write_str(r#"{"lastNodeInstallTime":123}"#)
+            .unwrap();
+
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = run_with_env("off", || cache.cache_workspace_state())
+            .await
+            .unwrap();
+
+        assert_eq!(item.item, WorkspaceState::default());
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn saves_to_cache() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let mut item = cache.cache_workspace_state().await.unwrap();
+
+        item.item.last_node_install_time = 123;
+
+        run_with_env("", || item.save()).await.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(item.path).unwrap(),
+            r#"{"lastNodeInstallTime":123,"lastVersionCheckTime":0}"#
+        );
+
+        dir.close().unwrap();
+    }
+}
+
+mod cache_projects_state {
+    use super::*;
+    use filetime::{set_file_mtime, FileTime};
+    use moon_utils::string_vec;
+    use std::collections::HashMap;
+    use std::time::SystemTime;
+
+    #[tokio::test]
+    #[serial]
+    async fn creates_parent_dir_on_call() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = cache.cache_projects_state().await.unwrap();
+
+        assert!(!item.path.exists());
+        assert!(item.path.parent().unwrap().exists());
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn loads_cache_if_it_exists() {
+        let dir = assert_fs::TempDir::new().unwrap();
+
+        dir.child(".moon/cache/projectsState.json")
+            .write_str(r#"{"globs":["**/*"],"projects":{"foo":"bar"}}"#)
+            .unwrap();
+
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = cache.cache_projects_state().await.unwrap();
+
+        assert_eq!(
+            item.item,
+            ProjectsState {
+                globs: string_vec!["**/*"],
+                projects: HashMap::from([("foo".to_owned(), "bar".to_owned())]),
+            }
+        );
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn loads_cache_if_it_exists_and_cache_is_readonly() {
+        let dir = assert_fs::TempDir::new().unwrap();
+
+        dir.child(".moon/cache/projectsState.json")
+            .write_str(r#"{"globs":["**/*"],"projects":{"foo":"bar"}}"#)
+            .unwrap();
+
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = run_with_env("read", || cache.cache_projects_state())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            item.item,
+            ProjectsState {
+                globs: string_vec!["**/*"],
+                projects: HashMap::from([("foo".to_owned(), "bar".to_owned())]),
+            }
+        );
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn doesnt_load_if_it_exists_but_cache_is_off() {
+        let dir = assert_fs::TempDir::new().unwrap();
+
+        dir.child(".moon/cache/projectsState.json")
+            .write_str(r#"{"globs":[],"projects":{"foo":"bar"}}"#)
+            .unwrap();
+
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = run_with_env("off", || cache.cache_projects_state())
+            .await
+            .unwrap();
+
+        assert_eq!(item.item, ProjectsState::default());
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn doesnt_load_if_it_exists_but_cache_is_stale() {
+        let dir = assert_fs::TempDir::new().unwrap();
+
+        dir.child(".moon/cache/projectsState.json")
+            .write_str(r#"{"globs":[],"projects":{"foo":"bar"}}"#)
+            .unwrap();
+
+        let now = to_millis(SystemTime::now()) - 100000;
+
+        set_file_mtime(
+            dir.path().join(".moon/cache/projectsState.json"),
+            FileTime::from_unix_time((now / 1000) as i64, 0),
+        )
+        .unwrap();
+
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let item = cache.cache_projects_state().await.unwrap();
+
+        assert_eq!(item.item, ProjectsState::default());
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn saves_to_cache() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let mut item = cache.cache_projects_state().await.unwrap();
+
+        item.item
+            .projects
+            .insert("foo".to_owned(), "bar".to_owned());
+
+        run_with_env("", || item.save()).await.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(item.path).unwrap(),
+            r#"{"globs":[],"projects":{"foo":"bar"}}"#
+        );
+
+        dir.close().unwrap();
+    }
+}
+
+mod create_hash_manifest {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Default, Deserialize, Serialize)]
+    struct TestHasher {
+        field: String,
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn creates_hash_file() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let hasher = TestHasher::default();
+
+        cache.create_hash_manifest("abc123", &hasher).await.unwrap();
+
+        assert!(cache.hashes_dir.join("abc123.json").exists());
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn doesnt_create_if_cache_off() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let hasher = TestHasher::default();
+
+        run_with_env("off", || cache.create_hash_manifest("abc123", &hasher))
+            .await
+            .unwrap();
+
+        assert!(!cache.hashes_dir.join("abc123.json").exists());
+
+        dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn doesnt_create_if_cache_readonly() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let cache = CacheEngine::create(dir.path()).await.unwrap();
+        let hasher = TestHasher::default();
+
+        run_with_env("read", || cache.create_hash_manifest("abc123", &hasher))
+            .await
+            .unwrap();
+
+        assert!(!cache.hashes_dir.join("abc123.json").exists());
+
+        dir.close().unwrap();
+    }
+}

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -46,4 +46,5 @@ moon_cache = { path = "../cache" }
 assert_cmd = "2.0.4"
 insta = "1.16.0"
 predicates = "2.1.1"
+pretty_assertions = "1.2.1"
 serial_test = "0.8.0"

--- a/crates/cli/src/commands/ci.rs
+++ b/crates/cli/src/commands/ci.rs
@@ -12,7 +12,7 @@ use moon_workspace::{Workspace, WorkspaceError};
 
 type TargetList = Vec<Target>;
 
-const TARGET: &str = "moon:ci";
+const LOG_TARGET: &str = "moon:ci";
 
 fn print_header(title: &str) {
     let prefix = if is_ci() { "--- " } else { "" };
@@ -78,7 +78,7 @@ fn gather_runnable_targets(
                 }
             } else {
                 debug!(
-                    target: TARGET,
+                    target: LOG_TARGET,
                     "Not running target {} because it either has no `outputs` or `runInCI` is false",
                     color::target(&target.id),
                 );

--- a/crates/cli/src/queries/projects.rs
+++ b/crates/cli/src/queries/projects.rs
@@ -4,7 +4,7 @@ use moon_utils::regex;
 use moon_workspace::{Workspace, WorkspaceError};
 use serde::{Deserialize, Serialize};
 
-const TARGET: &str = "moon:query:projects";
+const LOG_TARGET: &str = "moon:query:projects";
 
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct QueryProjectsOptions {
@@ -28,7 +28,7 @@ fn convert_to_regex(
     match value {
         Some(pattern) => {
             trace!(
-                target: TARGET,
+                target: LOG_TARGET,
                 "Filtering projects \"{}\" by matching pattern \"{}\"",
                 field,
                 pattern
@@ -45,7 +45,7 @@ pub async fn query_projects(
     workspace: &Workspace,
     options: &QueryProjectsOptions,
 ) -> Result<Vec<Project>, WorkspaceError> {
-    debug!(target: TARGET, "Querying for projects");
+    debug!(target: LOG_TARGET, "Querying for projects");
 
     let mut projects = vec![];
     let id_regex = convert_to_regex("id", &options.id)?;

--- a/crates/cli/src/queries/touched_files.rs
+++ b/crates/cli/src/queries/touched_files.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-const TARGET: &str = "moon:query:touched-files";
+const LOG_TARGET: &str = "moon:query:touched-files";
 
 #[derive(Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -32,7 +32,7 @@ pub async fn query_touched_files(
     workspace: &Workspace,
     options: &mut QueryTouchedFilesOptions,
 ) -> Result<TouchedFilePaths, WorkspaceError> {
-    debug!(target: TARGET, "Querying for touched files");
+    debug!(target: LOG_TARGET, "Querying for touched files");
 
     let vcs = &workspace.vcs;
     let default_branch = vcs.get_default_branch();
@@ -49,7 +49,7 @@ pub async fn query_touched_files(
     // On default branch, so compare against self -1 revision
     let touched_files_map = if options.default_branch && vcs.is_default_branch(&current_branch) {
         trace!(
-            target: TARGET,
+            target: LOG_TARGET,
             "On default branch {}, comparing against previous revision",
             current_branch
         );
@@ -60,7 +60,7 @@ pub async fn query_touched_files(
         // On a branch, so compare branch against upstream base/default branch
     } else if !options.local {
         trace!(
-            target: TARGET,
+            target: LOG_TARGET,
             "Against upstream using base \"{}\" with head \"{}\"",
             options.base,
             options.head,
@@ -71,7 +71,7 @@ pub async fn query_touched_files(
 
         // Otherwise, check locally touched files
     } else {
-        trace!(target: TARGET, "Against locally touched",);
+        trace!(target: LOG_TARGET, "Against locally touched",);
 
         vcs.get_touched_files().await?
     };
@@ -79,7 +79,7 @@ pub async fn query_touched_files(
     let mut touched_files_to_log = vec![];
 
     debug!(
-        target: TARGET,
+        target: LOG_TARGET,
         "Filtering based on touched status \"{}\"", options.status
     );
 

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -683,8 +683,7 @@ mod outputs {
         assert!(fixture
             .path()
             .join(".moon/cache/out")
-            .join(hash)
-            .join("lib/one.js")
+            .join(format!("{}.tar.gz", hash))
             .exists());
     }
 
@@ -710,14 +709,7 @@ mod outputs {
         assert!(fixture
             .path()
             .join(".moon/cache/out")
-            .join(&hash)
-            .join("lib/one.js")
-            .exists());
-        assert!(fixture
-            .path()
-            .join(".moon/cache/out")
-            .join(&hash)
-            .join("lib/two.js")
+            .join(format!("{}.tar.gz", hash))
             .exists());
     }
 
@@ -743,14 +735,7 @@ mod outputs {
         assert!(fixture
             .path()
             .join(".moon/cache/out")
-            .join(&hash)
-            .join("lib/one.js")
-            .exists());
-        assert!(fixture
-            .path()
-            .join(".moon/cache/out")
-            .join(&hash)
-            .join("lib/two.js")
+            .join(format!("{}.tar.gz", hash))
             .exists());
     }
 
@@ -776,14 +761,7 @@ mod outputs {
         assert!(fixture
             .path()
             .join(".moon/cache/out")
-            .join(&hash)
-            .join("lib/one.js")
-            .exists());
-        assert!(fixture
-            .path()
-            .join(".moon/cache/out")
-            .join(&hash)
-            .join("esm/two.js")
+            .join(format!("{}.tar.gz", hash))
             .exists());
     }
 
@@ -804,18 +782,12 @@ mod outputs {
             .join(".moon/cache/hashes")
             .join(format!("{}.json", hash))
             .exists());
+
         // outputs
         assert!(fixture
             .path()
             .join(".moon/cache/out")
-            .join(&hash)
-            .join("lib/one.js")
-            .exists());
-        assert!(fixture
-            .path()
-            .join(".moon/cache/out")
-            .join(&hash)
-            .join("esm/two.js")
+            .join(format!("{}.tar.gz", hash))
             .exists());
     }
 }

--- a/crates/cli/tests/snapshots/run_test__caching__creates_run_state_cache.snap
+++ b/crates/cli/tests/snapshots/run_test__caching__creates_run_state_cache.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/cli/tests/run_test.rs
 assertion_line: 251
-expression: "read_to_string(fixture.path().join(format!(\".moon/cache/hashes/{}.json\",\n                state.item.hash))).unwrap()"
+expression: "fs::read_to_string(fixture.path().join(format!(\".moon/cache/hashes/{}.json\",\n                state.item.hash))).unwrap()"
 ---
 [
   {
@@ -29,6 +29,7 @@ expression: "read_to_string(fixture.path().join(format!(\".moon/cache/hashes/{}.
       "node/topLevelAwait.mjs": "50945a9865eddbd52f7e648743d627749623da22",
       "node/unhandledPromise.js": "909d23eeb442f4daff733fe3b601a1a1613c1282"
     },
+    "outputs": [],
     "projectDeps": [],
     "target": "node:standard",
     "version": "1"

--- a/crates/cli/tests/snapshots/run_test__outputs__hydration__reuses_cache_from_previous_run-2.snap
+++ b/crates/cli/tests/snapshots/run_test__outputs__hydration__reuses_cache_from_previous_run-2.snap
@@ -1,0 +1,12 @@
+---
+source: crates/cli/tests/run_test.rs
+assertion_line: 824
+expression: get_assert_output(&assert2)
+---
+▪▪▪▪ outputs:generateFileAndFolder (cached)
+
+Tasks: 1 completed (1 cached)
+ Time: 100ms
+
+
+

--- a/crates/cli/tests/snapshots/run_test__outputs__hydration__reuses_cache_from_previous_run.snap
+++ b/crates/cli/tests/snapshots/run_test__outputs__hydration__reuses_cache_from_previous_run.snap
@@ -1,0 +1,13 @@
+---
+source: crates/cli/tests/run_test.rs
+assertion_line: 823
+expression: get_assert_output(&assert1)
+---
+▪▪▪▪ npm install
+▪▪▪▪ outputs:generateFileAndFolder
+
+Tasks: 1 completed
+ Time: 100ms
+
+
+

--- a/crates/hasher/src/hasher.rs
+++ b/crates/hasher/src/hasher.rs
@@ -23,6 +23,9 @@ pub struct TargetHasher {
     // Input files and globs mapped to a unique hash
     inputs: BTreeMap<String, String>,
 
+    // Relative output paths
+    outputs: Vec<String>,
+
     // `moon.yml` `dependsOn`
     project_deps: Vec<String>,
 
@@ -75,11 +78,13 @@ impl TargetHasher {
         self.args = task.args.clone();
         self.env_vars.extend(task.env.clone());
         self.deps = task.deps.clone();
+        self.outputs = task.outputs.clone();
         self.target = task.target.clone();
 
         // Sort vectors to be deterministic
         self.args.sort();
         self.deps.sort();
+        self.outputs.sort();
 
         // Inherits vars from inputs
         for var_name in &task.input_vars {
@@ -101,6 +106,7 @@ impl Hasher for TargetHasher {
         hash_vec(&self.deps, sha);
         hash_btree(&self.env_vars, sha);
         hash_btree(&self.inputs, sha);
+        hash_vec(&self.outputs, sha);
         hash_vec(&self.project_deps, sha);
     }
 }

--- a/crates/platform-node/src/task.rs
+++ b/crates/platform-node/src/task.rs
@@ -5,7 +5,7 @@ use moon_task::{PlatformType, Target, Task, TaskError, TaskID};
 use moon_utils::{process, regex, string_vec};
 use std::collections::{BTreeMap, HashMap};
 
-const TARGET: &str = "moon:node-task";
+const LOG_TARGET: &str = "moon:node-task";
 
 pub type TasksMap = BTreeMap<TaskID, Task>;
 pub type ScriptsMap = HashMap<String, String>;
@@ -318,7 +318,7 @@ impl<'a> ScriptParser<'a> {
             // Do not allow "cd ..."
             if INVALID_CD.is_match(script) {
                 warn!(
-                    target: TARGET,
+                    target: LOG_TARGET,
                     "Changing directories (cd ...) is not supported by moon, skipping script \"{}\" for project \"{}\". As an alternative, create an executable to handle it: https://moonrepo.dev/docs/faq#how-to-pipe-or-redirect-tasks",
                     name,
                     self.project_id,
@@ -330,7 +330,7 @@ impl<'a> ScriptParser<'a> {
             // Rust commands do not support redirects natively
             if INVALID_REDIRECT.is_match(script) {
                 warn!(
-                    target: TARGET,
+                    target: LOG_TARGET,
                     "Redirects (<, >, etc) are not supported by moon, skipping script \"{}\" for project \"{}\". As an alternative, create an executable that does the redirect: https://moonrepo.dev/docs/faq#how-to-pipe-or-redirect-tasks",
                     name,
                     self.project_id,
@@ -342,7 +342,7 @@ impl<'a> ScriptParser<'a> {
             // Rust commands do not support pipes natively
             if INVALID_PIPE.is_match(script) {
                 warn!(
-                    target: TARGET,
+                    target: LOG_TARGET,
                     "Pipes (|) are not supported by moon, skipping script \"{}\" for project \"{}\". As an alternative, create an executable that does the piping: https://moonrepo.dev/docs/faq#how-to-pipe-or-redirect-tasks",
                     name,
                     self.project_id,
@@ -354,7 +354,7 @@ impl<'a> ScriptParser<'a> {
             // Rust commands do not support operators natively
             if INVALID_OPERATOR.is_match(script) {
                 warn!(
-                    target: TARGET,
+                    target: LOG_TARGET,
                     "OR operator (||) is not supported by moon, skipping script \"{}\" for project \"{}\". As an alternative, create an executable to handle it: https://moonrepo.dev/docs/faq#how-to-pipe-or-redirect-tasks",
                     name,
                     self.project_id,

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+moon_archive = { path = "../archive" }
 moon_config = { path = "../config" }
 moon_constants = { path = "../constants" }
 moon_error = { path = "../error" }
@@ -12,12 +13,9 @@ moon_lang_node = { path = "../lang-node" }
 moon_logger = { path = "../logger" }
 moon_utils = { path = "../utils" }
 async-trait = "0.1.56"
-flate2 = "1.0.24"
 reqwest = "0.11.11"
 sha2 = "0.10.2"
-tar = "0.4.38"
 thiserror = "1.0.31"
-zip = "0.6.2"
 
 [dev-dependencies]
 assert_fs = "1.0.7"

--- a/crates/toolchain/src/errors.rs
+++ b/crates/toolchain/src/errors.rs
@@ -1,3 +1,4 @@
+use moon_archive::ArchiveError;
 use moon_error::MoonError;
 use moon_lang::LangError;
 use thiserror::Error;
@@ -12,6 +13,9 @@ pub enum ToolchainError {
 
     #[error("Unable to find a node module binary for <symbol>{0}</symbol>. Have you installed the corresponding package?")]
     MissingNodeModuleBin(String), // bin name
+
+    #[error(transparent)]
+    Archive(#[from] ArchiveError),
 
     #[error(transparent)]
     Lang(#[from] LangError),

--- a/crates/toolchain/src/helpers.rs
+++ b/crates/toolchain/src/helpers.rs
@@ -1,5 +1,5 @@
 use crate::errors::ToolchainError;
-use flate2::read::GzDecoder;
+use moon_archive::untar;
 use moon_error::map_io_to_fs_error;
 use moon_logger::{color, trace};
 use moon_utils::fs;
@@ -9,8 +9,6 @@ use std::env;
 use std::fs::File;
 use std::io;
 use std::path::Path;
-use tar::Archive;
-use zip::ZipArchive;
 
 pub const LOG_TARGET: &str = "moon:toolchain";
 
@@ -97,107 +95,6 @@ pub async fn download_file_from_url(url: &str, dest: &Path) -> Result<(), Toolch
     Ok(())
 }
 
-#[track_caller]
-pub fn unpack_tar(
-    input_file: &Path,
-    output_dir: &Path,
-    prefix: &str,
-) -> Result<(), ToolchainError> {
-    trace!(
-        target: LOG_TARGET,
-        "Unpacking archive {} to {}",
-        color::path(input_file),
-        color::path(output_dir),
-    );
-
-    // Open .tar.gz file
-    let tar_gz =
-        File::open(input_file).map_err(|e| map_io_to_fs_error(e, input_file.to_path_buf()))?;
-
-    // Decompress to .tar
-    let tar = GzDecoder::new(tar_gz);
-
-    // Unpack the archive into the install dir
-    let mut archive = Archive::new(tar);
-
-    archive.entries().unwrap().for_each(|entry_result| {
-        let mut entry = entry_result.unwrap();
-
-        // Remove the download folder prefix from all files
-        let path = entry
-            .path()
-            .unwrap()
-            .strip_prefix(&prefix)
-            .unwrap()
-            .to_owned();
-
-        entry.unpack(&output_dir.join(path)).unwrap();
-    });
-
-    Ok(())
-}
-
-#[track_caller]
-pub fn unpack_zip(
-    input_file: &Path,
-    output_dir: &Path,
-    prefix: &str,
-) -> Result<(), ToolchainError> {
-    trace!(
-        target: LOG_TARGET,
-        "Unzipping archive {} to {}",
-        color::path(input_file),
-        color::path(output_dir),
-    );
-
-    // Open .zip file
-    let zip =
-        File::open(input_file).map_err(|e| map_io_to_fs_error(e, input_file.to_path_buf()))?;
-
-    // Unpack the archive into the install dir
-    let mut archive = ZipArchive::new(zip).unwrap();
-
-    for i in 0..archive.len() {
-        let mut file = archive.by_index(i).unwrap();
-
-        // Remove the download folder prefix from all files
-        let path = match file.enclosed_name() {
-            Some(path) => path.strip_prefix(&prefix).unwrap().to_owned(),
-            None => continue,
-        };
-
-        let output_path = output_dir.join(&path);
-        let handle_error = |e: io::Error| map_io_to_fs_error(e, output_path.to_path_buf());
-
-        // If a folder, ensure it exists and continue
-        if file.is_dir() {
-            if !output_path.exists() {
-                // `zip` is not `Send`able, so we cant use our async variant here
-                std::fs::create_dir(&output_path).map_err(handle_error)?;
-            }
-
-            // If a file, copy it to the output dir
-        } else {
-            let mut out = File::create(&output_path).map_err(handle_error)?;
-
-            io::copy(&mut file, &mut out).map_err(handle_error)?;
-        }
-
-        // Update permissions when on a nix machine
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            if let Some(mode) = file.unix_mode() {
-                std::fs::set_permissions(&output_path, std::fs::Permissions::from_mode(mode))
-                    .map_err(handle_error)?;
-            }
-        }
-    }
-
-    Ok(())
-}
-
 pub async fn unpack(
     input_file: &Path,
     output_dir: &Path,
@@ -206,9 +103,9 @@ pub async fn unpack(
     fs::create_dir_all(output_dir).await?;
 
     if input_file.extension().unwrap() == "zip" {
-        unpack_zip(input_file, output_dir, prefix)?;
+        // unpack_zip(input_file, output_dir, prefix)?;
     } else {
-        unpack_tar(input_file, output_dir, prefix)?;
+        untar(input_file, output_dir, Some(prefix))?;
     }
 
     Ok(())

--- a/crates/toolchain/src/helpers.rs
+++ b/crates/toolchain/src/helpers.rs
@@ -1,5 +1,5 @@
 use crate::errors::ToolchainError;
-use moon_archive::untar;
+use moon_archive::{untar, unzip};
 use moon_error::map_io_to_fs_error;
 use moon_logger::{color, trace};
 use moon_utils::fs;
@@ -103,7 +103,7 @@ pub async fn unpack(
     fs::create_dir_all(output_dir).await?;
 
     if input_file.extension().unwrap() == "zip" {
-        // unpack_zip(input_file, output_dir, prefix)?;
+        unzip(input_file, output_dir, Some(prefix))?;
     } else {
         untar(input_file, output_dir, Some(prefix))?;
     }

--- a/crates/utils/src/fs.rs
+++ b/crates/utils/src/fs.rs
@@ -189,6 +189,18 @@ pub async fn read_json_string<T: AsRef<Path>>(path: T) -> Result<String, MoonErr
     clean_json(json)
 }
 
+pub async fn remove<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
+    let path = path.as_ref();
+
+    if path.is_file() {
+        remove_file(path).await?;
+    } else if path.is_dir() {
+        remove_dir_all(path).await?;
+    }
+
+    Ok(())
+}
+
 pub async fn remove_file<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
     let path = path.as_ref();
 

--- a/crates/utils/src/test.rs
+++ b/crates/utils/src/test.rs
@@ -131,7 +131,7 @@ pub fn get_assert_stdout_output(assert: &assert_cmd::assert::Assert) -> String {
     String::from_utf8(assert.get_output().stdout.to_owned()).unwrap()
 }
 
-fn debug_sandbox_files(dir: &Path) {
+pub fn debug_sandbox_files(dir: &Path) {
     for entry in std::fs::read_dir(dir).unwrap() {
         let path = entry.unwrap().path();
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,8 +4,16 @@
 
 #### 💥 Breaking
 
+- Task outputs are now cached as `.tar.gz` archives, instead of being copied as-is. This shouldn't
+  affect consumers, but we're raising awareness in case of any platform specific issues.
 - Renamed the project-level `project.yml` file to `moon.yml`. The `.moon/project.yml` file has not
   changed.
+
+#### 🐞 Fixes
+
+- Fixed some issues where task outputs were not being hydrated based on the state of the
+  target/project.
+- Fixed an issue where task outputs were not considered for hash generation.
 
 ## 0.9.1
 

--- a/tests/fixtures/cases/outputs/generate.js
+++ b/tests/fixtures/cases/outputs/generate.js
@@ -7,7 +7,7 @@ function createFile(file) {
 	const filePath = path.join(__dirname, file);
 
 	fs.mkdirSync(path.dirname(filePath), { recursive: true });
-	fs.writeFileSync(filePath, '', 'utf8');
+	fs.writeFileSync(filePath, String(Date.now()), 'utf8');
 }
 
 switch (type) {

--- a/tests/fixtures/cases/outputs/moon.yml
+++ b/tests/fixtures/cases/outputs/moon.yml
@@ -4,34 +4,46 @@ tasks:
   generateFile:
     command: node
     args: generate.js single-file
+    inputs:
+      - '*.js'
     outputs:
       - 'lib/one.js'
   generateFiles:
     command: node
     args: generate.js multiple-files
+    inputs:
+      - '*.js'
     outputs:
       - 'lib/one.js'
       - 'lib/two.js'
   generateFolder:
     command: node
     args: generate.js single-folder
+    inputs:
+      - '*.js'
     outputs:
       - 'lib'
   generateFolders:
     command: node
     args: generate.js multiple-folders
+    inputs:
+      - '*.js'
     outputs:
       - 'lib'
       - 'esm'
   generateFileAndFolder:
     command: node
     args: generate.js both
+    inputs:
+      - '*.js'
     outputs:
       - 'lib/one.js'
       - 'esm'
   noCache:
     command: node
     args: generate.js both
+    inputs:
+      - '*.js'
     outputs:
       - 'lib/one.js'
       - 'esm'

--- a/website/docs/concepts/cache.mdx
+++ b/website/docs/concepts/cache.mdx
@@ -40,16 +40,14 @@ The following diagram outlines our cache folder structure and why each piece exi
 	# State of the workspace. Mainly for tracking install times.
 	workspaceState.json
 
-	# Stores hashes of every ran task. Exists purely for debugging purposes.
+	# Stores hash manifests of every ran task. Exists purely for debugging purposes.
 	hashes/
 		# Contents includes all sources used to generate the hash.
 		<hash>.json
 
-	# Task outputs that are hard linked between the cache and project,
-	# grouped by the tasks unique hash (same hash as above).
+	# Stores `tar.gz` archives of a task's outputs based on its generated hash.
 	out/
-		<hash>/
-			...
+		<hash>.tar.gz
 
 	# State of targets that have been ran or are running, grouped by project and task.
 	runs/

--- a/website/docs/concepts/cache.mdx
+++ b/website/docs/concepts/cache.mdx
@@ -20,6 +20,7 @@ Our smart hashing currently takes the following sources into account:
 
 - Command (`command`) being ran and its arguments (`args`).
 - Input sources (`inputs`).
+- Output targets (`outputs`).
 - Environment variables (`env`).
 - Dependencies between projects (`dependsOn`) and tasks (`deps`).
 - **For Node.js tasks**:


### PR DESCRIPTION
Currently, when we cache a task's outputs, we recursively copy all the files/folders into `.moon/cache/out`, and do the reverse when hydrating on a cache hit. This isn't as performant as it could be, so instead we'll now create a `tar.gz` archive for each output, and store it at `.moon/cache/out/<hash>.tar.gz`. When hydrating, we'll simply unpack the archive into the target.

This also helps simplify our infrastructure for the future remote cache mechanism.