### PR TITLE
fix: Find the VCS root when configured in a sub-folder.

### DIFF
--- a/.yarn/versions/da55504b.yml
+++ b/.yarn/versions/da55504b.yml
@@ -1,0 +1,7 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/vcs/src/git.rs
+++ b/crates/vcs/src/git.rs
@@ -28,7 +28,7 @@ impl Git {
         let ignore_path = root.join(".gitignore");
 
         if ignore_path.exists() {
-            let mut builder = GitignoreBuilder::new(root);
+            let mut builder = GitignoreBuilder::new(&root);
 
             if let Some(error) = builder.add(ignore_path) {
                 return Err(VcsError::Ignore(error));

--- a/crates/vcs/src/svn.rs
+++ b/crates/vcs/src/svn.rs
@@ -264,6 +264,6 @@ impl Vcs for Svn {
     }
 
     fn is_enabled(&self) -> bool {
-        fs::find_upwards(".svn", &self.working_dir).is_some()
+        self.root.join(".svn").exists()
     }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Updated `projects` glob matching to support the root project (`'.'`).
+- Updated git/svn to traverse upwards to find the applicable root (`.git`, etc).
+
 ## 0.9.0
 
 #### 💥 Breaking

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 #### 🐞 Fixes
 
-- Updated `projects` glob matching to support the root project (`'.'`).
-- Updated git/svn to traverse upwards to find the applicable root (`.git`, etc).
+- Fixed an issue where a root-level project cannot be configured with a glob. Updated `projects`
+  glob matching to support `'.'`.
+- Fixed an issue where moon was setup in a sub-folder. Updated git/svn to traverse upwards to find
+  the applicable root (`.git`, etc).
 
 ## 0.9.0
 


### PR DESCRIPTION
Right now moon assumes it's at the root.