### PR TITLE
fix: Ensure rust/go binaries in node modules work.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1476,7 @@ version = "0.1.0"
 dependencies = [
  "assert_fs",
  "cached",
+ "content_inspector",
  "json",
  "lazy_static",
  "moon_error",

--- a/crates/cli/tests/run_node_test.rs
+++ b/crates/cli/tests/run_node_test.rs
@@ -900,3 +900,40 @@ mod aliases {
         assert_snapshot!(get_assert_output(&assert));
     }
 }
+
+mod non_js_bins {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn works_with_esbuild() {
+        let fixture = create_sandbox_with_git("node");
+
+        create_moon_command(fixture.path())
+            .arg("run")
+            .arg("esbuild:build")
+            .assert()
+            .success();
+
+        assert_eq!(
+            fs::read_to_string(fixture.path().join("esbuild/out.js")).unwrap(),
+            "(() => {\n  // index.js\n  var ESBUILD = \"esbuild\";\n})();\n"
+        );
+    }
+
+    #[test]
+    fn works_with_swc() {
+        let fixture = create_sandbox_with_git("node");
+
+        create_moon_command(fixture.path())
+            .arg("run")
+            .arg("swc:build")
+            .assert()
+            .success();
+
+        assert_eq!(
+            fs::read_to_string(fixture.path().join("swc/out.js")).unwrap(),
+            "export var SWC = \"swc\";\n\n\n//# sourceMappingURL=out.js.map"
+        );
+    }
+}

--- a/crates/lang-node/Cargo.toml
+++ b/crates/lang-node/Cargo.toml
@@ -9,6 +9,7 @@ moon_lang = { path = "../lang" }
 moon_logger = { path = "../logger" }
 moon_utils = { path = "../utils" }
 cached = "0.38.0"
+content_inspector = "0.2.4"
 json = "0.12.4"
 lazy_static = "1.4.0"
 regex = "1.6.0"

--- a/crates/lang-node/src/node.rs
+++ b/crates/lang-node/src/node.rs
@@ -41,29 +41,45 @@ pub fn parse_bin_file(bin_path: &Path, contents: String) -> PathBuf {
     PathBuf::from(captures.get(0).unwrap().as_str())
 }
 
+#[derive(Clone)]
+pub enum BinFile {
+    Binary(PathBuf), // Rust, Go
+    Script(PathBuf), // JavaScript
+}
+
 #[cached(result)]
 #[track_caller]
