### PR TITLE
new: Add an `outputStyle` option to  tasks.

### DIFF
--- a/.yarn/versions/34364e45.yml
+++ b/.yarn/versions/34364e45.yml
@@ -1,0 +1,7 @@
+releases:
+  "@moonrepo/cli": minor
+  "@moonrepo/core-linux-x64-gnu": minor
+  "@moonrepo/core-linux-x64-musl": minor
+  "@moonrepo/core-macos-arm64": minor
+  "@moonrepo/core-macos-x64": minor
+  "@moonrepo/core-windows-x64-msvc": minor

--- a/crates/action/src/target/runner.rs
+++ b/crates/action/src/target/runner.rs
@@ -2,6 +2,7 @@ use crate::action::Attempt;
 use crate::context::ActionContext;
 use crate::errors::ActionError;
 use moon_cache::{CacheItem, RunTargetState};
+use moon_config::TaskOutputStyle;
 use moon_error::MoonError;
 use moon_hasher::{convert_paths_to_strings, to_hash, Hasher, TargetHasher};
 use moon_logger::{color, debug, warn};
@@ -242,7 +243,11 @@ impl<'a> TargetRunner<'a> {
         let mut attempts = vec![];
         let is_primary = context.primary_targets.contains(self.target_id);
         let is_real_ci = is_ci() && !is_test_env();
-        let stream_output = is_primary || is_real_ci || self.task.options.stream_output;
+        let stream_output = match self.task.options.output_style {
+            Some(TaskOutputStyle::Stream) => true,
+            Some(TaskOutputStyle::OnExit) => false,
+            None => is_primary || is_real_ci,
+        };
         let output;
 
         loop {

--- a/crates/action/src/target/runner.rs
+++ b/crates/action/src/target/runner.rs
@@ -242,7 +242,7 @@ impl<'a> TargetRunner<'a> {
         let mut attempts = vec![];
         let is_primary = context.primary_targets.contains(self.target_id);
         let is_real_ci = is_ci() && !is_test_env();
-        let stream_output = is_primary || is_real_ci;
+        let stream_output = is_primary || is_real_ci || self.task.options.stream_output;
         let output;
 
         loop {

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -94,6 +94,9 @@ pub struct TaskOptionsConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_from_workspace_root: Option<bool>,
+
+    #[serde(rename = "streamOutput", skip_serializing_if = "Option::is_none")]
+    pub stream_output: Option<bool>,
 }
 
 // We use serde(default) here because figment *does not* apply defaults

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -65,6 +65,13 @@ pub enum TaskMergeStrategy {
     Replace,
 }
 
+#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TaskOutputStyle {
+    OnExit,
+    Stream,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Serialize, Validate)]
 #[serde(default, rename_all = "camelCase")]
 pub struct TaskOptionsConfig {
@@ -86,6 +93,9 @@ pub struct TaskOptionsConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub merge_outputs: Option<TaskMergeStrategy>,
 
+    #[serde(rename = "outputStyle", skip_serializing_if = "Option::is_none")]
+    pub output_style: Option<TaskOutputStyle>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_count: Option<u8>,
 
@@ -94,9 +104,6 @@ pub struct TaskOptionsConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_from_workspace_root: Option<bool>,
-
-    #[serde(rename = "streamOutput", skip_serializing_if = "Option::is_none")]
-    pub stream_output: Option<bool>,
 }
 
 // We use serde(default) here because figment *does not* apply defaults

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -93,7 +93,7 @@ pub struct TaskOptionsConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub merge_outputs: Option<TaskMergeStrategy>,
 
-    #[serde(rename = "outputStyle", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub output_style: Option<TaskOutputStyle>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -229,6 +229,7 @@ mod tasks {
             retry_count: Some(1),
             run_in_ci: Some(true),
             run_from_workspace_root: None,
+            stream_output: None,
         }
     }
 
@@ -243,6 +244,7 @@ mod tasks {
             retry_count: None,
             run_in_ci: None,
             run_from_workspace_root: None,
+            stream_output: None,
         }
     }
 
@@ -257,6 +259,7 @@ mod tasks {
             retry_count: Some(1),
             run_in_ci: Some(true),
             run_from_workspace_root: None,
+            stream_output: None,
         }
     }
 
@@ -735,6 +738,7 @@ mod tasks {
                     retry_count: Some(1),
                     run_in_ci: Some(true),
                     run_from_workspace_root: None,
+                    stream_output: None,
                 },
                 type_of: PlatformType::Unknown,
             },
