### PR TITLE
new: Add `--affected` to `moon query projects`.

### DIFF
--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -54,6 +54,12 @@ pub enum QueryCommands {
         #[clap(long, help = "Filter projects that match this alias")]
         alias: Option<String>,
 
+        #[clap(
+            long,
+            help = "Filter projects that are affected based on touched files"
+        )]
+        affected: bool,
+
         #[clap(long, help = "Filter projects that match this ID")]
         id: Option<String>,
 

--- a/crates/cli/src/commands/query.rs
+++ b/crates/cli/src/commands/query.rs
@@ -3,6 +3,8 @@ pub use crate::queries::touched_files::{
     query_touched_files, QueryTouchedFilesOptions, QueryTouchedFilesResult,
 };
 use moon_workspace::Workspace;
+use std::io;
+use std::io::prelude::*;
 
 pub async fn projects(options: &QueryProjectsOptions) -> Result<(), Box<dyn std::error::Error>> {
     let workspace = Workspace::load().await?;
@@ -12,7 +14,10 @@ pub async fn projects(options: &QueryProjectsOptions) -> Result<(), Box<dyn std:
         options: options.clone(),
     };
 
-    println!("{}", serde_json::to_string_pretty(&result)?);
+    // Write to stdout directly to avoid broken pipe panics
+    let mut stdout = io::stdout().lock();
+
+    writeln!(stdout, "{}", serde_json::to_string_pretty(&result)?)?;
 
     Ok(())
 }
@@ -27,7 +32,10 @@ pub async fn touched_files(
         options: options.clone(),
     };
 
