### PR TITLE
new: Update task `command` setting to accept arguments.

### DIFF
--- a/crates/cli/tests/snapshots/migrate_test__from_package_json__converts_scripts-2.snap
+++ b/crates/cli/tests/snapshots/migrate_test__from_package_json__converts_scripts-2.snap
@@ -6,15 +6,15 @@ expression: "fs::read_to_string(fixture.path().join(\"package-json/common/moon.y
 language: javascript
 tasks:
   lint:
-    command: eslint
-    args:
+    command:
+    - eslint
     - .
     inputs:
     - '**/*'
     type: node
   lint-fix:
-    command: moon
-    args:
+    command:
+    - moon
     - run
     - common:lint
     - --

--- a/crates/cli/tests/snapshots/migrate_test__from_package_json__links_depends_on-2.snap
+++ b/crates/cli/tests/snapshots/migrate_test__from_package_json__links_depends_on-2.snap
@@ -8,8 +8,8 @@ dependsOn:
 language: javascript
 tasks:
   build:
-    command: babel
-    args:
+    command:
+    - babel
     - ./src
     - --out
     - ./lib
@@ -19,7 +19,8 @@ tasks:
     - lib
     type: node
   test:
-    command: jest
+    command:
+    - jest
     inputs:
     - '**/*'
     type: node

--- a/crates/config/src/errors.rs
+++ b/crates/config/src/errors.rs
@@ -1,5 +1,6 @@
 use figment::{Error as FigmentError, Figment};
 use moon_error::MoonError;
+use moon_utils::process::ArgsParseError;
 use serde_json::Value;
 use std::borrow::Cow;
 use std::path::PathBuf;