-pub fn extract_canonical_bin_path_from_bin_file(bin_path: PathBuf) -> Result<PathBuf, MoonError> {
-    let contents =
-        fs::read_to_string(&bin_path).map_err(|e| map_io_to_fs_error(e, bin_path.clone()))?;
+pub fn extract_canonical_node_module_bin(bin_path: PathBuf) -> Result<BinFile, MoonError> {
+    let error_handler = |e| map_io_to_fs_error(e, bin_path.clone());
 
-    // Is most likely a symlinked JavaScript file!
-    if contents.starts_with("#!/usr/bin/env node") || contents.starts_with("#!/usr/bin/node") {
-        if bin_path.is_symlink() {
-            return bin_path
-                .canonicalize()
-                .map_err(|e| map_io_to_fs_error(e, bin_path.clone()));
-        }
+    // Resolve to the real file location if applicable
+    let bin_path = if bin_path.is_symlink() {
+        bin_path.canonicalize().map_err(error_handler)?
+    } else {
+        bin_path.clone()
+    };
 
-        return Ok(bin_path);
+    let buffer = fs::read(&bin_path).map_err(error_handler)?;
+
+    // Rust or Go binary shipped in node modules
+    if content_inspector::inspect(&buffer).is_binary() {
+        return Ok(BinFile::Binary(bin_path));
     }
 
+    let contents = String::from_utf8(buffer).map_err(|e| MoonError::Generic(e.to_string()))?;
+
+    // Symlinked JavaScript file
+    if contents.starts_with("#!/usr/bin/env node") || contents.starts_with("#!/usr/bin/node") {
+        return Ok(BinFile::Script(bin_path));
+    }
+
+    // A shell script that executes the relative binat
     let extracted_path = parse_bin_file(&bin_path, contents);
 
     // canonicalize() actually causes things to break, so normalize
-    Ok(path::normalize(
+    Ok(BinFile::Script(path::normalize(
         bin_path.parent().unwrap().join(extracted_path),
-    ))
+    )))
 }
 
 pub fn find_package<P: AsRef<Path>>(starting_dir: P, package_name: &str) -> Option<PathBuf> {
@@ -84,7 +100,7 @@ pub fn find_package<P: AsRef<Path>>(starting_dir: P, package_name: &str) -> Opti
 pub fn find_package_bin<P: AsRef<Path>, T: AsRef<str>>(
     starting_dir: P,
     bin_name: T,
-) -> Result<Option<PathBuf>, MoonError> {
+) -> Result<Option<BinFile>, MoonError> {
     let starting_dir = starting_dir.as_ref();
     let bin_name = bin_name.as_ref();
     let bin_path = starting_dir
@@ -92,7 +108,7 @@ pub fn find_package_bin<P: AsRef<Path>, T: AsRef<str>>(
         .join(get_bin_name_suffix(bin_name, "cmd", true));
 
     if bin_path.exists() {
-        return Ok(Some(extract_canonical_bin_path_from_bin_file(bin_path)?));
+        return Ok(Some(extract_canonical_node_module_bin(bin_path)?));
     }
 
     Ok(match starting_dir.parent() {

--- a/crates/toolchain/src/pms/npm.rs
+++ b/crates/toolchain/src/pms/npm.rs
@@ -10,7 +10,7 @@ use moon_logger::{color, debug, Logable};
 use moon_utils::is_ci;
 use moon_utils::process::Command;
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub struct NpmTool {
     bin_path: PathBuf,
@@ -242,18 +242,6 @@ impl PackageManager<NodeTool> for NpmTool {
             .await?;
 
         Ok(())
-    }
-
-    async fn find_package_bin(
-        &self,
-        toolchain: &Toolchain,
-        starting_dir: &Path,
-        bin_name: &str,
-    ) -> Result<PathBuf, ToolchainError> {
-        // npm binaries are symlinks to actual JavaScript files
-        toolchain
-            .get_node()
-            .find_package_bin(starting_dir, bin_name)
     }
 
     fn get_lock_filename(&self) -> String {

--- a/crates/toolchain/src/pms/pnpm.rs
+++ b/crates/toolchain/src/pms/pnpm.rs
@@ -9,7 +9,7 @@ use moon_lang_node::{node, PNPM};
 use moon_logger::{color, debug, Logable};
 use moon_utils::is_ci;
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub struct PnpmTool {
     bin_path: PathBuf,
@@ -169,25 +169,6 @@ impl PackageManager<NodeTool> for PnpmTool {
             .await?;
 
         Ok(())
-    }
-
-    async fn find_package_bin(
-        &self,
-        toolchain: &Toolchain,
-        starting_dir: &Path,
-        bin_name: &str,
-    ) -> Result<PathBuf, ToolchainError> {
-        // pnpm binaries are shell scripts that execute node and the binary
-        // under the hood. We must extract the binary path from it!
-        let bin_path = toolchain
-            .get_node()
-            .find_package_bin(starting_dir, bin_name)?;
-
-        Ok(if cfg!(windows) {
-            bin_path // already extracted from *.cmd
-        } else {
-            node::extract_canonical_bin_path_from_bin_file(bin_path)?
-        })
     }
 
     fn get_lock_filename(&self) -> String {

--- a/crates/toolchain/src/pms/yarn.rs
+++ b/crates/toolchain/src/pms/yarn.rs
@@ -9,7 +9,7 @@ use moon_lang_node::{node, YARN};
 use moon_logger::{color, debug, Logable};
 use moon_utils::is_ci;
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub struct YarnTool {
     bin_path: PathBuf,
@@ -233,18 +233,6 @@ impl PackageManager<NodeTool> for YarnTool {
             .await?;
 
         Ok(())
-    }
-
-    async fn find_package_bin(
-        &self,
-        toolchain: &Toolchain,
-        starting_dir: &Path,
-        bin_name: &str,
-    ) -> Result<PathBuf, ToolchainError> {
-        // Yarn binaries are symlinks to actual JavaScript files
-        toolchain
-            .get_node()
-            .find_package_bin(starting_dir, bin_name)
     }
 
     fn get_lock_filename(&self) -> String {

--- a/crates/toolchain/src/tools/node.rs
+++ b/crates/toolchain/src/tools/node.rs
@@ -117,9 +117,9 @@ impl NodeTool {
         &self,
         starting_dir: &Path,
         bin_name: &str,
-    ) -> Result<PathBuf, ToolchainError> {
+    ) -> Result<node::BinFile, ToolchainError> {
         match node::find_package_bin(starting_dir, bin_name)? {
-            Some(path) => Ok(path),
+            Some(bin) => Ok(bin),
             None => Err(ToolchainError::MissingNodeModuleBin(bin_name.to_owned())),
         }
     }

--- a/crates/toolchain/src/traits.rs
+++ b/crates/toolchain/src/traits.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use moon_logger::{debug, Logable};
 use moon_utils::process::Command;
 use moon_utils::{fs, is_offline};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[async_trait]
 pub trait Downloadable<T: Send + Sync>: Send + Sync + Logable {
@@ -233,12 +233,12 @@ pub trait PackageManager<T: Send + Sync>:
 
     /// Find a canonical path to a package's binary file.
     /// This is typically in "node_modules/.bin".
-    async fn find_package_bin(
-        &self,
-        toolchain: &Toolchain,
-        starting_dir: &Path,
-        bin_name: &str,
-    ) -> Result<PathBuf, ToolchainError>;
+    // async fn find_package_bin(
+    //     &self,
+    //     toolchain: &Toolchain,
+    //     starting_dir: &Path,
+    //     bin_name: &str,
+    // ) -> Result<PathBuf, ToolchainError>;
 
     /// Return the name of the lockfile.
     fn get_lock_filename(&self) -> String;

--- a/crates/utils/src/test.rs
+++ b/crates/utils/src/test.rs
@@ -88,7 +88,7 @@ pub fn create_moon_command<T: AsRef<Path>>(path: T) -> assert_cmd::Command {
     // Let our code know were running tests
     cmd.env("MOON_TEST", "true");
     // Hide install output as it disrupts testing snapshots
-    cmd.env("MOON_TEST_HIDE_INSTALL_OUTPUT", "true");
+    // cmd.env("MOON_TEST_HIDE_INSTALL_OUTPUT", "true");
     // Standardize file system paths for testing snapshots
     cmd.env("MOON_TEST_STANDARDIZE_PATHS", "true");
     // Enable logging for code coverage

--- a/crates/utils/src/test.rs
+++ b/crates/utils/src/test.rs
@@ -88,7 +88,7 @@ pub fn create_moon_command<T: AsRef<Path>>(path: T) -> assert_cmd::Command {
     // Let our code know were running tests
     cmd.env("MOON_TEST", "true");
     // Hide install output as it disrupts testing snapshots
-    // cmd.env("MOON_TEST_HIDE_INSTALL_OUTPUT", "true");
+    cmd.env("MOON_TEST_HIDE_INSTALL_OUTPUT", "true");
     // Standardize file system paths for testing snapshots
     cmd.env("MOON_TEST_STANDARDIZE_PATHS", "true");
     // Enable logging for code coverage

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Fixed an issue where output hydration was bypassing "off" cache.
 - Fixed an issue where parsing a node module binary would panic.
+- Fixed an issue where moon would panic attempting to read non-JS code shipped in node modules (Rust
+  or Go binaries).
 - Fixed an issue where project globs would pickup dot folders (`.git`, `.moon`, etc) or
   `node_modules`.
 - Fixed an issue where project names were stripping capital letters when using globs.

--- a/tests/fixtures/node/.moon/workspace.yml
+++ b/tests/fixtures/node/.moon/workspace.yml
@@ -1,0 +1,10 @@
+node:
+  # Use a unique version as to not collide with other tests
+  version: '16.1.0'
+
+typescript:
+  syncProjectReferences: false
+
+projects:
+  esbuild: esbuild
+  swc: swc

--- a/tests/fixtures/node/esbuild/index.js
+++ b/tests/fixtures/node/esbuild/index.js
@@ -1,0 +1,1 @@
+export const ESBUILD = 'esbuild';

--- a/tests/fixtures/node/esbuild/moon.yml
+++ b/tests/fixtures/node/esbuild/moon.yml
@@ -1,0 +1,10 @@
+language: javascript
+
+tasks:
+  build:
+    command: esbuild
+    args: 'index.js --bundle --outfile=out.js'
+    inputs:
+      - 'index.js'
+    outputs:
+      - 'out.js'

--- a/tests/fixtures/node/esbuild/package.json
+++ b/tests/fixtures/node/esbuild/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-node-esbuild",
+  "version": "1.0.0",
+  "dependencies": {
+    "esbuild": "0.15.2"
+  }
+}

--- a/tests/fixtures/node/package.json
+++ b/tests/fixtures/node/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-node",
+  "private": true,
+  "workspaces": [
+    "esbuild",
+    "swc"
+  ]
+}

--- a/tests/fixtures/node/swc/index.js
+++ b/tests/fixtures/node/swc/index.js
@@ -1,0 +1,1 @@
+export const SWC = 'swc';

--- a/tests/fixtures/node/swc/moon.yml
+++ b/tests/fixtures/node/swc/moon.yml
@@ -1,0 +1,10 @@
+language: javascript
+
+tasks:
+  build:
+    command: swc
+    args: './index.js -o ./out.js'
+    inputs:
+      - 'index.js'
+    outputs:
+      - 'out.js'

--- a/tests/fixtures/node/swc/package.json
+++ b/tests/fixtures/node/swc/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test-node-swc",
+  "version": "1.0.0",
+  "dependencies": {
+    "@swc/cli": "0.1.57",
+    "@swc/core": "1.2.229"
+  },
+  "optionalDependencies": {
+    "@swc/core-darwin-x64": "1.2.229",
+    "@swc/core-linux-x64-gnu": "1.2.229",
+    "@swc/core-win32-x64-msvc": "1.2.229"
+  }
+}

--- a/website/docs/guides/profile.mdx
+++ b/website/docs/guides/profile.mdx
@@ -7,7 +7,8 @@ import Image from '@site/src/components/Docs/Image';
 Troubleshooting slow or unperformant tasks? Profile and diagnose them with ease!
 
 > Profiling is only supported by Node.js based tasks, and is not supported by tasks that are created
-> through `package.json` inferrence.
+> through `package.json` inferrence, or for packages that ship non-JavaScript code (like Rust or
+> Go).
 
 ## CPU snapshots
 


### PR DESCRIPTION
Some npm packages, primarily esbuild and swc, ship non-js code (go and rust respectively). moon crashes when trying to read these files since they are binary, not utf-8, so this attempts to resolve that.

Fixes https://github.com/moonrepo/moon/issues/261