-    println!("{}", serde_json::to_string_pretty(&result)?);
+    // Write to stdout directly to avoid broken pipe panics
+    let mut stdout = io::stdout().lock();
+
+    writeln!(stdout, "{}", serde_json::to_string_pretty(&result)?)?;
 
     Ok(())
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -177,6 +177,15 @@ pub async fn run_cli() {
     };
 
     if let Err(error) = result {
-        Term::buffered_stderr().render_error(error);
+        let error_message = error.to_string();
+
+        // Rust crashes with a broken pipe error by default,
+        // so we unfortunately need to work around it with this hack!
+        // https://github.com/rust-lang/rust/issues/46016
+        if error_message.to_lowercase().contains("broken pipe") {
+            std::process::exit(0);
+        } else {
+            Term::buffered_stderr().render_error(error);
+        }
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -114,6 +114,7 @@ pub async fn run_cli() {
         Commands::Query { command } => match command {
             QueryCommands::Projects {
                 alias,
+                affected,
                 id,
                 language,
                 source,
@@ -122,6 +123,7 @@ pub async fn run_cli() {
             } => {
                 query::projects(&QueryProjectsOptions {
                     alias: alias.clone(),
+                    affected: *affected,
                     id: id.clone(),
                     language: language.clone(),
                     source: source.clone(),

--- a/crates/cli/src/queries/projects.rs
+++ b/crates/cli/src/queries/projects.rs
@@ -52,9 +52,7 @@ fn convert_to_regex(
 async fn load_touched_files(workspace: &Workspace) -> Result<TouchedFilePaths, WorkspaceError> {
     let mut buffer = String::new();
 
-    stdin()
-        .read_to_string(&mut buffer)
-        .map_err(|e| MoonError::Io(e))?;
+    stdin().read_to_string(&mut buffer).map_err(MoonError::Io)?;
 
     // If piped via stdin, parse and use it
     if !buffer.is_empty() {
@@ -64,14 +62,14 @@ async fn load_touched_files(workspace: &Workspace) -> Result<TouchedFilePaths, W
         return Ok(result.files);
     }
 
-    Ok(query_touched_files(
+    query_touched_files(
         workspace,
         &mut QueryTouchedFilesOptions {
             local: !is_ci(),
             ..QueryTouchedFilesOptions::default()
         },
     )
-    .await?)
+    .await
 }
 
 pub async fn query_projects(

--- a/crates/cli/src/queries/projects.rs
+++ b/crates/cli/src/queries/projects.rs
@@ -1,6 +1,8 @@
+use crate::queries::touched_files::{query_touched_files, QueryTouchedFilesOptions};
 use moon_logger::{debug, trace};
 use moon_project::Project;
-use moon_utils::regex;
+use moon_task::TouchedFilePaths;
+use moon_utils::{is_ci, regex};
 use moon_workspace::{Workspace, WorkspaceError};
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +11,7 @@ const LOG_TARGET: &str = "moon:query:projects";
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct QueryProjectsOptions {
     pub alias: Option<String>,
+    pub affected: bool,
     pub id: Option<String>,
     pub language: Option<String>,
     pub source: Option<String>,
@@ -42,6 +45,17 @@ fn convert_to_regex(
     }
 }
 
+async fn load_touched_files(workspace: &Workspace) -> Result<TouchedFilePaths, WorkspaceError> {
+    Ok(query_touched_files(
+        workspace,
+        &mut QueryTouchedFilesOptions {
+            local: !is_ci(),
+            ..QueryTouchedFilesOptions::default()
+        },
+    )
+    .await?)
+}
+
 pub async fn query_projects(
     workspace: &Workspace,
     options: &QueryProjectsOptions,
@@ -55,6 +69,11 @@ pub async fn query_projects(
     let source_regex = convert_to_regex("source", &options.source)?;
     let tasks_regex = convert_to_regex("tasks", &options.tasks)?;
     let type_regex = convert_to_regex("type", &options.type_of)?;
+    let touched_files = if options.affected {
+        Some(load_touched_files(workspace).await?)
+    } else {
+        None
+    };
 
     for project_id in workspace.projects.ids() {
         if let Some(regex) = &id_regex {
@@ -64,6 +83,14 @@ pub async fn query_projects(
         }
 
         let project = workspace.projects.load(&project_id)?;
+
+        if options.affected {
+            if let Some(touched) = &touched_files {
+                if !project.is_affected(touched) {
+                    continue;
+                }
+            }
+        }
 
         if let Some(regex) = &alias_regex {
             if let Some(alias) = &project.alias {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5,7 +5,7 @@ use moon_config::{
 };
 use moon_constants::CONFIG_PROJECT_FILENAME;
 use moon_logger::{color, debug, trace, Logable};
-use moon_task::{FileGroup, ResolverData, Target, Task, TokenResolver};
+use moon_task::{FileGroup, ResolverData, Target, Task, TokenResolver, TouchedFilePaths};
 use moon_utils::path;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -355,5 +355,17 @@ impl Project {
                 self.id.to_owned(),
             )),
         }
+    }
+
+    /// Return true if this project is affected based on touched files.
+    /// Since the project is a folder, we check if a file starts with the root.
+    pub fn is_affected(&self, touched_files: &TouchedFilePaths) -> bool {
+        for file in touched_files {
+            if file.starts_with(&self.root) {
+                return true;
+            }
+        }
+
+        false
     }
 }

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -491,7 +491,7 @@ impl Task {
         Ok(())
     }
 
-    /// Return true if this task is affected, based on touched files.
+    /// Return true if this task is affected based on touched files.
     /// Will attempt to find any file that matches our list of inputs.
     pub fn is_affected(&self, touched_files: &TouchedFilePaths) -> Result<bool, TaskError> {
         for var_name in &self.input_vars {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added support for Linux ARM GNU (`aarch64-unknown-linux-gnu`).
 - Added support for Linux ARM musl (`aarch64-unknown-linux-musl`).
 - Added a `typescript` setting to `moon.yml`, allowing TypeScript support to be toggled per project.
+- Added an `--affected` option to the `moon query projects` command.
 
 ## 0.11.1
 

--- a/website/docs/commands/query/projects.mdx
+++ b/website/docs/commands/query/projects.mdx
@@ -35,6 +35,7 @@ This will return a list of project objects with the following structure:
 All values are case-insensitive regex patterns.
 
 - `--alias <regex>` - Filter projects that match this alias.
+- `--affected` - Filter projects that have been affected by touched files.
 - `--id <regex>` - Filter projects that match this ID/name.
 - `--language <regex>` - Filter projects of this programming language.
 - `--source <regex>` - Filter projects that match this source path.

--- a/website/docs/commands/query/projects.mdx
+++ b/website/docs/commands/query/projects.mdx
@@ -30,6 +30,19 @@ This will return a list of project objects with the following structure:
 }
 ```
 
+### Affected projects
+
+This command can also be used to query for affected projects, based on the state of the VCS working
+tree. For advanced control, you can also pass the results of `moon query touched-files` to stdin.
+
+```shell
+# Find all affected projects
+$ moon query projects --affected
+
+# Find all affected projects using the results of another query
+$ moon query touched-files | moon query projects --affected
+```
+
 ### Options
 
 All values are case-insensitive regex patterns.


### PR DESCRIPTION
Provides more control to consumers.