### PR TITLE
new: Infer task type based on the command name.

### DIFF
--- a/crates/cli/tests/snapshots/migrate_test__from_package_json__converts_scripts-2.snap
+++ b/crates/cli/tests/snapshots/migrate_test__from_package_json__converts_scripts-2.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/cli/tests/migrate_test.rs
 assertion_line: 21
-expression: "fs::read_to_string(fixture.path().join(\"package-json/common/project.yml\")).unwrap()"
+expression: "fs::read_to_string(fixture.path().join(\"package-json/common/moon.yml\")).unwrap()"
 ---
 ---
 language: javascript

--- a/crates/cli/tests/snapshots/migrate_test__from_package_json__links_depends_on-2.snap
+++ b/crates/cli/tests/snapshots/migrate_test__from_package_json__links_depends_on-2.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/cli/tests/migrate_test.rs
-assertion_line: 41
-expression: "fs::read_to_string(fixture.path().join(\"package-json/deps/project.yml\")).unwrap()"
+assertion_line: 40
+expression: "fs::read_to_string(fixture.path().join(\"package-json/deps/moon.yml\")).unwrap()"
 ---
 ---
 dependsOn:

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -2,7 +2,7 @@ use crate::project::{ProjectConfig, ProjectLanguage};
 use crate::types::{FilePath, InputValue, TargetID};
 use crate::validators::{skip_if_default, validate_child_or_root_path, validate_target};
 use moon_utils::process::split_args;
-use moon_utils::regex::ENV_VAR;
+use moon_utils::regex::{ENV_VAR, NODE_COMMAND, UNIX_SYSTEM_COMMAND, WINDOWS_SYSTEM_COMMAND};
 use schemars::gen::SchemaGenerator;
 use schemars::schema::Schema;
 use schemars::{schema_for, JsonSchema};
@@ -136,7 +136,15 @@ pub struct TaskConfig {
 }
 
 impl TaskConfig {
-    pub fn detect_platform(project: &ProjectConfig) -> PlatformType {
+    pub fn detect_platform(project: &ProjectConfig, command: &str) -> PlatformType {
+        if NODE_COMMAND.is_match(command) {
+            return PlatformType::Node;
+        }
+
+        if UNIX_SYSTEM_COMMAND.is_match(command) || WINDOWS_SYSTEM_COMMAND.is_match(command) {
+            return PlatformType::System;
+        }
+
         match &project.language {
             ProjectLanguage::JavaScript | ProjectLanguage::TypeScript => PlatformType::Node,
             ProjectLanguage::Bash | ProjectLanguage::Batch => PlatformType::System,

--- a/crates/platform-node/src/task.rs
+++ b/crates/platform-node/src/task.rs
@@ -111,7 +111,10 @@ fn clean_script_name(name: &str) -> String {
 }
 
 fn detect_platform_type(command: &str) -> PlatformType {
-    if UNIX_SYSTEM_COMMAND.is_match(command) || WINDOWS_SYSTEM_COMMAND.is_match(command) {
+    if UNIX_SYSTEM_COMMAND.is_match(command)
+        || WINDOWS_SYSTEM_COMMAND.is_match(command)
+        || command == "noop"
+    {
         return PlatformType::System;
     }
 

--- a/crates/platform-node/src/task.rs
+++ b/crates/platform-node/src/task.rs
@@ -2,7 +2,7 @@ use lazy_static::lazy_static;
 use moon_lang_node::package::{PackageJson, ScriptsSet};
 use moon_logger::{color, debug, warn};
 use moon_task::{PlatformType, Target, Task, TaskError, TaskID};
-use moon_utils::regex::{NODE_COMMAND, UNIX_SYSTEM_COMMAND, WINDOWS_SYSTEM_COMMAND};
+use moon_utils::regex::{UNIX_SYSTEM_COMMAND, WINDOWS_SYSTEM_COMMAND};
 use moon_utils::{process, regex, string_vec};
 use std::collections::{BTreeMap, HashMap};
 
@@ -111,15 +111,11 @@ fn clean_script_name(name: &str) -> String {
 }
 
 fn detect_platform_type(command: &str) -> PlatformType {
-    if NODE_COMMAND.is_match(command) {
-        return PlatformType::Node;
-    }
-
     if UNIX_SYSTEM_COMMAND.is_match(command) || WINDOWS_SYSTEM_COMMAND.is_match(command) {
         return PlatformType::System;
     }
 
-    PlatformType::Unknown
+    PlatformType::Node
 }
 
 pub enum TaskContext {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -215,7 +215,7 @@ fn create_tasks_from_config(
     // Expand deps, args, inputs, and outputs after all tasks have been created
     for task in tasks.values_mut() {
         if matches!(task.platform, PlatformType::Unknown) {
-            task.platform = TaskConfig::detect_platform(project_config);
+            task.platform = TaskConfig::detect_platform(project_config, &task.command);
         }
 
         // Inherit implicit inputs before resolving

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -302,7 +302,7 @@ mod tasks {
             Target::format("id", "standard").unwrap(),
             &mock_task_config("cmd"),
         );
-        task.platform = PlatformType::Node;
+        task.platform = PlatformType::System;
 
         // Expanded
         task.input_globs
@@ -350,7 +350,7 @@ mod tasks {
             Target::format("id", "standard").unwrap(),
             &mock_task_config("cmd"),
         );
-        std.platform = PlatformType::Node;
+        std.platform = PlatformType::System;
 
         let mut test = Task::from_config(
             Target::format("id", "test").unwrap(),

--- a/crates/utils/src/regex.rs
+++ b/crates/utils/src/regex.rs
@@ -21,6 +21,16 @@ lazy_static! {
     pub static ref TOKEN_FUNC_PATTERN: Regex = Regex::new(&format!("^@([a-z]+)\\({}\\)$", *TOKEN_GROUP)).unwrap();
     pub static ref TOKEN_FUNC_ANYWHERE_PATTERN: Regex = Regex::new(&format!("@([a-z]+)\\({}\\)", *TOKEN_GROUP)).unwrap();
     pub static ref TOKEN_VAR_PATTERN: Regex = Regex::new("\\$(language|projectRoot|projectSource|projectType|project|target|taskType|task|workspaceRoot)").unwrap();
+
+    // Task commands (these are not exhaustive)
+    pub static ref NODE_COMMAND: regex::Regex =
+                Regex::new("^(node|nodejs|npm|npx|yarn|pnpm|corepack)$").unwrap();
+
+    pub static ref UNIX_SYSTEM_COMMAND: regex::Regex =
+                Regex::new("^(bash|cat|cd|chmod|cp|docker|echo|find|git|grep|make|mkdir|mv|pwd|rm|rsync|svn)$").unwrap();
+
+    pub static ref WINDOWS_SYSTEM_COMMAND: regex::Regex =
+                Regex::new("^(cd|cmd|copy|del|dir|echo|erase|find|git|mkdir|move|rd|rename|replace|rmdir|svn|xcopy)$").unwrap();
 }
 
 pub fn create_regex(value: &str) -> Result<Regex, MoonError> {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Renamed the project-level `project.yml` file to `moon.yml`. The `.moon/project.yml` file has not
   changed.
 
+#### 🚀 Updates
+
+- Updated tasks to automatically detect their `type` (when undefined) based on their defined
+  `command`. Will attempt to match against common system commands, like `rm`, `mkdir`, etc.
+
 #### 🐞 Fixes
 
 - Fixed some issues where task outputs were not being hydrated based on the state of the


### PR DESCRIPTION
More automation behind the scenes is always better than consumers having to explicitly define these.