@@ -768,6 +772,7 @@ mod tasks {
                                 retry_count: None,
                                 run_in_ci: None,
                                 run_from_workspace_root: None,
+                                stream_output: None,
                             },
                             type_of: PlatformType::Unknown,
                         }

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -226,10 +226,10 @@ mod tasks {
             merge_env: Some(strategy.clone()),
             merge_inputs: Some(strategy.clone()),
             merge_outputs: Some(strategy),
+            output_style: None,
             retry_count: Some(1),
             run_in_ci: Some(true),
             run_from_workspace_root: None,
-            stream_output: None,
         }
     }
 
@@ -241,10 +241,10 @@ mod tasks {
             merge_env: Some(strategy.clone()),
             merge_inputs: Some(strategy.clone()),
             merge_outputs: Some(strategy),
+            output_style: None,
             retry_count: None,
             run_in_ci: None,
             run_from_workspace_root: None,
-            stream_output: None,
         }
     }
 
@@ -256,10 +256,10 @@ mod tasks {
             merge_env: None,
             merge_inputs: None,
             merge_outputs: None,
+            output_style: None,
             retry_count: Some(1),
             run_in_ci: Some(true),
             run_from_workspace_root: None,
-            stream_output: None,
         }
     }
 
@@ -735,10 +735,10 @@ mod tasks {
                     merge_env: Some(TaskMergeStrategy::Replace),
                     merge_inputs: Some(TaskMergeStrategy::Replace),
                     merge_outputs: Some(TaskMergeStrategy::Append),
+                    output_style: None,
                     retry_count: Some(1),
                     run_in_ci: Some(true),
                     run_from_workspace_root: None,
-                    stream_output: None,
                 },
                 type_of: PlatformType::Unknown,
             },
@@ -769,10 +769,10 @@ mod tasks {
                                 merge_env: Some(TaskMergeStrategy::Replace),
                                 merge_inputs: Some(TaskMergeStrategy::Replace),
                                 merge_outputs: Some(TaskMergeStrategy::Append),
+                                output_style: None,
                                 retry_count: None,
                                 run_in_ci: None,
                                 run_from_workspace_root: None,
-                                stream_output: None,
                             },
                             type_of: PlatformType::Unknown,
                         }

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -33,6 +33,8 @@ pub struct TaskOptions {
     pub run_in_ci: bool,
 
     pub run_from_workspace_root: bool,
+
+    pub stream_output: bool,
 }
 
 impl Default for TaskOptions {
@@ -47,6 +49,7 @@ impl Default for TaskOptions {
             retry_count: 0,
             run_in_ci: true,
             run_from_workspace_root: false,
+            stream_output: false,
         }
     }
 }