@@ -25,6 +26,9 @@ pub enum ConfigError {
 
     #[error("Cannot extend configuration file <file>{0}</file>, only HTTPS URLs are supported.")]
     UnsupportedHttps(String),
+
+    #[error(transparent)]
+    ArgsParse(#[from] ArgsParseError),
 
     #[error(transparent)]
     Figment(#[from] FigmentError),

--- a/crates/config/src/errors.rs
+++ b/crates/config/src/errors.rs
@@ -1,6 +1,5 @@
 use figment::{Error as FigmentError, Figment};
 use moon_error::MoonError;
-use moon_utils::process::ArgsParseError;
 use serde_json::Value;
 use std::borrow::Cow;
 use std::path::PathBuf;
@@ -26,9 +25,6 @@ pub enum ConfigError {
 
     #[error("Cannot extend configuration file <file>{0}</file>, only HTTPS URLs are supported.")]
     UnsupportedHttps(String),
-
-    #[error(transparent)]
-    ArgsParse(#[from] ArgsParseError),
 
     #[error(transparent)]
     Figment(#[from] FigmentError),

--- a/crates/config/src/project/global_config.rs
+++ b/crates/config/src/project/global_config.rs
@@ -31,9 +31,7 @@ fn validate_tasks(map: &BTreeMap<String, TaskConfig>) -> Result<(), ValidationEr
         validate_id(&format!("tasks.{}", name), name)?;
 
         // Fail for both `None` and empty strings
-        let command = task.command.clone().unwrap_or_default();
-
-        if command.is_empty() {
+        if task.get_command().is_empty() {
             return Err(create_validation_error(
                 "required_command",
                 &format!("tasks.{}.command", name),

--- a/crates/config/src/project/local_config.rs
+++ b/crates/config/src/project/local_config.rs
@@ -31,14 +31,12 @@ fn validate_tasks(map: &BTreeMap<String, TaskConfig>) -> Result<(), ValidationEr
         validate_id(&format!("tasks.{}", name), name)?;
 
         // Only fail for empty strings and not `None`
-        if task.command.is_some() {
-            if task.get_command().is_empty() {
-                return Err(create_validation_error(
-                    "required_command",
-                    &format!("tasks.{}.command", name),
-                    String::from("An npm/system command is required"),
-                ));
-            }
+        if task.command.is_some() && task.get_command().is_empty() {
+            return Err(create_validation_error(
+                "required_command",
+                &format!("tasks.{}.command", name),
+                String::from("An npm/system command is required"),
+            ));
         }
     }
 

--- a/crates/config/src/project/local_config.rs
+++ b/crates/config/src/project/local_config.rs
@@ -31,8 +31,8 @@ fn validate_tasks(map: &BTreeMap<String, TaskConfig>) -> Result<(), ValidationEr
         validate_id(&format!("tasks.{}", name), name)?;
 
         // Only fail for empty strings and not `None`
-        if let Some(command) = &task.command {
-            if command.is_empty() {
+        if task.command.is_some() {
+            if task.get_command().is_empty() {
                 return Err(create_validation_error(
                     "required_command",
                     &format!("tasks.{}.command", name),

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -2,8 +2,8 @@ use crate::project::local_config::{ProjectConfig, ProjectLanguage};
 use crate::project::task_options::TaskOptionsConfig;
 use crate::types::{FilePath, InputValue, TargetID};
 use crate::validators::{skip_if_default, validate_child_or_root_path, validate_target};
-use crate::ConfigError;
 use moon_utils::process::split_args;
+use moon_utils::process::ArgsParseError;
 use moon_utils::regex::{ENV_VAR, NODE_COMMAND, UNIX_SYSTEM_COMMAND, WINDOWS_SYSTEM_COMMAND};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -137,7 +137,7 @@ impl TaskConfig {
         String::new()
     }
 
-    pub fn get_command_and_args(&self) -> Result<(Option<String>, Vec<String>), ConfigError> {
+    pub fn get_command_and_args(&self) -> Result<(Option<String>, Vec<String>), ArgsParseError> {
         let mut command = None;
         let mut args = vec![];
 

--- a/crates/config/tests/global_project_test.rs
+++ b/crates/config/tests/global_project_test.rs
@@ -1,4 +1,4 @@
-use moon_config::{ConfigError, GlobalProjectConfig};
+use moon_config::{ConfigError, GlobalProjectConfig, TaskCommandArgs};
 use moon_constants::CONFIG_GLOBAL_PROJECT_FILENAME;
 use moon_utils::string_vec;
 use moon_utils::test::get_fixtures_dir;
@@ -65,21 +65,21 @@ mod extends {
                     (
                         "lint".to_owned(),
                         TaskConfig {
-                            command: Some(String::from("eslint")),
+                            command: Some(TaskCommandArgs::String("eslint".to_owned())),
                             ..TaskConfig::default()
                         },
                     ),
                     (
                         "format".to_owned(),
                         TaskConfig {
-                            command: Some(String::from("prettier")),
+                            command: Some(TaskCommandArgs::String("prettier".to_owned())),
                             ..TaskConfig::default()
                         },
                     ),
                     (
                         "test".to_owned(),
                         TaskConfig {
-                            command: Some(String::from("noop")),
+                            command: Some(TaskCommandArgs::String("noop".to_owned())),
                             ..TaskConfig::default()
                         },
                     )
@@ -178,30 +178,30 @@ mod extends {
             (
                 "onlyCommand".to_owned(),
                 TaskConfig {
-                    command: Some(String::from("a")),
+                    command: Some(TaskCommandArgs::String("a".to_owned())),
                     ..TaskConfig::default()
                 },
             ),
             (
                 "stringArgs".to_owned(),
                 TaskConfig {
-                    command: Some(String::from("b")),
-                    args: Some(string_vec!["string", "args"]),
+                    command: Some(TaskCommandArgs::String("b".to_owned())),
+                    args: Some(TaskCommandArgs::String("string args".to_owned())),
                     ..TaskConfig::default()
                 },
             ),
             (
                 "arrayArgs".to_owned(),
                 TaskConfig {
-                    command: Some(String::from("c")),
-                    args: Some(string_vec!["array", "args"]),
+                    command: Some(TaskCommandArgs::String("c".to_owned())),
+                    args: Some(TaskCommandArgs::Sequence(string_vec!["array", "args"])),
                     ..TaskConfig::default()
                 },
             ),
             (
                 "inputs".to_owned(),
                 TaskConfig {
-                    command: Some(String::from("d")),
+                    command: Some(TaskCommandArgs::String("d".to_owned())),
                     inputs: Some(string_vec!["src/**/*"]),
                     ..TaskConfig::default()
                 },
@@ -209,7 +209,7 @@ mod extends {
             (
                 "options".to_owned(),
                 TaskConfig {
-                    command: Some(String::from("e")),
+                    command: Some(TaskCommandArgs::String("e".to_owned())),
                     options: TaskOptionsConfig {
                         run_in_ci: Some(false),
                         ..TaskOptionsConfig::default()
@@ -398,7 +398,7 @@ tasks:
 
     #[test]
     #[should_panic(
-        expected = "invalid type: found unsigned int `123`, expected a string for key \"globalProject.tasks.test.command\""
+        expected = "expected a string or a sequence of strings for key \"globalProject.tasks.test.command\""
     )]
     fn invalid_value_field() {
         figment::Jail::expect_with(|jail| {

--- a/crates/config/tests/local_project_test.rs
+++ b/crates/config/tests/local_project_test.rs
@@ -1,4 +1,6 @@
-use moon_config::{DependencyConfig, DependencyScope, ProjectConfig, ProjectDependsOn, TaskConfig};
+use moon_config::{
+    DependencyConfig, DependencyScope, ProjectConfig, ProjectDependsOn, TaskCommandArgs, TaskConfig,
+};
 use moon_constants::CONFIG_PROJECT_FILENAME;
 use moon_utils::string_vec;
 use std::collections::{BTreeMap, HashMap};
@@ -225,8 +227,8 @@ tasks:
                     tasks: BTreeMap::from([(
                         String::from("lint"),
                         TaskConfig {
-                            args: Some(vec![".".to_owned()]),
-                            command: Some("eslint".to_owned()),
+                            command: Some(TaskCommandArgs::String("eslint".to_owned())),
+                            args: Some(TaskCommandArgs::Sequence(vec![".".to_owned()])),
                             ..TaskConfig::default()
                         }
                     )]),
@@ -273,7 +275,7 @@ tasks:
 
     #[test]
     #[should_panic(
-        expected = "invalid type: found unsigned int `123`, expected a string for key \"project.tasks.test.command\""
+        expected = "expected a string or a sequence of strings for key \"project.tasks.test.command\""
     )]
     fn invalid_value_field() {
         figment::Jail::expect_with(|jail| {

--- a/crates/platform-node/src/task.rs
+++ b/crates/platform-node/src/task.rs
@@ -163,7 +163,7 @@ pub fn create_task(
     }
 
     if is_wrapping {
-        task_config.type_of = PlatformType::System;
+        task_config.type_of = PlatformType::Node;
         task_config.command = Some(TaskCommandArgs::Sequence(string_vec![
             "moon",
             "node",
@@ -184,7 +184,11 @@ pub fn create_task(
         }
 
         task_config.type_of = detect_platform_type(&args[0]);
-        task_config.command = Some(TaskCommandArgs::Sequence(args));
+        task_config.command = Some(if args.len() == 1 {
+            TaskCommandArgs::String(args.remove(0))
+        } else {
+            TaskCommandArgs::Sequence(args)
+        });
     }
 
     task_config.env = Some(env);

--- a/crates/platform-node/src/task.rs
+++ b/crates/platform-node/src/task.rs
@@ -195,7 +195,7 @@ pub fn create_task(
     task_config.outputs = Some(outputs);
     task_config.local = !should_run_in_ci(script_name, script);
 
-    let task = Task::from_config(target_id.to_owned(), &task_config);
+    let task = Task::from_config(target_id.to_owned(), &task_config)?;
 
     if is_wrapping {
         debug!(

--- a/crates/platform-node/src/task.rs
+++ b/crates/platform-node/src/task.rs
@@ -1,6 +1,6 @@
 use crate::LOG_TARGET;
 use lazy_static::lazy_static;
-use moon_config::TaskConfig;
+use moon_config::{TaskCommandArgs, TaskConfig};
 use moon_lang_node::package::{PackageJson, ScriptsSet};
 use moon_logger::{color, debug, warn};
 use moon_task::{PlatformType, Target, Task, TaskError, TaskID};
@@ -163,27 +163,32 @@ pub fn create_task(
     }
 
     if is_wrapping {
-        task_config.command = Some("moon".to_owned());
-        task_config.args = Some(string_vec!["node", "run-script", script_name]);
+        task_config.type_of = PlatformType::System;
+        task_config.command = Some(TaskCommandArgs::Sequence(string_vec![
+            "moon",
+            "node",
+            "run-script",
+            script_name
+        ]));
     } else {
         if let Some(command) = args.get(0) {
             if is_bash_script(command) {
-                task_config.command = Some("bash".to_owned());
+                args.insert(0, "bash".to_owned());
             } else if is_node_script(command) {
-                task_config.command = Some("node".to_owned());
+                args.insert(0, "node".to_owned());
             } else {
-                task_config.command = Some(args.remove(0));
+                // Already there
             }
         } else {
-            task_config.command = Some("noop".to_owned());
+            args.insert(0, "noop".to_owned());
         }
 
-        task_config.args = Some(args);
+        task_config.type_of = detect_platform_type(&args[0]);
+        task_config.command = Some(TaskCommandArgs::Sequence(args));
     }
 
     task_config.env = Some(env);
     task_config.outputs = Some(outputs);
-    task_config.type_of = detect_platform_type(task_config.command.as_ref().unwrap());
     task_config.local = !should_run_in_ci(script_name, script);
 
     let task = Task::from_config(target_id.to_owned(), &task_config);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -188,13 +188,13 @@ fn create_tasks_from_config(
 
         tasks.insert(
             task_name.to_owned(),
-            Task::from_config(Target::format(project_id, task_name)?, task_config),
+            Task::from_config(Target::format(project_id, task_name)?, task_config)?,
         );
     }
 
     // Add local tasks second
     for (task_id, task_config) in &project_config.tasks {
-        if tasks.contains_key(task_id) {
+        if let Some(existing_task) = tasks.get_mut(task_id) {
             debug!(
                 target: log_target,
                 "Merging task {} with global config",
@@ -202,12 +202,12 @@ fn create_tasks_from_config(
             );
 
             // Task already exists, so merge with it
-            tasks.get_mut(task_id).unwrap().merge(task_config);
+            existing_task.merge(task_config)?;
         } else {
             // Insert a new task
             tasks.insert(
                 task_id.clone(),
-                Task::from_config(Target::format(project_id, task_id)?, task_config),
+                Task::from_config(Target::format(project_id, task_id)?, task_config)?,
             );
         }
     }

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -311,7 +311,8 @@ mod tasks {
         let mut task = Task::from_config(
             Target::format("id", "standard").unwrap(),
             &mock_task_config("cmd"),
-        );
+        )
+        .unwrap();
         task.platform = PlatformType::System;
 
         // Expanded
@@ -353,25 +354,29 @@ mod tasks {
         let mut build = Task::from_config(
             Target::format("id", "build").unwrap(),
             &mock_task_config("webpack"),
-        );
+        )
+        .unwrap();
         build.platform = PlatformType::Node;
 
         let mut std = Task::from_config(
             Target::format("id", "standard").unwrap(),
             &mock_task_config("cmd"),
-        );
+        )
+        .unwrap();
         std.platform = PlatformType::System;
 
         let mut test = Task::from_config(
             Target::format("id", "test").unwrap(),
             &mock_task_config("jest"),
-        );
+        )
+        .unwrap();
         test.platform = PlatformType::Node;
 
         let mut lint = Task::from_config(
             Target::format("id", "lint").unwrap(),
             &mock_task_config("eslint"),
-        );
+        )
+        .unwrap();
         lint.platform = PlatformType::Node;
 
         // Expanded
@@ -432,22 +437,26 @@ mod tasks {
         let mut build = Task::from_config(
             Target::format("id", "build").unwrap(),
             &mock_task_config("webpack"),
-        );
+        )
+        .unwrap();
 
         let mut std = Task::from_config(
             Target::format("id", "standard").unwrap(),
             &mock_task_config("cmd"),
-        );
+        )
+        .unwrap();
 
         let mut test = Task::from_config(
             Target::format("id", "test").unwrap(),
             &mock_task_config("jest"),
-        );
+        )
+        .unwrap();
 
         let mut lint = Task::from_config(
             Target::format("id", "lint").unwrap(),
             &mock_task_config("eslint"),
-        );
+        )
+        .unwrap();
 
         // Expanded
         build.inputs.extend(implicit_inputs.clone());

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -1,6 +1,7 @@
 use moon_config::{
     GlobalProjectConfig, PlatformType, ProjectConfig, ProjectDependsOn, ProjectLanguage,
-    ProjectMetadataConfig, ProjectType, TargetID, TaskConfig, TaskMergeStrategy, TaskOptionsConfig,
+    ProjectMetadataConfig, ProjectType, TargetID, TaskCommandArgs, TaskConfig, TaskMergeStrategy,
+    TaskOptionsConfig,
 };
 use moon_project::{Project, ProjectError};
 use moon_task::{EnvVars, FileGroup, Target, Task};
@@ -213,7 +214,7 @@ mod tasks {
 
     fn mock_task_config(command: &str) -> TaskConfig {
         TaskConfig {
-            command: Some(command.to_owned()),
+            command: Some(TaskCommandArgs::String(command.to_owned())),
             ..TaskConfig::default()
         }
     }
@@ -478,8 +479,8 @@ mod tasks {
                 tasks: BTreeMap::from([(
                     String::from("standard"),
                     TaskConfig {
-                        args: Some(string_vec!["--a"]),
-                        command: Some(String::from("standard")),
+                        args: Some(TaskCommandArgs::Sequence(string_vec!["--a"])),
+                        command: Some(TaskCommandArgs::String("standard".to_owned())),
                         deps: Some(string_vec!["a:standard"]),
                         env: Some(stub_global_env_vars()),
                         local: false,
@@ -503,8 +504,8 @@ mod tasks {
                     tasks: BTreeMap::from([(
                         String::from("standard"),
                         TaskConfig {
-                            args: Some(string_vec!["--b"]),
-                            command: Some(String::from("newcmd")),
+                            args: Some(TaskCommandArgs::Sequence(string_vec!["--b"])),
+                            command: Some(TaskCommandArgs::String("newcmd".to_owned())),
                             deps: Some(string_vec!["b:standard"]),
                             env: Some(HashMap::from([("KEY".to_owned(), "b".to_owned())])),
                             local: false,
@@ -524,8 +525,8 @@ mod tasks {
                     create_expanded_task(
                         Target::format("id", "standard").unwrap(),
                         TaskConfig {
-                            args: Some(string_vec!["--b"]),
-                            command: Some(String::from("newcmd")),
+                            args: Some(TaskCommandArgs::Sequence(string_vec!["--b"])),
+                            command: Some(TaskCommandArgs::String("newcmd".to_owned())),
                             deps: Some(string_vec!["b:standard"]),
                             env: Some(HashMap::from([("KEY".to_owned(), "b".to_owned())])),
                             local: false,
@@ -556,8 +557,8 @@ mod tasks {
                 tasks: BTreeMap::from([(
                     String::from("standard"),
                     TaskConfig {
-                        args: Some(string_vec!["--a"]),
-                        command: Some(String::from("standard")),
+                        args: Some(TaskCommandArgs::Sequence(string_vec!["--a"])),
+                        command: Some(TaskCommandArgs::String("standard".to_owned())),
                         deps: Some(string_vec!["a:standard"]),
                         env: Some(stub_global_env_vars()),
                         local: false,
@@ -581,7 +582,7 @@ mod tasks {
                     tasks: BTreeMap::from([(
                         String::from("standard"),
                         TaskConfig {
-                            args: Some(string_vec!["--b"]),
+                            args: Some(TaskCommandArgs::Sequence(string_vec!["--b"])),
                             command: None,
                             deps: Some(string_vec!["b:standard"]),
                             env: Some(HashMap::from([("KEY".to_owned(), "b".to_owned())])),
@@ -602,8 +603,8 @@ mod tasks {
                     create_expanded_task(
                         Target::format("id", "standard").unwrap(),
                         TaskConfig {
-                            args: Some(string_vec!["--a", "--b"]),
-                            command: Some(String::from("standard")),
+                            args: Some(TaskCommandArgs::Sequence(string_vec!["--a", "--b"])),
+                            command: Some(TaskCommandArgs::String("standard".to_owned())),
                             deps: Some(string_vec!["a:standard", "b:standard"]),
                             env: Some(HashMap::from([
                                 ("GLOBAL".to_owned(), "1".to_owned()),
@@ -637,8 +638,8 @@ mod tasks {
                 tasks: BTreeMap::from([(
                     String::from("standard"),
                     TaskConfig {
-                        args: Some(string_vec!["--a"]),
-                        command: Some(String::from("standard")),
+                        args: Some(TaskCommandArgs::Sequence(string_vec!["--a"])),
+                        command: Some(TaskCommandArgs::String("standard".to_owned())),
                         deps: Some(string_vec!["a:standard"]),
                         env: Some(stub_global_env_vars()),
                         inputs: Some(string_vec!["a.*"]),
@@ -662,8 +663,8 @@ mod tasks {
                     tasks: BTreeMap::from([(
                         String::from("standard"),
                         TaskConfig {
-                            args: Some(string_vec!["--b"]),
-                            command: Some(String::from("newcmd")),
+                            args: Some(TaskCommandArgs::Sequence(string_vec!["--b"])),
+                            command: Some(TaskCommandArgs::String("newcmd".to_owned())),
                             deps: Some(string_vec!["b:standard"]),
                             env: Some(HashMap::from([("KEY".to_owned(), "b".to_owned())])),
                             inputs: Some(string_vec!["b.*"]),
@@ -683,8 +684,8 @@ mod tasks {
                     create_expanded_task(
                         Target::format("id", "standard").unwrap(),
                         TaskConfig {
-                            args: Some(string_vec!["--b", "--a"]),
-                            command: Some(String::from("newcmd")),
+                            args: Some(TaskCommandArgs::Sequence(string_vec!["--b", "--a"])),
+                            command: Some(TaskCommandArgs::String("newcmd".to_owned())),
                             deps: Some(string_vec!["b:standard", "a:standard"]),
                             env: Some(HashMap::from([
                                 ("GLOBAL".to_owned(), "1".to_owned()),
@@ -718,8 +719,8 @@ mod tasks {
                 tasks: BTreeMap::from([(
                     String::from("standard"),
                     TaskConfig {
-                        args: Some(string_vec!["--a"]),
-                        command: Some(String::from("standard")),
+                        args: Some(TaskCommandArgs::Sequence(string_vec!["--a"])),
+                        command: Some(TaskCommandArgs::String("standard".to_owned())),
                         deps: Some(string_vec!["a:standard"]),
                         env: Some(stub_global_env_vars()),
                         inputs: Some(string_vec!["a.*"]),
@@ -738,8 +739,8 @@ mod tasks {
         let mut task = create_expanded_task(
             Target::format("id", "standard").unwrap(),
             TaskConfig {
-                args: Some(string_vec!["--a", "--b"]),
-                command: Some(String::from("standard")),
+                args: Some(TaskCommandArgs::Sequence(string_vec!["--a", "--b"])),
+                command: Some(TaskCommandArgs::String("standard".to_owned())),
                 deps: Some(string_vec!["b:standard", "a:standard"]),
                 env: Some(HashMap::from([("KEY".to_owned(), "b".to_owned())])),
                 inputs: Some(string_vec!["b.*"]),
@@ -774,7 +775,7 @@ mod tasks {
                     tasks: BTreeMap::from([(
                         String::from("standard"),
                         TaskConfig {
-                            args: Some(string_vec!["--b"]),
+                            args: Some(TaskCommandArgs::Sequence(string_vec!["--b"])),
                             command: None,
                             deps: Some(string_vec!["b:standard"]),
                             env: Some(HashMap::from([("KEY".to_owned(), "b".to_owned())])),
@@ -912,7 +913,7 @@ mod tasks {
                     tasks: BTreeMap::from([(
                         String::from("test"),
                         TaskConfig {
-                            args: Some(string_vec![
+                            args: Some(TaskCommandArgs::Sequence(string_vec![
                                 "--dirs",
                                 "@dirs(static)",
                                 "--files",
@@ -921,8 +922,8 @@ mod tasks {
                                 "@globs(globs)",
                                 "--root",
                                 "@root(static)",
-                            ]),
-                            command: Some(String::from("test")),
+                            ])),
+                            command: Some(TaskCommandArgs::String("test".to_owned())),
                             ..TaskConfig::default()
                         },
                     )]),
@@ -981,7 +982,7 @@ mod tasks {
                     tasks: BTreeMap::from([(
                         String::from("test"),
                         TaskConfig {
-                            args: Some(string_vec![
+                            args: Some(TaskCommandArgs::Sequence(string_vec![
                                 "--dirs",
                                 "@dirs(static)",
                                 "--files",
@@ -990,8 +991,8 @@ mod tasks {
                                 "@globs(globs)",
                                 "--root",
                                 "@root(static)",
-                            ]),
-                            command: Some(String::from("test")),
+                            ])),
+                            command: Some(TaskCommandArgs::String("test".to_owned())),
                             options: TaskOptionsConfig {
                                 run_from_workspace_root: Some(true),
                                 ..TaskOptionsConfig::default()
@@ -1046,7 +1047,7 @@ mod tasks {
                     tasks: BTreeMap::from([(
                         String::from("test"),
                         TaskConfig {
-                            args: Some(string_vec![
+                            args: Some(TaskCommandArgs::Sequence(string_vec![
                                 "some/$unknown/var", // Unknown
                                 "--pid",
                                 "$project/foo", // At start
@@ -1059,8 +1060,8 @@ mod tasks {
                                 "--tid=$task",     // As an arg
                                 "--wsroot",
                                 "$workspaceRoot" // Alone
-                            ]),
-                            command: Some(String::from("test")),
+                            ])),
+                            command: Some(TaskCommandArgs::String("test".to_owned())),
                             ..TaskConfig::default()
                         },
                     )]),
@@ -1107,7 +1108,7 @@ mod tasks {
                     tasks: BTreeMap::from([(
                         String::from("test"),
                         TaskConfig {
-                            command: Some(String::from("test")),
+                            command: Some(TaskCommandArgs::String("test".to_owned())),
                             inputs: Some(string_vec![
                                 "file.ts",
                                 "@dirs(static)",
@@ -1167,7 +1168,7 @@ mod tasks {
                     tasks: BTreeMap::from([(
                         String::from("test"),
                         TaskConfig {
-                            command: Some(String::from("test")),
+                            command: Some(TaskCommandArgs::String("test".to_owned())),
                             inputs: Some(string_vec!["local.ts",]),
                             type_of: PlatformType::Node,
                             ..TaskConfig::default()
@@ -1219,21 +1220,21 @@ mod workspace {
                     (
                         String::from("a"),
                         TaskConfig {
-                            command: Some(String::from("a")),
+                            command: Some(TaskCommandArgs::String("a".to_owned())),
                             ..TaskConfig::default()
                         },
                     ),
                     (
                         String::from("b"),
                         TaskConfig {
-                            command: Some(String::from("b")),
+                            command: Some(TaskCommandArgs::String("b".to_owned())),
                             ..TaskConfig::default()
                         },
                     ),
                     (
                         String::from("c"),
                         TaskConfig {
-                            command: Some(String::from("c")),
+                            command: Some(TaskCommandArgs::String("c".to_owned())),
                             ..TaskConfig::default()
                         },
                     ),

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -3,8 +3,8 @@ use crate::target::{Target, TargetProjectScope};
 use crate::token::{ResolverData, TokenResolver};
 use crate::types::{EnvVars, TouchedFilePaths};
 use moon_config::{
-    DependencyConfig, FileGlob, FilePath, InputValue, PlatformType, TargetID, TaskConfig,
-    TaskMergeStrategy, TaskOptionEnvFile, TaskOptionsConfig, TaskOutputStyle,
+    DependencyConfig, FileGlob, FilePath, InputValue, PlatformType, TargetID, TaskCommandArgs,
+    TaskConfig, TaskMergeStrategy, TaskOptionEnvFile, TaskOptionsConfig, TaskOutputStyle,
 };
 use moon_logger::{color, debug, trace, Logable};
 use moon_utils::{glob, is_ci, path, regex::ENV_VAR, string_vec};
@@ -200,13 +200,15 @@ impl Task {
     pub fn from_config(target: TargetID, config: &TaskConfig) -> Self {
         let cloned_config = config.clone();
         let cloned_options = cloned_config.options;
-        let command = cloned_config.command.unwrap_or_default();
+
+        let (command, args) = config.get_command_and_args().unwrap();
+        let command = command.unwrap_or_default();
         let is_local =
             cloned_config.local || command == "dev" || command == "serve" || command == "start";
         let log_target = format!("moon:project:{}", target);
 
         let task = Task {
-            args: cloned_config.args.unwrap_or_default(),
+            args,
             command,
             deps: cloned_config.deps.unwrap_or_default(),
             env: cloned_config.env.unwrap_or_default(),
@@ -250,15 +252,14 @@ impl Task {
     }
 
     pub fn to_config(&self) -> TaskConfig {
+        let mut command = vec![self.command.clone()];
+        command.extend(self.args.clone());
+
         let mut config = TaskConfig {
-            command: Some(self.command.clone()),
+            command: Some(TaskCommandArgs::Sequence(command)),
             options: self.options.to_config(),
             ..TaskConfig::default()
         };
-
-        if !self.args.is_empty() {
-            config.args = Some(self.args.clone());
-        }
 
         if !self.deps.is_empty() {
             config.deps = Some(self.deps.clone());
@@ -542,17 +543,19 @@ impl Task {
     }
 
     pub fn merge(&mut self, config: &TaskConfig) {
+        let (command, args) = config.get_command_and_args().unwrap();
+
         // Merge options first incase the merge strategy has changed
         self.options.merge(&config.options);
         self.platform = config.type_of.clone();
 
         // Then merge the actual task fields
-        if let Some(command) = &config.command {
-            self.command = command.clone();
+        if let Some(cmd) = command {
+            self.command = cmd;
         }
 
-        if let Some(args) = &config.args {
-            self.args = self.merge_string_vec(&self.args, args, &self.options.merge_args);
+        if !args.is_empty() {
+            self.args = self.merge_string_vec(&self.args, &args, &self.options.merge_args);
         }
 
         if let Some(deps) = &config.deps {

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -197,11 +197,11 @@ impl Task {
         }
     }
 
-    pub fn from_config(target: TargetID, config: &TaskConfig) -> Self {
+    pub fn from_config(target: TargetID, config: &TaskConfig) -> Result<Self, TaskError> {
         let cloned_config = config.clone();
         let cloned_options = cloned_config.options;
 
-        let (command, args) = config.get_command_and_args().unwrap();
+        let (command, args) = config.get_command_and_args()?;
         let command = command.unwrap_or_default();
         let is_local =
             cloned_config.local || command == "dev" || command == "serve" || command == "start";
@@ -248,7 +248,7 @@ impl Task {
             color::shell(&task.command)
         );
 
-        task
+        Ok(task)
     }
 
     pub fn to_config(&self) -> TaskConfig {
@@ -542,8 +542,8 @@ impl Task {
         self.command == "nop" || self.command == "noop" || self.command == "no-op"
     }
 
-    pub fn merge(&mut self, config: &TaskConfig) {
-        let (command, args) = config.get_command_and_args().unwrap();
+    pub fn merge(&mut self, config: &TaskConfig) -> Result<(), TaskError> {
+        let (command, args) = config.get_command_and_args()?;
 
         // Merge options first incase the merge strategy has changed
         self.options.merge(&config.options);
@@ -574,6 +574,8 @@ impl Task {
             self.outputs =
                 self.merge_string_vec(&self.outputs, outputs, &self.options.merge_outputs);
         }
+
+        Ok(())
     }
 
     pub fn should_run_in_ci(&self) -> bool {

--- a/crates/task/src/test.rs
+++ b/crates/task/src/test.rs
@@ -74,6 +74,7 @@ pub fn create_initial_task(config: Option<TaskConfig>) -> Task {
         Target::format("project", "task").unwrap(),
         &config.unwrap_or_default(),
     )
+    .unwrap()
 }
 
 pub fn create_expanded_task(

--- a/crates/task/tests/task_test.rs
+++ b/crates/task/tests/task_test.rs
@@ -30,7 +30,7 @@ mod from_config {
 
     #[test]
     fn sets_defaults() {
-        let task = Task::from_config("foo:test".to_owned(), &TaskConfig::default());
+        let task = Task::from_config("foo:test".to_owned(), &TaskConfig::default()).unwrap();
 
         assert_eq!(task.inputs, string_vec!["**/*"]);
         assert_eq!(task.log_target, "moon:project:foo:test");
@@ -62,7 +62,8 @@ mod from_config {
                 local: true,
                 ..TaskConfig::default()
             },
-        );
+        )
+        .unwrap();
 
         assert_eq!(
             task.options,
@@ -83,7 +84,8 @@ mod from_config {
                 command: Some(TaskCommandArgs::String("dev".to_owned())),
                 ..TaskConfig::default()
             },
-        );
+        )
+        .unwrap();
 
         assert_eq!(
             task.options,
@@ -108,7 +110,8 @@ mod from_config {
                 },
                 ..TaskConfig::default()
             },
-        );
+        )
+        .unwrap();
 
         assert_eq!(
             task.options,
@@ -132,7 +135,8 @@ mod from_config {
                 },
                 ..TaskConfig::default()
             },
-        );
+        )
+        .unwrap();
 
         assert_eq!(
             task.options,

--- a/crates/task/tests/task_test.rs
+++ b/crates/task/tests/task_test.rs
@@ -1,4 +1,4 @@
-use moon_config::{TaskConfig, TaskOptionEnvFile, TaskOptionsConfig};
+use moon_config::{TaskCommandArgs, TaskConfig, TaskOptionEnvFile, TaskOptionsConfig};
 use moon_task::test::create_expanded_task;
 use moon_task::{Task, TaskOptions};
 use moon_utils::test::{create_sandbox, get_fixtures_dir};
@@ -80,7 +80,7 @@ mod from_config {
         let task = Task::from_config(
             "foo:test".to_owned(),
             &TaskConfig {
-                command: Some("dev".to_owned()),
+                command: Some(TaskCommandArgs::String("dev".to_owned())),
                 ..TaskConfig::default()
             },
         );

--- a/crates/task/tests/task_test.rs
+++ b/crates/task/tests/task_test.rs
@@ -146,6 +146,196 @@ mod from_config {
             }
         )
     }
+
+    #[test]
+    fn handles_command_string() {
+        let task = Task::from_config(
+            "foo:test".to_owned(),
+            &TaskConfig {
+                command: Some(TaskCommandArgs::String("foo --bar".to_owned())),
+                args: Some(TaskCommandArgs::Sequence(string_vec!["--baz"])),
+                ..TaskConfig::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(task.command, "foo".to_owned());
+        assert_eq!(task.args, string_vec!["--bar", "--baz"]);
+    }
+
+    #[test]
+    fn handles_command_list() {
+        let task = Task::from_config(
+            "foo:test".to_owned(),
+            &TaskConfig {
+                command: Some(TaskCommandArgs::Sequence(string_vec!["foo", "--bar"])),
+                args: Some(TaskCommandArgs::String("--baz".to_owned())),
+                ..TaskConfig::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(task.command, "foo".to_owned());
+        assert_eq!(task.args, string_vec!["--bar", "--baz"]);
+    }
+}
+
+mod merge {
+    use moon_config::TaskMergeStrategy;
+
+    use super::*;
+
+    #[test]
+    fn merges_command_string() {
+        let mut task = Task {
+            command: "cmd".to_owned(),
+            args: string_vec!["--arg"],
+            ..Task::default()
+        };
+
+        task.merge(&TaskConfig {
+            command: Some(TaskCommandArgs::String("foo --bar".to_owned())),
+            args: Some(TaskCommandArgs::Sequence(string_vec!["--baz"])),
+            ..TaskConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(task.command, "foo".to_owned());
+        assert_eq!(task.args, string_vec!["--arg", "--bar", "--baz"]);
+    }
+
+    #[test]
+    fn merges_command_list() {
+        let mut task = Task {
+            command: "cmd".to_owned(),
+            args: string_vec!["--arg"],
+            ..Task::default()
+        };
+
+        task.merge(&TaskConfig {
+            command: Some(TaskCommandArgs::Sequence(string_vec!["foo", "--bar"])),
+            args: Some(TaskCommandArgs::String("--baz".to_owned())),
+            ..TaskConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(task.command, "foo".to_owned());
+        assert_eq!(task.args, string_vec!["--arg", "--bar", "--baz"]);
+    }
+
+    #[test]
+    fn appends_command_args() {
+        let mut task = Task {
+            command: "cmd".to_owned(),
+            args: string_vec!["--arg"],
+            ..Task::default()
+        };
+
+        task.merge(&TaskConfig {
+            command: Some(TaskCommandArgs::String("foo --after".to_owned())),
+            args: Some(TaskCommandArgs::String("--post".to_owned())),
+            options: TaskOptionsConfig {
+                merge_args: Some(TaskMergeStrategy::Append),
+                ..TaskOptionsConfig::default()
+            },
+            ..TaskConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(task.args, string_vec!["--arg", "--after", "--post"]);
+    }
+
+    #[test]
+    fn prepends_command_args() {
+        let mut task = Task {
+            command: "cmd".to_owned(),
+            args: string_vec!["--arg"],
+            ..Task::default()
+        };
+
+        task.merge(&TaskConfig {
+            command: Some(TaskCommandArgs::String("foo --before".to_owned())),
+            args: Some(TaskCommandArgs::String("--pre".to_owned())),
+            options: TaskOptionsConfig {
+                merge_args: Some(TaskMergeStrategy::Prepend),
+                ..TaskOptionsConfig::default()
+            },
+            ..TaskConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(task.args, string_vec!["--before", "--pre", "--arg"]);
+    }
+
+    #[test]
+    fn replaces_command_args() {
+        let mut task = Task {
+            command: "cmd".to_owned(),
+            args: string_vec!["--arg"],
+            ..Task::default()
+        };
+
+        task.merge(&TaskConfig {
+            command: Some(TaskCommandArgs::String("foo --new".to_owned())),
+            args: Some(TaskCommandArgs::String("--hot".to_owned())),
+            options: TaskOptionsConfig {
+                merge_args: Some(TaskMergeStrategy::Replace),
+                ..TaskOptionsConfig::default()
+            },
+            ..TaskConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(task.args, string_vec!["--new", "--hot"]);
+    }
+
+    #[test]
+    fn handles_all_strategies() {
+        let mut task = Task {
+            command: "cmd".to_owned(),
+            args: string_vec!["--arg"],
+            ..Task::default()
+        };
+
+        task.merge(&TaskConfig {
+            args: Some(TaskCommandArgs::String("--a".to_owned())),
+            options: TaskOptionsConfig {
+                merge_args: Some(TaskMergeStrategy::Append),
+                ..TaskOptionsConfig::default()
+            },
+            ..TaskConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(task.command, "cmd".to_owned());
+        assert_eq!(task.args, string_vec!["--arg", "--a"]);
+
+        task.merge(&TaskConfig {
+            args: Some(TaskCommandArgs::Sequence(string_vec!["--b"])),
+            options: TaskOptionsConfig {
+                merge_args: Some(TaskMergeStrategy::Prepend),
+                ..TaskOptionsConfig::default()
+            },
+            ..TaskConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(task.command, "cmd".to_owned());
+        assert_eq!(task.args, string_vec!["--b", "--arg", "--a"]);
+
+        task.merge(&TaskConfig {
+            command: Some(TaskCommandArgs::String("foo --r".to_owned())),
+            options: TaskOptionsConfig {
+                merge_args: Some(TaskMergeStrategy::Replace),
+                ..TaskOptionsConfig::default()
+            },
+            ..TaskConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(task.command, "foo".to_owned());
+        assert_eq!(task.args, string_vec!["--r"]);
+    }
 }
 
 mod is_affected {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Added support for Linux ARM musl (`aarch64-unknown-linux-musl`).
 - Added a `typescript` setting to `moon.yml`, allowing TypeScript support to be toggled per project.
 - Added an `--affected` option to the `moon query projects` command.
+- Updated the task `command` to also support inline arguments. You can now merge `command` and
+  `args` into a single field.
 
 ## 0.11.1
 

--- a/website/docs/concepts/task.mdx
+++ b/website/docs/concepts/task.mdx
@@ -49,8 +49,8 @@ point.
 # Global
 tasks:
   build:
-    command: 'webpack'
-    args:
+    command:
+      - 'webpack'
       - '--mode'
       - 'production'
       - '--color'
@@ -77,8 +77,8 @@ tasks:
 # Merged result
 tasks:
   build:
-    command: 'webpack'
-    args:
+    command:
+      - 'webpack'
       - '--mode'
       - 'production'
       - '--color'

--- a/website/docs/concepts/token.mdx
+++ b/website/docs/concepts/token.mdx
@@ -86,16 +86,15 @@ fileGroups:
 # Configured as
 tasks:
   lint:
-    command: 'eslint'
-    args: '@dirs(lintable) --color'
+    command: 'eslint @dirs(lintable) --color'
     inputs:
       - '@dirs(lintable)'
 
 # Resolves to
 tasks:
   lint:
-    command: 'eslint'
-    args:
+    command:
+      - 'eslint'
       - 'src'
       - 'tests'
       - 'scripts'
@@ -126,16 +125,15 @@ fileGroups:
 # Configured as
 tasks:
   build:
-    command: 'webpack'
-    args: 'build @files(config)'
+    command: 'webpack build @files(config)'
     inputs:
       - '@files(config)'
 
 # Resolves to
 tasks:
   build:
-    command: 'webpack'
-    args:
+    command:
+      - 'webpack'
       - 'build'
       - 'babel.config.js'
       - 'webpack.config.js'
@@ -167,16 +165,15 @@ fileGroups:
 # Configured as
 tasks:
   test:
-    command: 'jest'
-    args: '--testMatch @globs(tests)'
+    command: 'jest --testMatch @globs(tests)'
     inputs:
       - '@globs(tests)'
 
 # Resolves to
 tasks:
   test:
-    command: 'jest'
-    args:
+    command:
+      - 'jest'
       - '--testMatch'
       - 'tests/**/*'
       - '**/__tests__/**/*'
@@ -206,16 +203,15 @@ fileGroups:
 # Configured as
 tasks:
   format:
-    command: 'prettier'
-    args: '--write @root(sources)'
+    command: 'prettier --write @root(sources)'
     inputs:
       - '@root(sources)'
 
 # Resolves to
 tasks:
   format:
-    command: 'prettier'
-    args:
+    command:
+      - 'prettier'
       - '--write'
       - 'src'
     inputs:
@@ -239,8 +235,8 @@ the glob will be used as-is, instead of returning the expanded list of files.
 # Configured as
 tasks:
   build:
-    command: 'babel'
-    args:
+    command:
+      - 'babel'
       - '--copy-files'
       - '--config-file'
       - '@in(1)'
@@ -252,8 +248,8 @@ tasks:
 # Resolves to
 tasks:
   build:
-    command: 'babel'
-    args:
+    command:
+      - 'babel'
       - '--copy-files'
       - '--config-file'
       - 'babel.config.js'
@@ -275,8 +271,8 @@ the process will **fail**, as it requires literal folder and file paths.
 # Configured as
 tasks:
   build:
-    command: 'babel'
-    args:
+    command:
+      - 'babel'
       - '.'
       - '--out-dir'
       - '@out(0)'
@@ -286,8 +282,8 @@ tasks:
 # Resolves to
 tasks:
   build:
-    command: 'babel'
-    args:
+    command:
+      - 'babel'
       - '.'
       - '--out-dir'
       - 'lib'
@@ -313,14 +309,13 @@ config, this defaults to "unknown".
 # Configured as
 tasks:
   build:
-    command: 'example'
-    args: 'debug $language'
+    command: 'example debug $language'
 
 # Resolves to
 tasks:
   build:
-    command: 'example'
-    args:
+    command:
+      - 'example'
       - 'debug'
       - 'node'
 ```
@@ -334,14 +329,13 @@ ID/name of the project that owns the currently running task, as defined in
 # Configured as
 tasks:
   build:
-    command: 'example'
-    args: '--project $project'
+    command: 'example --project $project'
 
 # Resolves to
 tasks:
   build:
-    command: 'example'
-    args:
+    command:
+      - 'example'
       - '--project'
       - 'web'
 ```
@@ -354,14 +348,13 @@ Absolute file path to the project root.
 # Configured as
 tasks:
   build:
-    command: 'example'
-    args: '--cwd $projectRoot'
+    command: 'example --cwd $projectRoot'
 
 # Resolves to
 tasks:
   build:
-    command: 'example'
-    args:
+    command:
+      - 'example'
       - '--cwd'
       - '/path/to/repo/apps/web'
 ```
@@ -375,16 +368,16 @@ Relative file path from the workspace root to the project root, as defined in
 # Configured as
 tasks:
   build:
-    command: 'example'
-    args:
+    command:
+      - 'example'
       - '--cache-dir'
       - '../../.cache/$projectSource'
 
 # Resolves to
 tasks:
   build:
-    command: 'example'
-    args:
+    command:
+      - 'example'
       - '--cache-dir'
       - '../../.cache/apps/web'
 ```
@@ -399,14 +392,13 @@ the [`type`](../config/project#type-1) setting, or does not have a config, this 
 # Configured as
 tasks:
   build:
-    command: 'example'
-    args: 'debug $projectType'
+    command: 'example debug $projectType'
 
 # Resolves to
 tasks:
   build:
-    command: 'example'
-    args:
+    command:
+      - 'example'
       - 'debug'
       - 'application'
 ```
@@ -419,14 +411,13 @@ Target that is currently running. Is a combination of project and task name.
 # Configured as
 tasks:
   build:
-    command: 'example'
-    args: '$target'
+    command: 'example $target'
 
 # Resolves to
 tasks:
   build:
-    command: 'example'
-    args:
+    command:
+      - 'example'
       - 'web:build'
 ```
 
@@ -438,14 +429,13 @@ ID/name of the task that is currently running.
 # Configured as
 tasks:
   build:
-    command: 'example'
-    args: '--task=$task'
+    command: 'example --task=$task'
 
 # Resolves to
 tasks:
   build:
-    command: 'example'
-    args:
+    command:
+      - 'example'
       - '--task=build'
 ```
 
@@ -457,14 +447,13 @@ The type of task that is currently running.
 # Configured as
 tasks:
   build:
-    command: 'example'
-    args: '--type $taskType'
+    command: 'example --type $taskType'
 
 # Resolves to
 tasks:
   build:
-    command: 'example'
-    args:
+    command:
+      - 'example'
       - '--type'
       - 'system'
 ```
@@ -477,16 +466,16 @@ Absolute file path to the workspace root.
 # Configured as
 tasks:
   build:
-    command: 'example'
-    args:
+    command:
+      - 'example'
       - '--cwd'
       - '$workspaceRoot'
 
 # Resolves to
 tasks:
   build:
-    command: 'example'
-    args:
+    command:
+      - 'example'
       - '--cwd'
       - '/path/to/repo'
 ```

--- a/website/docs/config/global-project.mdx
+++ b/website/docs/config/global-project.mdx
@@ -77,20 +77,16 @@ per project.
 ```yaml title=".moon/project.yml"
 tasks:
   format:
-    command: 'prettier'
-    args: '--check .'
+    command: 'prettier --check .'
 
   lint:
-    command: 'eslint'
-    args: '--no-error-on-unmatched-pattern .'
+    command: 'eslint --no-error-on-unmatched-pattern .'
 
   test:
-    command: 'jest'
-    args: '--passWithNoTests'
+    command: 'jest --passWithNoTests'
 
   typecheck:
-    command: 'tsc'
-    args: '--build'
+    command: 'tsc --build'
 ```
 
 > Relative file paths and globs used within a task are relative from the inherited project's root,

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -177,31 +177,38 @@ tasks:
 
 ### `command`<RequiredLabel />
 
-> `string`
+> `string | string[]`
 
-The `command` field is the name of an npm binary or native system command to run when executing the
-task. This field is required when _not_ inheriting a global task of the same name.
+The `command` field is the command line to run for the task, including the command name (must be
+first) and any optional [arguments](#args). This field is required when _not_ inheriting a global
+task of the same name.
 
 ```yaml title="moon.yml" {3}
 tasks:
   format:
-    command: 'prettier'
+    # Using a string
+    command: 'prettier --check .'
+    # Using an array
+    command:
+      - 'prettier'
+      - '--check'
+      - '.'
 ```
 
-By default a task assumes the command is an npm binary, and if you'd like to reference a system
-command, you'll also need to set the [`type`](#type) to "system".
+By default a task assumes the command name is an npm binary, and if you'd like to reference a system
+command, you'll also need to set the [`type`](#type) to "system". We do our best to automatically
+detect this, but it's not perfect.
 
 ```yaml title="moon.yml"
 tasks:
   clean:
-    command: 'rm'
-    args: '-rf dist'
+    command: 'rm -rf ./dist'
     type: 'system'
 ```
 
 #### Special commands
 
-For interoperability reasons, the following commands have special handling.
+For interoperability reasons, the following command names have special handling.
 
 - `noop`, `no-op`, `nop` - Marks the task as a "no operation". Will not execute a command in the
   action runner but can define dependencies.
@@ -216,7 +223,10 @@ For interoperability reasons, the following commands have special handling.
 
 > `string | string[]`
 
-The `args` field is a collection of arguments to pass on the command line when executing the task.
+The `args` field is a collection of _additional_ arguments to pass to the command line when
+executing the task. This field exists purely to provide arguments for
+[inherited tasks](./global-project#tasks).
+
 This setting can be defined using a string, or an array of strings. We suggest using arrays when
 dealing with many args, or the args string cannot be parsed easily.
 
@@ -224,9 +234,9 @@ dealing with many args, or the args string cannot be parsed easily.
 tasks:
   test:
     command: 'jest'
-    # String
+    # Using a string
     args: '--color --maxWorkers 3'
-    # Array
+    # Using an array
     args:
       - '--color'
       - '--maxWorkers'
@@ -335,8 +345,7 @@ This is a convenience setting for local development that sets the following task
 ```yaml title="moon.yml" {5}
 tasks:
   dev:
-    command: 'webpack'
-    args: 'server'
+    command: 'webpack server'
     local: true
 ```
 
@@ -373,8 +382,7 @@ execution. The following fields can be provided, with merge related fields suppo
 ```yaml title="moon.yml" {6-8}
 tasks:
   typecheck:
-    command: 'tsc'
-    args: '--noEmit'
+    command: 'tsc --noEmit'
     options:
       mergeArgs: 'replace'
       runFromWorkspaceRoot: true
@@ -394,8 +402,7 @@ operations.
 ```yaml title="moon.yml" {6}
 tasks:
   clean:
-    command: 'rm'
-    args: '-rf ./temp'
+    command: 'rm -rf ./temp'
     options:
       cache: false
 ```

--- a/website/docs/create-project.mdx
+++ b/website/docs/create-project.mdx
@@ -77,8 +77,8 @@ following:
 ```yaml title="apps/client/moon.yml"
 tasks:
 	build:
-		command: 'webpack'
-		args:
+		command:
+			- 'webpack'
 			- 'build'
 			- '--mode'
 			- 'production'
@@ -98,8 +98,7 @@ tasks:
 ```yaml title="apps/server/moon.yml"
 tasks:
 	build:
-		command: 'babel'
-		args: 'src --out-dir build'
+		command: 'babel src --out-dir build'
 		inputs:
 			- 'src/**/*'
 		outputs:
@@ -112,17 +111,13 @@ tasks:
 ```yaml title=".moon/project.yml"
 tasks:
 	format:
-		command: 'prettier'
-		args: '--write .'
+		command: 'prettier --write .'
 	lint:
-		command: 'eslint'
-		args: '--no-error-on-unmatched-pattern .'
+		command: 'eslint --no-error-on-unmatched-pattern .'
 	test:
-		command: 'jest'
-		args: '--passWithNoTests .'
+		command: 'jest --passWithNoTests .'
 	typecheck:
-		command: 'tsc'
-		args: '--build'
+		command: 'tsc --build'
 ```
 
 </TabItem>

--- a/website/docs/create-task.mdx
+++ b/website/docs/create-task.mdx
@@ -41,8 +41,7 @@ for project boundaries and strict encapsulation, and as such, we'll use it below
 ```yaml title=".moon/project.yml" {4}
 tasks:
 	typecheck:
-		command: 'tsc'
-		args: '--build --verbose'
+		command: 'tsc --build --verbose'
 ```
 
 With this, the task can be ran from the command line with
@@ -66,8 +65,7 @@ to exist in the project, and probably in the workspace root too.
 ```yaml title=".moon/project.yml" {5-11}
 tasks:
 	typecheck:
-		command: 'tsc'
-		args: '--build --verbose'
+		command: 'tsc --build --verbose'
 		inputs:
 			- 'src/**/*'
 			- 'tests/**/*'
@@ -111,8 +109,7 @@ task with the [`outputs`](./config/project#outputs) setting.
 ```yaml title=".moon/project.yml" {12,13}
 tasks:
 	typecheck:
-		command: 'tsc'
-		args: '--build --verbose'
+		command: 'tsc --build --verbose'
 		inputs:
 			- 'src/**/*'
 			- 'tests/**/*'
@@ -189,8 +186,7 @@ to their documentation for more information!
 ```yaml title=".moon/project.yml" {6-8}
 tasks:
 	typecheck:
-		command: 'tsc'
-		args: '--build --verbose'
+		command: 'tsc --build --verbose'
 		inputs:
 			- '@globs(sources)'
 			- '@globs(tests)'

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -77,8 +77,7 @@ moon project foo --json | jq ...
 ```yaml title="moon.yml"
 tasks:
 	pipe:
-		command: 'bash'
-		args: './scripts/pipe.sh'
+		command: 'bash ./scripts/pipe.sh'
 		type: 'system'
 ```
 

--- a/website/docs/guides/ci.mdx
+++ b/website/docs/guides/ci.mdx
@@ -33,10 +33,11 @@ options.
 ```yaml
 tasks:
   dev:
-    command: 'webpack'
-    args: 'server'
+    command: 'webpack server'
     options:
       runInCI: false
+    # Or
+    local: true
 ```
 
 :::caution

--- a/website/docs/guides/examples/eslint.mdx
+++ b/website/docs/guides/examples/eslint.mdx
@@ -24,8 +24,8 @@ Since linting is a universal workflow, add a `lint` task to
 ```yaml title=".moon/project.yml"
 tasks:
 	lint:
-		command: 'eslint'
-		args:
+		command:
+		 	- 'eslint'
 			# Support other extensions
 			- '--ext'
 			- '.js,.jsx,.ts,.tsx'

--- a/website/docs/guides/examples/jest.mdx
+++ b/website/docs/guides/examples/jest.mdx
@@ -24,8 +24,8 @@ Since testing is a universal workflow, add a `test` task to
 ```yaml title=".moon/project.yml"
 tasks:
 	test:
-		command: 'jest'
-		args:
+		command:
+			- 'jest'
 			# Always run code coverage
 			- '--coverage'
 			# Dont fail if a project has no tests

--- a/website/docs/guides/examples/next.mdx
+++ b/website/docs/guides/examples/next.mdx
@@ -41,23 +41,20 @@ fileGroups:
 tasks:
 	# Development server
 	dev:
-		command: 'next'
-		args: 'dev'
+		command: 'next dev'
 		inputs:
 			- '@group(next)'
 		local: true
 
 	# Production build (SSR)
 	build:
-		command: 'next'
-		args: 'build'
+		command: 'next build'
 		inputs:
 			- '@group(next)'
 
 	# Production build (SSG)
 	export:
-		command: 'next'
-		args: 'export -o ./build'
+		command: 'next export -o ./build'
 		deps:
 			- '~:build'
 		inputs:
@@ -67,8 +64,7 @@ tasks:
 
 	# Serve the build
 	start:
-		command: 'next'
-		args: 'start'
+		command: 'next start'
 		inputs:
 			- '@group(next)'
 		local: true
@@ -138,8 +134,7 @@ If you'd prefer to use the `next lint` command, add it as a task to the project'
 ```yaml title="<project>/moon.yml"
 tasks:
 	lint:
-		command: 'next'
-		args: 'lint'
+		command: 'next lint'
 		inputs:
 			- '@group(next)'
 ```

--- a/website/docs/guides/examples/packemon.mdx
+++ b/website/docs/guides/examples/packemon.mdx
@@ -46,8 +46,8 @@ is up to you. The following patterns are suggested:
 
 ```yaml title=".moon/project.yml"
 buildPackage:
-	command: 'packemon'
-	args:
+	command:
+		- 'packemon'
 		- 'pack'
 		# Add `engines` field to package
 		- '--addEngines'
@@ -103,8 +103,8 @@ workspace:
 
 ```yaml title="<package>/moon.yml"
 build:
-	command: 'packemon'
-	args:
+	command:
+		- 'packemon'
 		- 'pack'
 		# Add `engines` field to package
 		- '--addEngines'

--- a/website/docs/guides/examples/prettier.mdx
+++ b/website/docs/guides/examples/prettier.mdx
@@ -24,8 +24,8 @@ Since code formatting is a universal workflow, add a `format` task to
 ```yaml title=".moon/project.yml"
 tasks:
 	format:
-		command: 'prettier'
-		args:
+		command:
+			- 'packemon'
 			# Use the same config for the entire repo
 			- '--config'
 			- '@in(4)'

--- a/website/docs/guides/examples/remix.mdx
+++ b/website/docs/guides/examples/remix.mdx
@@ -42,16 +42,14 @@ fileGroups:
 tasks:
 	# Development server
 	dev:
-		command: 'remix'
-		args: 'dev'
+		command: 'remix dev'
 		inputs:
 			- '@group(remix)'
 		local: true
 
 	# Production build
 	build:
-		command: 'remix'
-		args: 'build'
+		command: 'remix build'
 		inputs:
 			- '@group(remix)'
 		outputs:
@@ -59,8 +57,7 @@ tasks:
 
 	# Serve the build
 	start:
-		command: 'remix-serve'
-		args: './build'
+		command: 'remix-serve ./build'
 		deps:
 			- '~:build'
 		inputs:

--- a/website/docs/guides/examples/typescript.mdx
+++ b/website/docs/guides/examples/typescript.mdx
@@ -28,8 +28,8 @@ Since type-checking is a universal workflow, add a `typecheck` task to
 ```yaml title=".moon/project.yml"
 tasks:
 	typecheck:
-		command: 'tsc'
-		args:
+		command:
+			- 'tsc'
 			# Use incremental builds with project references
 			- '--build'
 			# Always use pretty output

--- a/website/docs/guides/examples/vite.mdx
+++ b/website/docs/guides/examples/vite.mdx
@@ -35,16 +35,14 @@ fileGroups:
 tasks:
 	# Development server
 	dev:
-		command: 'vite'
-		args: 'dev'
+		command: 'vite dev'
 		inputs:
 			- '@group(vite)'
 		local: true
 
 	# Production build
 	build:
-		command: 'vite'
-		args: 'build'
+		command: 'vite build'
 		inputs:
 			- '@group(vite)'
 		outputs:
@@ -52,8 +50,7 @@ tasks:
 
 	# Preview production build locally
 	preview:
-		command: 'vite'
-		args: 'preview'
+		command: 'vite preview'
 		inputs:
 			- '@group(vite)'
 		deps:
@@ -62,8 +59,8 @@ tasks:
 
 	# Unit testing (if using Vitest)
 	test:
-		command: 'vitest'
-		args:
+		command:
+			- 'vitest'
 			- 'run'
 			# Always run code coverage
 			- '--coverage'

--- a/website/docs/guides/examples/vue.mdx
+++ b/website/docs/guides/examples/vue.mdx
@@ -56,8 +56,8 @@ workspace:
 
 tasks:
 	typecheck:
-		command: 'vue-tsc'
-		args:
+		command:
+			- 'vue-tsc'
 			- '--noEmit'
 			# Always use pretty output
 			- '--pretty'

--- a/website/docs/guides/root-project.mdx
+++ b/website/docs/guides/root-project.mdx
@@ -29,8 +29,7 @@ can define tasks that can be ran using this new root-level project name, for exa
 ```yaml title="moon.yml"
 tasks:
 	versionCheck:
-		command: 'yarn'
-		args: 'version check'
+		command: 'yarn version check'
 		inputs: []
 		options:
 			cache: false

--- a/website/static/schemas/global-project.json
+++ b/website/static/schemas/global-project.json
@@ -5,6 +5,7 @@
   "type": "object",
   "properties": {
     "extends": {
+      "default": null,
       "type": [
         "string",
         "null"
@@ -37,27 +38,40 @@
         "unknown"
       ]
     },
+    "TaskCommandArgs": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "TaskConfig": {
       "type": "object",
       "properties": {
         "args": {
-          "title": "ArgsField",
           "anyOf": [
             {
-              "type": "string"
+              "$ref": "#/definitions/TaskCommandArgs"
             },
             {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "type": "null"
             }
           ]
         },
         "command": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TaskCommandArgs"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "deps": {
@@ -235,7 +249,10 @@
     "TaskOutputStyle": {
       "type": "string",
       "enum": [
-        "on-exit",
+        "buffer",
+        "buffer-only-failure",
+        "hash",
+        "none",
         "stream"
       ]
     }

--- a/website/static/schemas/project.json
+++ b/website/static/schemas/project.json
@@ -143,6 +143,10 @@
       "properties": {
         "inheritedTasks": {
           "$ref": "#/definitions/ProjectWorkspaceInheritedTasksConfig"
+        },
+        "typescript": {
+          "default": true,
+          "type": "boolean"
         }
       }
     },
@@ -178,27 +182,40 @@
         }
       }
     },
+    "TaskCommandArgs": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "TaskConfig": {
       "type": "object",
       "properties": {
         "args": {
-          "title": "ArgsField",
           "anyOf": [
             {
-              "type": "string"
+              "$ref": "#/definitions/TaskCommandArgs"
             },
             {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "type": "null"
             }
           ]
         },
         "command": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TaskCommandArgs"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "deps": {
@@ -376,7 +393,10 @@
     "TaskOutputStyle": {
       "type": "string",
       "enum": [
-        "on-exit",
+        "buffer",
+        "buffer-only-failure",
+        "hash",
+        "none",
         "stream"
       ]
     }

--- a/website/static/schemas/workspace.json
+++ b/website/static/schemas/workspace.json
@@ -6,6 +6,7 @@
   "properties": {
     "actionRunner": {
       "default": {
+        "cacheLifetime": "7 days",
         "implicitInputs": [
           "package.json",
           "/.moon/project.yml",
@@ -59,16 +60,13 @@
       ]
     },
     "typescript": {
-      "default": {
-        "createMissingConfig": true,
-        "projectConfigFileName": "tsconfig.json",
-        "rootConfigFileName": "tsconfig.json",
-        "rootOptionsConfigFileName": "tsconfig.options.json",
-        "syncProjectReferences": true
-      },
-      "allOf": [
+      "default": null,
+      "anyOf": [
         {
           "$ref": "#/definitions/TypeScriptConfig"
+        },
+        {
+          "type": "null"
         }
       ]
     },
@@ -88,6 +86,10 @@
     "ActionRunnerConfig": {
       "type": "object",
       "properties": {
+        "cacheLifetime": {
+          "default": "7 days",
+          "type": "string"
+        },
         "implicitInputs": {
           "default": [
             "package.json",


### PR DESCRIPTION
Implements https://github.com/moonrepo/moon/issues/229

Instead of making this a breaking change and removing the `args` setting, it updates the `command` to also support args (and being defined as an array). This is backwards compatible, but also forward thinking.