@@ -84,6 +87,10 @@ impl TaskOptions {
         if let Some(run_from_workspace_root) = &config.run_from_workspace_root {
             self.run_from_workspace_root = *run_from_workspace_root;
         }
+
+        if let Some(stream_output) = &config.stream_output {
+            self.stream_output = *stream_output;
+        }
     }
 
     pub fn to_config(&self) -> TaskOptionsConfig {
@@ -102,6 +109,10 @@ impl TaskOptions {
 
         if self.run_from_workspace_root != default_options.run_from_workspace_root {
             config.run_from_workspace_root = Some(self.run_from_workspace_root);
+        }
+
+        if self.stream_output != default_options.stream_output {
+            config.stream_output = Some(self.stream_output);
         }
 
         config
@@ -187,6 +198,7 @@ impl Task {
                 retry_count: cloned_options.retry_count.unwrap_or_default(),
                 run_in_ci: cloned_options.run_in_ci.unwrap_or(!is_long_running),
                 run_from_workspace_root: cloned_options.run_from_workspace_root.unwrap_or_default(),
+                stream_output: cloned_options.stream_output.unwrap_or_default(),
             },
             outputs: cloned_config.outputs.unwrap_or_default(),
             output_paths: HashSet::new(),

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -4,7 +4,7 @@ use crate::token::TokenResolver;
 use crate::types::{EnvVars, TouchedFilePaths};
 use moon_config::{
     DependencyConfig, FileGlob, FilePath, FilePathOrGlob, PlatformType, TargetID, TaskConfig,
-    TaskMergeStrategy, TaskOptionsConfig,
+    TaskMergeStrategy, TaskOptionsConfig, TaskOutputStyle,
 };
 use moon_logger::{color, debug, trace, Logable};
 use moon_utils::{glob, path, regex::ENV_VAR, string_vec};
@@ -28,13 +28,13 @@ pub struct TaskOptions {
 
     pub merge_outputs: TaskMergeStrategy,
 
+    pub output_style: Option<TaskOutputStyle>,
+
     pub retry_count: u8,
 
     pub run_in_ci: bool,
 
     pub run_from_workspace_root: bool,
-
-    pub stream_output: bool,
 }
 
 impl Default for TaskOptions {
@@ -46,10 +46,10 @@ impl Default for TaskOptions {
             merge_env: TaskMergeStrategy::Append,
             merge_inputs: TaskMergeStrategy::Append,
             merge_outputs: TaskMergeStrategy::Append,
+            output_style: None,
             retry_count: 0,
             run_in_ci: true,
             run_from_workspace_root: false,
-            stream_output: false,
         }
     }
 }
@@ -76,6 +76,10 @@ impl TaskOptions {
             self.merge_outputs = merge_outputs.clone();
         }
 
+        if let Some(output_style) = &config.output_style {
+            self.output_style = Some(output_style.clone());
+        }
+
         if let Some(retry_count) = &config.retry_count {
             self.retry_count = *retry_count;
         }
@@ -87,10 +91,6 @@ impl TaskOptions {
         if let Some(run_from_workspace_root) = &config.run_from_workspace_root {
             self.run_from_workspace_root = *run_from_workspace_root;
         }
-
-        if let Some(stream_output) = &config.stream_output {
-            self.stream_output = *stream_output;
-        }
     }
 
     pub fn to_config(&self) -> TaskOptionsConfig {
@@ -98,6 +98,10 @@ impl TaskOptions {
         let mut config = TaskOptionsConfig::default();
 
         // Skip merge options until we need them
+
+        if let Some(output_style) = &self.output_style {
+            config.output_style = Some(output_style.clone());
+        }
 
         if self.retry_count != default_options.retry_count {
             config.retry_count = Some(self.retry_count);
@@ -109,10 +113,6 @@ impl TaskOptions {
 
         if self.run_from_workspace_root != default_options.run_from_workspace_root {
             config.run_from_workspace_root = Some(self.run_from_workspace_root);
-        }
-
-        if self.stream_output != default_options.stream_output {
-            config.stream_output = Some(self.stream_output);
         }
 
         config
@@ -195,10 +195,10 @@ impl Task {
                 merge_env: cloned_options.merge_env.unwrap_or_default(),
                 merge_inputs: cloned_options.merge_inputs.unwrap_or_default(),
                 merge_outputs: cloned_options.merge_outputs.unwrap_or_default(),
+                output_style: cloned_options.output_style,
                 retry_count: cloned_options.retry_count.unwrap_or_default(),
                 run_in_ci: cloned_options.run_in_ci.unwrap_or(!is_long_running),
                 run_from_workspace_root: cloned_options.run_from_workspace_root.unwrap_or_default(),
-                stream_output: cloned_options.stream_output.unwrap_or_default(),
             },
             outputs: cloned_config.outputs.unwrap_or_default(),
             output_paths: HashSet::new(),


### PR DESCRIPTION
### Background

I would like to be able to run multiple `dev`-style tasks at the same time - for example, I have a Remix application and run both a Remix dev server and a Tailwind CSS dev server simultaneously. With moon, that looks something like this:

```yaml
tasks:
  dev:
    command: noop
    deps:
      - app:dev-css
      - app:dev-remix

  dev-css:
    command: tailwindcss
    args: -w -i styles/app.css -o app/styles/app.css

  dev-remix:
    command: remix
    args: dev
```

Currently though, moon only streams the output of the primary task, so running `moon run app:dev` runs both dev servers, but prints nothing.

### Change

This PR adds a new task option named `streamOutput` that when true, streams the output of the task, even if it is not the primary task:

```yaml
  dev:
    command: noop
    deps:
      - app:dev-css
      - app:dev-remix

  dev-css:
    command: tailwindcss
    args: -w -i styles/app.css -o app/styles/app.css
    options:
      streamOutput: true

  dev-remix:
    command: remix
    args: dev
    options:
      streamOutput: true
```

## Review Notes

I'm not sure if this is the best option name or if this fits in with your plans for how moon works internally - let me know if anything should be changed, and no worries about rejecting this PR if it isn't the approach you would prefer. 👍 