### PR TITLE
breaking: Make `node` optional. Rework toolchain setup.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,6 +1326,7 @@ dependencies = [
  "moon_action",
  "moon_cache",
  "moon_config",
+ "moon_contract",
  "moon_error",
  "moon_hasher",
  "moon_lang",

--- a/crates/action-runner/Cargo.toml
+++ b/crates/action-runner/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 moon_action = { path = "../action" }
 moon_cache = { path = "../cache" }
 moon_config = { path = "../config" }
+moon_contract = { path = "../contract" }
 moon_error = { path = "../error" }
 moon_hasher = { path = "../hasher" }
 moon_lang = { path = "../lang" }

--- a/crates/action-runner/src/actions/mod.rs
+++ b/crates/action-runner/src/actions/mod.rs
@@ -1,5 +1,3 @@
 mod run_target;
-mod setup_toolchain;
 
 pub use run_target::run_target;
-pub use setup_toolchain::setup_toolchain;

--- a/crates/action-runner/src/node.rs
+++ b/crates/action-runner/src/node.rs
@@ -1,14 +1,14 @@
-use moon_lang::SupportedLanguage;
+use moon_contract::SupportedPlatform;
 use moon_project::ProjectID;
 use moon_task::TargetID;
 use std::hash::{Hash, Hasher};
 
 #[derive(Clone, Eq)]
 pub enum ActionNode {
-    InstallDeps(SupportedLanguage),
+    InstallDeps(SupportedPlatform),
     RunTarget(TargetID),
-    SetupToolchain(SupportedLanguage),
-    SyncProject(SupportedLanguage, ProjectID),
+    SetupToolchain(SupportedPlatform),
+    SyncProject(SupportedPlatform, ProjectID),
 }
 
 impl ActionNode {

--- a/crates/action-runner/src/node.rs
+++ b/crates/action-runner/src/node.rs
@@ -7,7 +7,7 @@ use std::hash::{Hash, Hasher};
 pub enum ActionNode {
     InstallDeps(SupportedLanguage),
     RunTarget(TargetID),
-    SetupToolchain,
+    SetupToolchain(SupportedLanguage),
     SyncProject(SupportedLanguage, ProjectID),
 }
 
@@ -16,7 +16,7 @@ impl ActionNode {
         match self {
             ActionNode::InstallDeps(lang) => format!("Install{}Deps", lang),
             ActionNode::RunTarget(id) => format!("RunTarget({})", id),
-            ActionNode::SetupToolchain => "SetupToolchain".into(),
+            ActionNode::SetupToolchain(lang) => format!("Setup{}Toolchain", lang),
             ActionNode::SyncProject(lang, id) => format!("Sync{}Project({})", lang, id),
         }
     }

--- a/crates/action-runner/src/node.rs
+++ b/crates/action-runner/src/node.rs
@@ -14,10 +14,10 @@ pub enum ActionNode {
 impl ActionNode {
     pub fn label(&self) -> String {
         match self {
-            ActionNode::InstallDeps(lang) => format!("Install{}Deps", lang),
+            ActionNode::InstallDeps(platform) => format!("Install{}Deps", platform),
             ActionNode::RunTarget(id) => format!("RunTarget({})", id),
-            ActionNode::SetupToolchain(lang) => format!("Setup{}Toolchain", lang),
-            ActionNode::SyncProject(lang, id) => format!("Sync{}Project({})", lang, id),
+            ActionNode::SetupToolchain(platform) => format!("Setup{}Toolchain", platform),
+            ActionNode::SyncProject(platform, id) => format!("Sync{}Project({})", platform, id),
         }
     }
 }

--- a/crates/action-runner/src/runner.rs
+++ b/crates/action-runner/src/runner.rs
@@ -34,12 +34,18 @@ async fn run_action(
                 .map_err(ActionRunnerError::Workspace),
             _ => Ok(ActionStatus::Passed),
         },
+
         ActionNode::RunTarget(target_id) => {
             actions::run_target(action, context, workspace, target_id).await
         }
-        ActionNode::SetupToolchain(lang) => {
-            actions::setup_toolchain(action, context, workspace).await
-        }
+
+        ActionNode::SetupToolchain(lang) => match lang {
+            SupportedLanguage::Node => node_actions::setup_toolchain(action, context, workspace)
+                .await
+                .map_err(ActionRunnerError::Workspace),
+            _ => Ok(ActionStatus::Passed),
+        },
+
         ActionNode::SyncProject(lang, project_id) => match lang {
             SupportedLanguage::Node => {
                 node_actions::sync_project(action, context, workspace, project_id)

--- a/crates/action-runner/src/runner.rs
+++ b/crates/action-runner/src/runner.rs
@@ -37,7 +37,9 @@ async fn run_action(
         ActionNode::RunTarget(target_id) => {
             actions::run_target(action, context, workspace, target_id).await
         }
-        ActionNode::SetupToolchain => actions::setup_toolchain(action, context, workspace).await,
+        ActionNode::SetupToolchain(lang) => {
+            actions::setup_toolchain(action, context, workspace).await
+        }
         ActionNode::SyncProject(lang, project_id) => match lang {
             SupportedLanguage::Node => {
                 node_actions::sync_project(action, context, workspace, project_id)
@@ -56,7 +58,7 @@ async fn run_action(
             action.fail(error.to_string());
 
             // If these fail, we should abort instead of trying to continue
-            if matches!(node, ActionNode::SetupToolchain)
+            if matches!(node, ActionNode::SetupToolchain(_))
                 || matches!(node, ActionNode::InstallDeps(_))
             {
                 action.abort();

--- a/crates/action-runner/src/runner.rs
+++ b/crates/action-runner/src/runner.rs
@@ -5,8 +5,8 @@ use crate::node::ActionNode;
 use console::Term;
 use moon_action::{Action, ActionContext, ActionStatus};
 use moon_cache::RunReport;
+use moon_contract::SupportedPlatform;
 use moon_error::MoonError;
-use moon_lang::SupportedLanguage;
 use moon_logger::{color, debug, error, trace};
 use moon_platform_node::actions as node_actions;
 use moon_terminal::{replace_style_tokens, ExtendedTerm};
@@ -28,8 +28,8 @@ async fn run_action(
     workspace: Arc<RwLock<Workspace>>,
 ) -> Result<(), ActionRunnerError> {
     let result = match node {
-        ActionNode::InstallDeps(lang) => match lang {
-            SupportedLanguage::Node => node_actions::install_deps(action, context, workspace)
+        ActionNode::InstallDeps(platform) => match platform {
+            SupportedPlatform::Node => node_actions::install_deps(action, context, workspace)
                 .await
                 .map_err(ActionRunnerError::Workspace),
             _ => Ok(ActionStatus::Passed),
@@ -39,15 +39,15 @@ async fn run_action(
             actions::run_target(action, context, workspace, target_id).await
         }
 
-        ActionNode::SetupToolchain(lang) => match lang {
-            SupportedLanguage::Node => node_actions::setup_toolchain(action, context, workspace)
+        ActionNode::SetupToolchain(platform) => match platform {
+            SupportedPlatform::Node => node_actions::setup_toolchain(action, context, workspace)
                 .await
                 .map_err(ActionRunnerError::Workspace),
             _ => Ok(ActionStatus::Passed),
         },
 
-        ActionNode::SyncProject(lang, project_id) => match lang {
-            SupportedLanguage::Node => {
+        ActionNode::SyncProject(platform, project_id) => match platform {
+            SupportedPlatform::Node => {
                 node_actions::sync_project(action, context, workspace, project_id)
                     .await
                     .map_err(ActionRunnerError::Workspace)

--- a/crates/action-runner/tests/dep_graph_test.rs
+++ b/crates/action-runner/tests/dep_graph_test.rs
@@ -86,11 +86,7 @@ fn default_graph() {
 
     assert_snapshot!(graph.to_dot());
 
-    assert_eq!(graph.sort_topological().unwrap(), vec![NodeIndex::new(0)]);
-    assert_eq!(
-        sort_batches(graph.sort_batched_topological().unwrap()),
-        vec![vec![NodeIndex::new(0)]]
-    );
+    assert_eq!(graph.sort_topological().unwrap(), vec![]);
 }
 
 #[tokio::test]
@@ -417,16 +413,17 @@ mod sync_project {
                 NodeIndex::new(0),
                 NodeIndex::new(1), // advanced
                 NodeIndex::new(3), // noConfig
+                NodeIndex::new(4),
                 NodeIndex::new(2), // basic
-                NodeIndex::new(4), // emptyConfig
+                NodeIndex::new(5), // emptyConfig
             ]
         );
         assert_eq!(
             sort_batches(graph.sort_batched_topological().unwrap()),
             vec![
-                vec![NodeIndex::new(0)],
                 vec![NodeIndex::new(3)],
-                vec![NodeIndex::new(1), NodeIndex::new(2), NodeIndex::new(4)]
+                vec![NodeIndex::new(0), NodeIndex::new(4)],
+                vec![NodeIndex::new(1), NodeIndex::new(2), NodeIndex::new(5)]
             ]
         );
     }
@@ -450,17 +447,23 @@ mod sync_project {
                 NodeIndex::new(0),
                 NodeIndex::new(2), // baz
                 NodeIndex::new(3), // bar
+                NodeIndex::new(4),
                 NodeIndex::new(1), // foo
-                NodeIndex::new(5), // noConfig
-                NodeIndex::new(4), // basic
+                NodeIndex::new(6), // noConfig
+                NodeIndex::new(5), // basic
             ]
         );
         assert_eq!(
             sort_batches(graph.sort_batched_topological().unwrap()),
             vec![
-                vec![NodeIndex::new(0)],
-                vec![NodeIndex::new(2), NodeIndex::new(3), NodeIndex::new(5)],
-                vec![NodeIndex::new(1), NodeIndex::new(4)]
+                vec![NodeIndex::new(2)],
+                vec![
+                    NodeIndex::new(0),
+                    NodeIndex::new(3),
+                    NodeIndex::new(4),
+                    NodeIndex::new(6)
+                ],
+                vec![NodeIndex::new(1), NodeIndex::new(5)]
             ]
         );
     }
@@ -480,14 +483,15 @@ mod sync_project {
             vec![
                 NodeIndex::new(0),
                 NodeIndex::new(1), // noConfig
-                NodeIndex::new(2), // tasks
+                NodeIndex::new(2),
+                NodeIndex::new(3) // tasks
             ]
         );
         assert_eq!(
             sort_batches(graph.sort_batched_topological().unwrap()),
             vec![
-                vec![NodeIndex::new(0)],
-                vec![NodeIndex::new(1), NodeIndex::new(2)]
+                vec![NodeIndex::new(0), NodeIndex::new(2)],
+                vec![NodeIndex::new(1), NodeIndex::new(3)]
             ]
         );
     }

--- a/crates/action-runner/tests/snapshots/dep_graph_test__default_graph.snap
+++ b/crates/action-runner/tests/snapshots/dep_graph_test__default_graph.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/action-runner/tests/dep_graph_test.rs
-assertion_line: 78
+assertion_line: 87
 expression: graph.to_dot()
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
 }
 

--- a/crates/action-runner/tests/snapshots/dep_graph_test__run_target__avoids_dupe_targets.snap
+++ b/crates/action-runner/tests/snapshots/dep_graph_test__run_target__avoids_dupe_targets.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/action-runner/tests/dep_graph_test.rs
-assertion_line: 210
+assertion_line: 219
 expression: graph.to_dot()
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="InstallNodeDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(tasks)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     3 [ label="RunTarget(tasks:lint)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]

--- a/crates/action-runner/tests/snapshots/dep_graph_test__run_target__deps_chain_target.snap
+++ b/crates/action-runner/tests/snapshots/dep_graph_test__run_target__deps_chain_target.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/action-runner/tests/dep_graph_test.rs
-assertion_line: 162
+assertion_line: 171
 expression: graph.to_dot()
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="InstallNodeDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(basic)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     3 [ label="RunTarget(basic:test)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]

--- a/crates/action-runner/tests/snapshots/dep_graph_test__run_target__runs_all_projects_for_target_all_scope.snap
+++ b/crates/action-runner/tests/snapshots/dep_graph_test__run_target__runs_all_projects_for_target_all_scope.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/action-runner/tests/dep_graph_test.rs
-assertion_line: 240
+assertion_line: 249
 expression: graph.to_dot()
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="InstallNodeDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(basic)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     3 [ label="RunTarget(basic:build)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]

--- a/crates/action-runner/tests/snapshots/dep_graph_test__run_target__single_targets.snap
+++ b/crates/action-runner/tests/snapshots/dep_graph_test__run_target__single_targets.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/action-runner/tests/dep_graph_test.rs
-assertion_line: 125
+assertion_line: 134
 expression: graph.to_dot()
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="InstallNodeDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(tasks)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     3 [ label="RunTarget(tasks:test)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]

--- a/crates/action-runner/tests/snapshots/dep_graph_test__run_target_if_touched__skips_if_untouched_project.snap
+++ b/crates/action-runner/tests/snapshots/dep_graph_test__run_target_if_touched__skips_if_untouched_project.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/action-runner/tests/dep_graph_test.rs
-assertion_line: 349
+assertion_line: 359
 expression: graph.to_dot()
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="InstallNodeDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(inputA)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     3 [ label="RunTarget(inputA:a)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]

--- a/crates/action-runner/tests/snapshots/dep_graph_test__run_target_if_touched__skips_if_untouched_task.snap
+++ b/crates/action-runner/tests/snapshots/dep_graph_test__run_target_if_touched__skips_if_untouched_task.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/action-runner/tests/dep_graph_test.rs
-assertion_line: 384
+assertion_line: 395
 expression: graph.to_dot()
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="InstallNodeDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(inputB)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     3 [ label="RunTarget(inputB:b2)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]

--- a/crates/action-runner/tests/snapshots/dep_graph_test__sync_project__avoids_dupe_projects.snap
+++ b/crates/action-runner/tests/snapshots/dep_graph_test__sync_project__avoids_dupe_projects.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/action-runner/tests/dep_graph_test.rs
-assertion_line: 493
+assertion_line: 504
 expression: graph.to_dot()
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="SyncNodeProject(advanced)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 -> 0 [ arrowhead=box, arrowtail=box]
 }

--- a/crates/action-runner/tests/snapshots/dep_graph_test__sync_project__isolated_projects.snap
+++ b/crates/action-runner/tests/snapshots/dep_graph_test__sync_project__isolated_projects.snap
@@ -1,18 +1,19 @@
 ---
 source: crates/action-runner/tests/dep_graph_test.rs
-assertion_line: 401
+assertion_line: 412
 expression: graph.to_dot()
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="SyncNodeProject(advanced)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(basic)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
-    3 [ label="SyncSystemProject(noConfig)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
-    4 [ label="SyncSystemProject(emptyConfig)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    3 [ label="SetupSystemToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    4 [ label="SyncSystemProject(noConfig)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    5 [ label="SyncSystemProject(emptyConfig)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 -> 0 [ arrowhead=box, arrowtail=box]
     2 -> 0 [ arrowhead=box, arrowtail=box]
-    3 -> 0 [ arrowhead=box, arrowtail=box]
-    2 -> 3 [ arrowhead=box, arrowtail=box]
-    4 -> 0 [ arrowhead=box, arrowtail=box]
+    4 -> 3 [ arrowhead=box, arrowtail=box]
+    2 -> 4 [ arrowhead=box, arrowtail=box]
+    5 -> 3 [ arrowhead=box, arrowtail=box]
 }
 

--- a/crates/action-runner/tests/snapshots/dep_graph_test__sync_project__projects_with_tasks.snap
+++ b/crates/action-runner/tests/snapshots/dep_graph_test__sync_project__projects_with_tasks.snap
@@ -1,13 +1,14 @@
 ---
 source: crates/action-runner/tests/dep_graph_test.rs
-assertion_line: 465
+assertion_line: 476
 expression: graph.to_dot()
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupSystemToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="SyncSystemProject(noConfig)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
-    2 [ label="SyncNodeProject(tasks)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    2 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    3 [ label="SyncNodeProject(tasks)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 -> 0 [ arrowhead=box, arrowtail=box]
-    2 -> 0 [ arrowhead=box, arrowtail=box]
+    3 -> 2 [ arrowhead=box, arrowtail=box]
 }
 

--- a/crates/cli/src/commands/bin.rs
+++ b/crates/cli/src/commands/bin.rs
@@ -38,13 +38,13 @@ pub async fn bin(tool_type: &BinTools) -> Result<(), Box<dyn std::error::Error>>
 
     match tool_type {
         BinTools::Node => {
-            let node = toolchain.get_node();
+            let node = toolchain.get_node()?;
 
             is_installed(node, toolchain).await;
             log_bin_path(node);
         }
         BinTools::Npm | BinTools::Pnpm | BinTools::Yarn => {
-            let node = toolchain.get_node();
+            let node = toolchain.get_node()?;
 
             match tool_type {
                 BinTools::Pnpm => match node.get_pnpm() {

--- a/crates/cli/src/commands/node/run_script.rs
+++ b/crates/cli/src/commands/node/run_script.rs
@@ -11,7 +11,7 @@ pub async fn run_script(
     let mut command = Command::new(
         workspace
             .toolchain
-            .get_node()
+            .get_node()?
             .get_package_manager()
             .get_bin_path(),
     );

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -1,9 +1,18 @@
 use crate::helpers::{create_progress_bar, load_workspace};
+use moon_action_runner::{ActionRunner, DepGraph};
+use moon_lang::SupportedLanguage;
 
 pub async fn setup() -> Result<(), Box<dyn std::error::Error>> {
     let done = create_progress_bar("Downloading and installing tools...");
 
-    load_workspace().await?.toolchain.setup(true).await?;
+    let workspace = load_workspace().await?;
+    let mut dep_graph = DepGraph::default();
+
+    if workspace.config.node.is_some() {
+        dep_graph.setup_tool(SupportedLanguage::Node);
+    }
+
+    ActionRunner::new(workspace).run(dep_graph, None).await?;
 
     done("Setup complete", true);
 

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -1,6 +1,6 @@
 use crate::helpers::{create_progress_bar, load_workspace};
 use moon_action_runner::{ActionRunner, DepGraph};
-use moon_lang::SupportedLanguage;
+use moon_contract::SupportedPlatform;
 
 pub async fn setup() -> Result<(), Box<dyn std::error::Error>> {
     let done = create_progress_bar("Downloading and installing tools...");
@@ -9,7 +9,7 @@ pub async fn setup() -> Result<(), Box<dyn std::error::Error>> {
     let mut dep_graph = DepGraph::default();
 
     if workspace.config.node.is_some() {
-        dep_graph.setup_tool(SupportedLanguage::Node);
+        dep_graph.setup_tool(SupportedPlatform::Node);
     }
 
     ActionRunner::new(workspace).run(dep_graph, None).await?;

--- a/crates/cli/src/helpers.rs
+++ b/crates/cli/src/helpers.rs
@@ -17,9 +17,11 @@ pub async fn load_workspace() -> Result<Workspace, WorkspaceError> {
         .projects
         .register_platform(Box::new(SystemPlatform::default()))?;
 
-    workspace
-        .projects
-        .register_platform(Box::new(NodePlatform::default()))?;
+    if workspace.config.node.is_some() {
+        workspace
+            .projects
+            .register_platform(Box::new(NodePlatform::default()))?;
+    }
 
     Ok(workspace)
 }

--- a/crates/cli/tests/dep_graph_test.rs
+++ b/crates/cli/tests/dep_graph_test.rs
@@ -11,7 +11,7 @@ fn all_by_default() {
     let dot = get_assert_output(&assert);
 
     // Snapshot is not deterministic
-    assert_eq!(dot.split('\n').count(), 310);
+    assert_eq!(dot.split('\n').count(), 311);
 }
 
 #[test]

--- a/crates/cli/tests/snapshots/dep_graph_test__aliases__can_focus_using_an_alias.snap
+++ b/crates/cli/tests/snapshots/dep_graph_test__aliases__can_focus_using_an_alias.snap
@@ -4,7 +4,7 @@ assertion_line: 65
 expression: get_assert_output(&assert)
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="InstallNodeDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(nodeNameScoped)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     3 [ label="RunTarget(nodeNameScoped:test)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]

--- a/crates/cli/tests/snapshots/dep_graph_test__aliases__resolves_aliases_in_task_deps.snap
+++ b/crates/cli/tests/snapshots/dep_graph_test__aliases__resolves_aliases_in_task_deps.snap
@@ -4,7 +4,7 @@ assertion_line: 77
 expression: get_assert_output(&assert)
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="InstallNodeDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(node)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     3 [ label="SyncNodeProject(nodeNameOnly)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]

--- a/crates/cli/tests/snapshots/dep_graph_test__focused_by_target.snap
+++ b/crates/cli/tests/snapshots/dep_graph_test__focused_by_target.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/cli/tests/dep_graph_test.rs
-assertion_line: 20
+assertion_line: 26
 expression: get_assert_output(&assert)
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="InstallNodeDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(node)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     3 [ label="RunTarget(node:standard)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]

--- a/crates/cli/tests/snapshots/dep_graph_test__includes_dependencies_when_focused.snap
+++ b/crates/cli/tests/snapshots/dep_graph_test__includes_dependencies_when_focused.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/cli/tests/dep_graph_test.rs
-assertion_line: 30
+assertion_line: 38
 expression: get_assert_output(&assert)
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="InstallNodeDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(dependsOn)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     3 [ label="SyncNodeProject(depsC)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]

--- a/crates/cli/tests/snapshots/dep_graph_test__includes_dependents_when_focused.snap
+++ b/crates/cli/tests/snapshots/dep_graph_test__includes_dependents_when_focused.snap
@@ -4,7 +4,7 @@ assertion_line: 50
 expression: get_assert_output(&assert)
 ---
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     1 [ label="InstallNodeDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(depsC)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     3 [ label="RunTarget(depsC:standard)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]

--- a/crates/cli/tests/snapshots/sync_test__syncs_all_projects.snap
+++ b/crates/cli/tests/snapshots/sync_test__syncs_all_projects.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/cli/tests/sync_test.rs
-assertion_line: 12
+assertion_line: 10
 expression: get_assert_output(&assert)
 ---
 
-pass SetupToolchain (skipped)
+pass SetupSystemToolchain (100ms)
 pass SyncSystemProject(c) (100ms)
 pass SyncSystemProject(b) (100ms)
 pass SyncSystemProject(a) (100ms)

--- a/crates/config/src/workspace/config.rs
+++ b/crates/config/src/workspace/config.rs
@@ -69,7 +69,7 @@ pub struct WorkspaceConfig {
     pub extends: Option<String>,
 
     #[validate]
-    pub node: NodeConfig,
+    pub node: Option<NodeConfig>,
 
     #[validate(custom = "validate_projects")]
     pub projects: WorkspaceProjects,
@@ -102,24 +102,26 @@ impl WorkspaceConfig {
         let mut config = WorkspaceConfig::load_config(figment.select(&profile_name))?;
         config.extends = None;
 
-        // Versions from env vars should take precedence
-        if let Ok(node_version) = env::var("MOON_NODE_VERSION") {
-            config.node.version = node_version;
-        }
-
-        if let Ok(npm_version) = env::var("MOON_NPM_VERSION") {
-            config.node.npm.version = npm_version;
-        }
-
-        if let Ok(pnpm_version) = env::var("MOON_PNPM_VERSION") {
-            if let Some(pnpm_config) = &mut config.node.pnpm {
-                pnpm_config.version = pnpm_version;
+        if let Some(node_config) = &mut config.node {
+            // Versions from env vars should take precedence
+            if let Ok(node_version) = env::var("MOON_NODE_VERSION") {
+                node_config.version = node_version;
             }
-        }
 
-        if let Ok(yarn_version) = env::var("MOON_YARN_VERSION") {
-            if let Some(yarn_config) = &mut config.node.yarn {
-                yarn_config.version = yarn_version;
+            if let Ok(npm_version) = env::var("MOON_NPM_VERSION") {
+                node_config.npm.version = npm_version;
+            }
+
+            if let Ok(pnpm_version) = env::var("MOON_PNPM_VERSION") {
+                if let Some(pnpm_config) = &mut node_config.pnpm {
+                    pnpm_config.version = pnpm_version;
+                }
+            }
+
+            if let Ok(yarn_version) = env::var("MOON_YARN_VERSION") {
+                if let Some(yarn_config) = &mut node_config.yarn {
+                    yarn_config.version = yarn_version;
+                }
             }
         }
 

--- a/crates/config/src/workspace/node.rs
+++ b/crates/config/src/workspace/node.rs
@@ -150,7 +150,8 @@ impl Default for YarnConfig {
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize, Validate)]
 #[schemars(default)]
-#[serde(rename_all = "camelCase")]
+// `default` is required since the parent field is `Option`
+#[serde(default, rename_all = "camelCase")]
 pub struct NodeConfig {
     pub add_engines_constraint: bool,
 

--- a/crates/config/tests/workspace_test.rs
+++ b/crates/config/tests/workspace_test.rs
@@ -29,7 +29,7 @@ fn loads_defaults() {
             WorkspaceConfig {
                 action_runner: ActionRunnerConfig::default(),
                 extends: None,
-                node: NodeConfig::default(),
+                node: None,
                 projects: WorkspaceProjects::default(),
                 typescript: None,
                 vcs: VcsConfig::default(),
@@ -60,7 +60,7 @@ mod extends {
                     log_running_command: false,
                     ..ActionRunnerConfig::default()
                 },
-                node: NodeConfig {
+                node: Some(NodeConfig {
                     version: "4.5.6".into(),
                     add_engines_constraint: true,
                     dedupe_on_lockfile_change: false,
@@ -69,7 +69,7 @@ mod extends {
                         version: "3.0.0".into()
                     }),
                     ..NodeConfig::default()
-                },
+                }),
                 vcs: VcsConfig {
                     manager: VcsManager::Svn,
                     ..VcsConfig::default()
@@ -201,13 +201,16 @@ node:
             let config: WorkspaceConfig = super::load_jailed_config(jail.directory())?;
 
             // Inherits from extended file
-            assert!(!config.node.add_engines_constraint);
+            assert!(!config.node.as_ref().unwrap().add_engines_constraint);
             assert!(!config.typescript.unwrap().sync_project_references);
             assert_eq!(config.vcs.manager, VcsManager::Svn);
 
             // Ensure we can override the extended config
-            assert_eq!(config.node.version, "18.0.0".to_owned());
-            assert_eq!(config.node.npm.version, "8.0.0".to_owned());
+            assert_eq!(config.node.as_ref().unwrap().version, "18.0.0".to_owned());
+            assert_eq!(
+                config.node.as_ref().unwrap().npm.version,
+                "8.0.0".to_owned()
+            );
 
             Ok(())
         });
@@ -231,13 +234,16 @@ node:
             let config: WorkspaceConfig = super::load_jailed_config(jail.directory())?;
 
             // Inherits from extended file
-            assert!(!config.node.add_engines_constraint);
+            assert!(!config.node.as_ref().unwrap().add_engines_constraint);
             assert!(!config.typescript.unwrap().sync_project_references);
             assert_eq!(config.vcs.manager, VcsManager::Svn);
 
             // Ensure we can override the extended config
-            assert_eq!(config.node.version, "18.0.0".to_owned());
-            assert_eq!(config.node.npm.version, "8.0.0".to_owned());
+            assert_eq!(config.node.as_ref().unwrap().version, "18.0.0".to_owned());
+            assert_eq!(
+                config.node.as_ref().unwrap().npm.version,
+                "8.0.0".to_owned()
+            );
 
             Ok(())
         });
@@ -281,10 +287,10 @@ node:
                 WorkspaceConfig {
                     action_runner: ActionRunnerConfig::default(),
                     extends: None,
-                    node: NodeConfig {
+                    node: Some(NodeConfig {
                         package_manager: NodePackageManager::Yarn,
                         ..NodeConfig::default()
-                    },
+                    }),
                     projects: WorkspaceProjects::default(),
                     typescript: None,
                     vcs: VcsConfig::default(),
@@ -430,7 +436,7 @@ projects: {}
 
             let config = super::load_jailed_config(jail.directory())?;
 
-            assert_eq!(config.node.version, String::from("4.5.6"));
+            assert_eq!(config.node.unwrap().version, String::from("4.5.6"));
 
             Ok(())
         });
@@ -500,7 +506,7 @@ projects: {}
 
             let config = super::load_jailed_config(jail.directory())?;
 
-            assert_eq!(config.node.npm.version, String::from("4.5.6"));
+            assert_eq!(config.node.unwrap().npm.version, String::from("4.5.6"));
 
             Ok(())
         });
@@ -571,7 +577,10 @@ projects: {}
 
             let config = super::load_jailed_config(jail.directory())?;
 
-            assert_eq!(config.node.pnpm.unwrap().version, String::from("4.5.6"));
+            assert_eq!(
+                config.node.unwrap().pnpm.unwrap().version,
+                String::from("4.5.6")
+            );
 
             Ok(())
         });
@@ -642,7 +651,10 @@ projects: {}
 
             let config = super::load_jailed_config(jail.directory())?;
 
-            assert_eq!(config.node.yarn.unwrap().version, String::from("4.5.6"));
+            assert_eq!(
+                config.node.unwrap().yarn.unwrap().version,
+                String::from("4.5.6")
+            );
 
             Ok(())
         });
@@ -774,7 +786,7 @@ vcs:
                 WorkspaceConfig {
                     action_runner: ActionRunnerConfig::default(),
                     extends: None,
-                    node: NodeConfig::default(),
+                    node: None, // NodeConfig::default(),
                     projects: WorkspaceProjects::default(),
                     typescript: None,
                     vcs: VcsConfig {

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -5,6 +5,7 @@ use moon_config::{
 };
 use moon_error::MoonError;
 use std::collections::BTreeMap;
+use std::fmt;
 use std::path::Path;
 
 pub trait Platform: Send + Sync {
@@ -38,4 +39,28 @@ pub type RegisteredPlatforms = Vec<Box<dyn Platform>>;
 
 pub trait Platformable {
     fn register_platform(&mut self, platform: Box<dyn Platform>) -> Result<(), MoonError>;
+}
+
+#[derive(Clone, Eq, PartialEq)]
+pub enum SupportedPlatform {
+    Node,
+    System,
+}
+
+impl SupportedPlatform {
+    pub fn label(&self) -> String {
+        match self {
+            SupportedPlatform::Node => "Node.js".into(),
+            SupportedPlatform::System => "system".into(),
+        }
+    }
+}
+
+impl fmt::Display for SupportedPlatform {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SupportedPlatform::Node => write!(f, "Node"),
+            SupportedPlatform::System => write!(f, "System"),
+        }
+    }
 }

--- a/crates/lang/src/lib.rs
+++ b/crates/lang/src/lib.rs
@@ -2,7 +2,6 @@ mod config;
 mod errors;
 
 pub use errors::LangError;
-use std::fmt;
 use std::fs;
 use std::path::Path;
 
@@ -85,28 +84,4 @@ pub fn is_using_version_manager<T: AsRef<Path>>(base_dir: T, vm: &VersionManager
     }
 
     false
-}
-
-#[derive(Clone, Eq, PartialEq)]
-pub enum SupportedLanguage {
-    Node,
-    System,
-}
-
-impl SupportedLanguage {
-    pub fn label(&self) -> String {
-        match self {
-            SupportedLanguage::Node => "Node.js".into(),
-            SupportedLanguage::System => "system".into(),
-        }
-    }
-}
-
-impl fmt::Display for SupportedLanguage {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            SupportedLanguage::Node => write!(f, "Node"),
-            SupportedLanguage::System => write!(f, "System"),
-        }
-    }
 }

--- a/crates/platform-node/src/actions/install_deps.rs
+++ b/crates/platform-node/src/actions/install_deps.rs
@@ -1,10 +1,11 @@
 use moon_action::{Action, ActionContext, ActionStatus};
-use moon_config::{NodeConfig, NodePackageManager};
+use moon_config::NodePackageManager;
 use moon_error::map_io_to_fs_error;
 use moon_lang::has_vendor_installed_dependencies;
 use moon_lang_node::{package::PackageJson, NODE, NPM};
 use moon_logger::{color, debug, warn};
 use moon_terminal::{label_checkpoint, Checkpoint};
+use moon_toolchain::tools::node::NodeTool;
 use moon_utils::{fs, is_ci, is_offline};
 use moon_workspace::{Workspace, WorkspaceError};
 use std::sync::Arc;
@@ -13,16 +14,12 @@ use tokio::sync::RwLock;
 const LOG_TARGET: &str = "moon:platform-node:install-deps";
 
 /// Add `packageManager` to root `package.json`.
-fn add_package_manager(
-    workspace: &Workspace,
-    node_config: &NodeConfig,
-    package_json: &mut PackageJson,
-) -> bool {
-    let manager_version = match node_config.package_manager {
-        NodePackageManager::Npm => format!("npm@{}", node_config.npm.version),
+fn add_package_manager(node: &NodeTool, package_json: &mut PackageJson) -> bool {
+    let manager_version = match node.config.package_manager {
+        NodePackageManager::Npm => format!("npm@{}", node.config.npm.version),
         NodePackageManager::Pnpm => format!(
             "pnpm@{}",
-            match &node_config.pnpm {
+            match &node.config.pnpm {
                 Some(pnpm) => pnpm.version.clone(),
                 None => {
                     return false;
@@ -31,7 +28,7 @@ fn add_package_manager(
         ),
         NodePackageManager::Yarn => format!(
             "yarn@{}",
-            match &node_config.yarn {
+            match &node.config.yarn {
                 Some(yarn) => yarn.version.clone(),
                 None => {
                     return false;
@@ -41,7 +38,7 @@ fn add_package_manager(
     };
 
     if manager_version != "npm@inherit"
-        && workspace.toolchain.get_node().is_corepack_aware()
+        && node.is_corepack_aware()
         && package_json.set_package_manager(&manager_version)
     {
         debug!(
@@ -57,8 +54,8 @@ fn add_package_manager(
 }
 
 /// Add `engines` constraint to root `package.json`.
-fn add_engines_constraint(node_config: &NodeConfig, package_json: &mut PackageJson) -> bool {
-    if node_config.add_engines_constraint && package_json.add_engine("node", &node_config.version) {
+fn add_engines_constraint(node: &NodeTool, package_json: &mut PackageJson) -> bool {
+    if node.config.add_engines_constraint && package_json.add_engine("node", &node.config.version) {
         debug!(
             target: LOG_TARGET,
             "Adding engines version constraint to root {}",
@@ -71,34 +68,29 @@ fn add_engines_constraint(node_config: &NodeConfig, package_json: &mut PackageJs
     false
 }
 
-#[track_caller]
 pub async fn install_deps(
     _action: &mut Action,
     context: &ActionContext,
     workspace: Arc<RwLock<Workspace>>,
 ) -> Result<ActionStatus, WorkspaceError> {
     let workspace = workspace.read().await;
-    let node_config = workspace
-        .config
-        .node
-        .as_ref()
-        .expect("node must be configured");
+    let node = workspace.toolchain.get_node()?;
     let mut cache = workspace.cache.cache_workspace_state().await?;
 
     // Sync values to root `package.json`
     PackageJson::sync(&workspace.root, |package_json| {
-        add_package_manager(&workspace, node_config, package_json);
-        add_engines_constraint(node_config, package_json);
+        add_package_manager(node, package_json);
+        add_engines_constraint(node, package_json);
 
         Ok(())
     })?;
 
     // Create nvm/nodenv version file
-    if let Some(version_manager) = &node_config.sync_version_manager_config {
+    if let Some(version_manager) = &node.config.sync_version_manager_config {
         let rc_name = version_manager.get_config_filename();
         let rc_path = workspace.root.join(&rc_name);
 
-        fs::write(&rc_path, &node_config.version).await?;
+        fs::write(&rc_path, &node.config.version).await?;
 
         debug!(
             target: LOG_TARGET,
@@ -108,7 +100,7 @@ pub async fn install_deps(
     }
 
     // Get the last modified time of the root lockfile
-    let manager = workspace.toolchain.get_node().get_package_manager();
+    let manager = node.get_package_manager();
     let lockfile_name = manager.get_lock_filename();
     let lockfile = workspace.root.join(&lockfile_name);
     let mut last_modified = 0;
@@ -157,7 +149,7 @@ pub async fn install_deps(
             return Ok(ActionStatus::Skipped);
         }
 
-        let install_command = match node_config.package_manager {
+        let install_command = match node.config.package_manager {
             NodePackageManager::Npm => "npm install",
             NodePackageManager::Pnpm => "pnpm install",
             NodePackageManager::Yarn => "yarn install",
@@ -167,7 +159,7 @@ pub async fn install_deps(
 
         manager.install_dependencies(&workspace.toolchain).await?;
 
-        if !is_ci() && node_config.dedupe_on_lockfile_change {
+        if !is_ci() && node.config.dedupe_on_lockfile_change {
             debug!(target: LOG_TARGET, "Dedupeing dependencies");
 
             manager.dedupe_dependencies(&workspace.toolchain).await?;

--- a/crates/platform-node/src/actions/mod.rs
+++ b/crates/platform-node/src/actions/mod.rs
@@ -1,7 +1,9 @@
 mod install_deps;
 mod run_target;
+mod setup_toolchain;
 mod sync_project;
 
 pub use install_deps::install_deps;
 pub use run_target::*;
+pub use setup_toolchain::setup_toolchain;
 pub use sync_project::sync_project;

--- a/crates/platform-node/src/actions/run_target.rs
+++ b/crates/platform-node/src/actions/run_target.rs
@@ -156,11 +156,17 @@ pub async fn create_target_command(
     Ok(command)
 }
 
+#[track_caller]
 pub fn create_target_hasher(
     workspace: &Workspace,
     project: &Project,
 ) -> Result<NodeTargetHasher, WorkspaceError> {
-    let mut hasher = NodeTargetHasher::new(workspace.config.node.version.clone());
+    let node_config = workspace
+        .config
+        .node
+        .as_ref()
+        .expect("node must be configured");
+    let mut hasher = NodeTargetHasher::new(node_config.version.clone());
 
     if let Some(root_package) = PackageJson::read(&workspace.root)? {
         hasher.hash_package_json(&root_package);

--- a/crates/platform-node/src/actions/run_target.rs
+++ b/crates/platform-node/src/actions/run_target.rs
@@ -88,8 +88,7 @@ pub async fn create_target_command(
     project: &Project,
     task: &Task,
 ) -> Result<Command, WorkspaceError> {
-    let toolchain = &workspace.toolchain;
-    let node = toolchain.get_node();
+    let node = workspace.toolchain.get_node()?;
     let mut cmd = node.get_bin_path().clone();
     let mut args = vec![];
 
@@ -156,17 +155,12 @@ pub async fn create_target_command(
     Ok(command)
 }
 
-#[track_caller]
 pub fn create_target_hasher(
     workspace: &Workspace,
     project: &Project,
 ) -> Result<NodeTargetHasher, WorkspaceError> {
-    let node_config = workspace
-        .config
-        .node
-        .as_ref()
-        .expect("node must be configured");
-    let mut hasher = NodeTargetHasher::new(node_config.version.clone());
+    let node = workspace.toolchain.get_node()?;
+    let mut hasher = NodeTargetHasher::new(node.config.version.clone());
 
     if let Some(root_package) = PackageJson::read(&workspace.root)? {
         hasher.hash_package_json(&root_package);

--- a/crates/platform-node/src/actions/setup_toolchain.rs
+++ b/crates/platform-node/src/actions/setup_toolchain.rs
@@ -5,7 +5,7 @@ use moon_workspace::{Workspace, WorkspaceError};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-const LOG_TARGET: &str = "moon:platform-node:install-deps";
+const LOG_TARGET: &str = "moon:platform-node:setup-toolchain";
 const SECOND: u128 = 1000;
 const MINUTE: u128 = SECOND * 60;
 const HOUR: u128 = MINUTE * 60;

--- a/crates/platform-node/src/actions/setup_toolchain.rs
+++ b/crates/platform-node/src/actions/setup_toolchain.rs
@@ -1,10 +1,11 @@
-use crate::ActionRunnerError;
 use moon_action::{Action, ActionContext, ActionStatus};
 use moon_logger::debug;
-use moon_workspace::Workspace;
+use moon_toolchain::Tool;
+use moon_workspace::{Workspace, WorkspaceError};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+const LOG_TARGET: &str = "moon:platform-node:install-deps";
 const SECOND: u128 = 1000;
 const MINUTE: u128 = SECOND * 60;
 const HOUR: u128 = MINUTE * 60;
@@ -13,24 +14,27 @@ pub async fn setup_toolchain(
     _action: &mut Action,
     _context: &ActionContext,
     workspace: Arc<RwLock<Workspace>>,
-) -> Result<ActionStatus, ActionRunnerError> {
-    debug!(
-        target: "moon:action:setup-toolchain",
-        "Setting up toolchain",
-    );
+) -> Result<ActionStatus, WorkspaceError> {
+    debug!(target: LOG_TARGET, "Setting up Node.js toolchain",);
 
     let mut workspace = workspace.write().await;
     let mut cache = workspace.cache.cache_workspace_state().await?;
 
-    // Only check the versions of some tools every 12 hours,
-    // as checking every run has considerable overhead spawning all
-    // the child processes. Revisit the threshold if need be.
+    // Check that the tool has been configured
+    workspace.toolchain.get_node()?;
+
+    // Only check the versions every 12 hours, as checking every
+    // run has considerable overhead spawning all the child processes.
+    // Revisit the threshold if need be.
     let now = cache.now_millis();
     let check_versions = cache.item.last_version_check_time == 0
         || (cache.item.last_version_check_time + HOUR * 12) <= now;
 
-    // Install all tools
-    let installed_tools = workspace.toolchain.setup(check_versions).await?;
+    // Install Node.js tooling
+    let mut node = workspace.toolchain.node.take().unwrap();
+    let installed = node.run_setup(&workspace.toolchain, check_versions).await?;
+
+    workspace.toolchain.node = Some(node);
 
     // Update the cache with the timestamp
     if check_versions {
@@ -38,7 +42,7 @@ pub async fn setup_toolchain(
         cache.save().await?;
     }
 
-    Ok(if installed_tools > 0 {
+    Ok(if installed > 0 {
         ActionStatus::Passed
     } else {
         ActionStatus::Skipped

--- a/crates/platform-node/src/actions/sync_project.rs
+++ b/crates/platform-node/src/actions/sync_project.rs
@@ -70,7 +70,6 @@ fn sync_root_tsconfig(
     false
 }
 
-#[track_caller]
 pub async fn sync_project(
     _action: &mut Action,
     _context: &ActionContext,
@@ -79,11 +78,7 @@ pub async fn sync_project(
 ) -> Result<ActionStatus, WorkspaceError> {
     let mut mutated_files = false;
     let workspace = workspace.read().await;
-    let node_config = workspace
-        .config
-        .node
-        .as_ref()
-        .expect("node must be configured");
+    let node = workspace.toolchain.get_node()?;
     let project = workspace.projects.load(project_id)?;
     let is_project_typescript_enabled = project.config.workspace.typescript;
 
@@ -103,8 +98,8 @@ pub async fn sync_project(
         // Update dependencies within this project's `package.json`.
         // Only add if the dependent project has a `package.json`,
         // and this `package.json` has not already declared the dep.
-        if node_config.sync_project_workspace_dependencies {
-            let format = &node_config.dependency_version_format;
+        if node.config.sync_project_workspace_dependencies {
+            let format = &node.config.dependency_version_format;
 
             if let Some(dep_package_json) = PackageJson::read(&dep_project.root)? {
                 if let Some(dep_package_name) = &dep_package_json.name {

--- a/crates/platform-node/src/actions/sync_project.rs
+++ b/crates/platform-node/src/actions/sync_project.rs
@@ -70,6 +70,7 @@ fn sync_root_tsconfig(
     false
 }
 
+#[track_caller]
 pub async fn sync_project(
     _action: &mut Action,
     _context: &ActionContext,
@@ -78,7 +79,11 @@ pub async fn sync_project(
 ) -> Result<ActionStatus, WorkspaceError> {
     let mut mutated_files = false;
     let workspace = workspace.read().await;
-    let node_config = &workspace.config.node;
+    let node_config = workspace
+        .config
+        .node
+        .as_ref()
+        .expect("node must be configured");
     let project = workspace.projects.load(project_id)?;
     let is_project_typescript_enabled = project.config.workspace.typescript;
 

--- a/crates/platform-node/src/lib.rs
+++ b/crates/platform-node/src/lib.rs
@@ -53,7 +53,7 @@ impl Platform for NodePlatform {
         projects_map: &ProjectsSourcesMap,
         aliases_map: &mut ProjectsAliasesMap,
     ) -> Result<(), MoonError> {
-        let alias_format = match &workspace_config.node.alias_package_names {
+        let alias_format = match &workspace_config.node.as_ref().unwrap().alias_package_names {
             Some(f) => f,
             None => {
                 return Ok(());
@@ -119,7 +119,11 @@ impl Platform for NodePlatform {
         let mut tasks = BTreeMap::new();
 
         if !project_config.language.is_node_platform()
-            || !workspace_config.node.infer_tasks_from_scripts
+            || !workspace_config
+                .node
+                .as_ref()
+                .unwrap()
+                .infer_tasks_from_scripts
         {
             return Ok(tasks);
         }

--- a/crates/platform-node/tests/project_aliases_test.rs
+++ b/crates/platform-node/tests/project_aliases_test.rs
@@ -17,7 +17,7 @@ async fn get_aliases_graph(node_config: NodeConfig) -> ProjectGraph {
             ("nodeNameOnly".to_owned(), "node-name-only".to_owned()),
             ("nodeNameScope".to_owned(), "node-name-scope".to_owned()),
         ])),
-        node: node_config,
+        node: Some(node_config),
         ..WorkspaceConfig::default()
     };
 

--- a/crates/toolchain/src/errors.rs
+++ b/crates/toolchain/src/errors.rs
@@ -14,6 +14,9 @@ pub enum ToolchainError {
     #[error("Unable to find a node module binary for <symbol>{0}</symbol>. Have you installed the corresponding package?")]
     MissingNodeModuleBin(String), // bin name
 
+    #[error("Node.js has not been configured or installed, unable to proceed.")]
+    RequiresNode,
+
     #[error(transparent)]
     Archive(#[from] ArchiveError),
 

--- a/crates/toolchain/src/pms/npm.rs
+++ b/crates/toolchain/src/pms/npm.rs
@@ -231,7 +231,7 @@ impl PackageManager<NodeTool> for NpmTool {
 
         exec_args.extend(args);
 
-        let install_dir = toolchain.get_node().get_install_dir()?;
+        let install_dir = toolchain.get_node()?.get_install_dir()?;
         let npx_path = node::find_package_manager_bin(install_dir, "npx");
 
         Command::new(&npx_path)

--- a/crates/toolchain/src/pms/yarn.rs
+++ b/crates/toolchain/src/pms/yarn.rs
@@ -194,7 +194,7 @@ impl PackageManager<NodeTool> for YarnTool {
             {
                 // Will error if the lockfile does not exist!
                 toolchain
-                    .get_node()
+                    .get_node()?
                     .get_npm()
                     .exec_package(
                         toolchain,

--- a/crates/toolchain/src/toolchain.rs
+++ b/crates/toolchain/src/toolchain.rs
@@ -74,7 +74,9 @@ impl Toolchain {
             node: None,
         };
 
-        toolchain.node = Some(NodeTool::new(&toolchain, &workspace_config.node)?);
+        if let Some(node_config) = &workspace_config.node {
+            toolchain.node = Some(NodeTool::new(&toolchain, node_config)?);
+        }
 
         Ok(toolchain)
     }

--- a/crates/toolchain/src/toolchain.rs
+++ b/crates/toolchain/src/toolchain.rs
@@ -125,7 +125,11 @@ impl Toolchain {
     }
 
     /// Return the Node.js tool.
-    pub fn get_node(&self) -> &NodeTool {
-        self.node.as_ref().unwrap()
+    pub fn get_node(&self) -> Result<&NodeTool, ToolchainError> {
+        if self.node.is_none() {
+            return Err(ToolchainError::RequiresNode);
+        }
+
+        Ok(self.node.as_ref().unwrap())
     }
 }

--- a/crates/toolchain/src/toolchain.rs
+++ b/crates/toolchain/src/toolchain.rs
@@ -31,6 +31,9 @@ pub struct Toolchain {
     /// This is typically ~/.moon.
     pub dir: PathBuf,
 
+    /// Node.js!
+    pub node: Option<NodeTool>,
+
     /// The directory where temporary files are stored.
     /// This is typically ~/.moon/temp.
     pub temp_dir: PathBuf,
@@ -41,9 +44,6 @@ pub struct Toolchain {
 
     /// The workspace root directory.
     pub workspace_root: PathBuf,
-
-    // Tool instances are private, as we want to lazy load them.
-    node: Option<NodeTool>,
 }
 
 impl Toolchain {
@@ -95,19 +95,19 @@ impl Toolchain {
 
     /// Download and install all tools into the toolchain.
     /// Return a count of how many tools were installed.
-    pub async fn setup(&mut self, check_versions: bool) -> Result<u8, ToolchainError> {
-        debug!(target: LOG_TARGET, "Downloading and installing tools",);
+    // pub async fn setup(&mut self, check_versions: bool) -> Result<u8, ToolchainError> {
+    //     debug!(target: LOG_TARGET, "Downloading and installing tools",);
 
-        let mut installed = 0;
+    //     let mut installed = 0;
 
-        if self.node.is_some() {
-            let mut node = self.node.take().unwrap();
-            installed += node.run_setup(self, check_versions).await?;
-            self.node = Some(node);
-        }
+    //     if self.node.is_some() {
+    //         let mut node = self.node.take().unwrap();
+    //         installed += node.run_setup(self, check_versions).await?;
+    //         self.node = Some(node);
+    //     }
 
-        Ok(installed)
-    }
+    //     Ok(installed)
+    // }
 
     /// Uninstall all tools from the toolchain, and delete any temporary files.
     pub async fn teardown(&mut self) -> Result<(), ToolchainError> {

--- a/crates/toolchain/tests/node_test.rs
+++ b/crates/toolchain/tests/node_test.rs
@@ -34,7 +34,7 @@ fn create_shasums(hash: &str) -> String {
 #[tokio::test]
 async fn generates_paths() {
     let (toolchain, temp_dir) = create_node_tool().await;
-    let node = toolchain.get_node();
+    let node = toolchain.get_node().unwrap();
 
     assert!(predicates::str::ends_with(
         PathBuf::from(".moon")
@@ -75,7 +75,7 @@ mod download {
     #[tokio::test]
     async fn is_downloaded_checks() {
         let (toolchain, temp_dir) = create_node_tool().await;
-        let node = toolchain.get_node();
+        let node = toolchain.get_node().unwrap();
 
         assert!(!node.is_downloaded().await.unwrap());
 
@@ -94,7 +94,7 @@ mod download {
     #[tokio::test]
     async fn downloads_to_temp_dir() {
         let (toolchain, temp_dir) = create_node_tool().await;
-        let node = toolchain.get_node();
+        let node = toolchain.get_node().unwrap();
 
         assert!(!node.get_download_path().unwrap().exists());
 
@@ -127,7 +127,7 @@ mod download {
     #[should_panic(expected = "InvalidShasum")]
     async fn fails_on_invalid_shasum() {
         let (toolchain, temp_dir) = create_node_tool().await;
-        let node = toolchain.get_node();
+        let node = toolchain.get_node().unwrap();
 
         let archive = mock(
             "GET",

--- a/crates/toolchain/tests/node_test.rs
+++ b/crates/toolchain/tests/node_test.rs
@@ -1,4 +1,4 @@
-use moon_config::WorkspaceConfig;
+use moon_config::{NodeConfig, WorkspaceConfig};
 use moon_lang_node::node;
 use moon_toolchain::{Downloadable, Executable, Installable, Toolchain};
 use predicates::prelude::*;
@@ -8,9 +8,13 @@ use std::path::PathBuf;
 async fn create_node_tool() -> (Toolchain, assert_fs::TempDir) {
     let base_dir = assert_fs::TempDir::new().unwrap();
 
-    let mut config = WorkspaceConfig::default();
-
-    config.node.version = String::from("1.0.0");
+    let config = WorkspaceConfig {
+        node: Some(NodeConfig {
+            version: String::from("1.0.0"),
+            ..NodeConfig::default()
+        }),
+        ..WorkspaceConfig::default()
+    };
 
     let toolchain = Toolchain::create_from_dir(base_dir.path(), &env::temp_dir(), &config)
         .await

--- a/crates/toolchain/tests/npm_test.rs
+++ b/crates/toolchain/tests/npm_test.rs
@@ -29,7 +29,7 @@ async fn create_npm_tool() -> (Toolchain, assert_fs::TempDir) {
 #[tokio::test]
 async fn generates_paths() {
     let (toolchain, temp_dir) = create_npm_tool().await;
-    let npm = toolchain.get_node().get_npm();
+    let npm = toolchain.get_node().unwrap().get_npm();
 
     assert!(predicates::str::ends_with(
         PathBuf::from(".moon")

--- a/crates/toolchain/tests/npm_test.rs
+++ b/crates/toolchain/tests/npm_test.rs
@@ -1,4 +1,4 @@
-use moon_config::WorkspaceConfig;
+use moon_config::{NodeConfig, NpmConfig, WorkspaceConfig};
 use moon_lang_node::node;
 use moon_toolchain::{Executable, Installable, Toolchain};
 use predicates::prelude::*;
@@ -8,10 +8,16 @@ use std::path::PathBuf;
 async fn create_npm_tool() -> (Toolchain, assert_fs::TempDir) {
     let base_dir = assert_fs::TempDir::new().unwrap();
 
-    let mut config = WorkspaceConfig::default();
-
-    config.node.version = String::from("1.0.0");
-    config.node.npm.version = String::from("6.0.0");
+    let config = WorkspaceConfig {
+        node: Some(NodeConfig {
+            version: String::from("1.0.0"),
+            npm: NpmConfig {
+                version: String::from("6.0.0"),
+            },
+            ..NodeConfig::default()
+        }),
+        ..WorkspaceConfig::default()
+    };
 
     let toolchain = Toolchain::create_from_dir(base_dir.path(), &env::temp_dir(), &config)
         .await

--- a/crates/toolchain/tests/pnpm_test.rs
+++ b/crates/toolchain/tests/pnpm_test.rs
@@ -30,7 +30,7 @@ async fn create_pnpm_tool() -> (Toolchain, assert_fs::TempDir) {
 #[tokio::test]
 async fn generates_paths() {
     let (toolchain, temp_dir) = create_pnpm_tool().await;
-    let pnpm = toolchain.get_node().get_pnpm().unwrap();
+    let pnpm = toolchain.get_node().unwrap().get_pnpm().unwrap();
 
     assert!(predicates::str::ends_with(
         PathBuf::from(".moon")

--- a/crates/toolchain/tests/pnpm_test.rs
+++ b/crates/toolchain/tests/pnpm_test.rs
@@ -1,4 +1,4 @@
-use moon_config::{NodePackageManager, PnpmConfig, WorkspaceConfig};
+use moon_config::{NodeConfig, NodePackageManager, PnpmConfig, WorkspaceConfig};
 use moon_lang_node::node;
 use moon_toolchain::{Executable, Installable, Toolchain};
 use predicates::prelude::*;
@@ -8,13 +8,17 @@ use std::path::PathBuf;
 async fn create_pnpm_tool() -> (Toolchain, assert_fs::TempDir) {
     let base_dir = assert_fs::TempDir::new().unwrap();
 
-    let mut config = WorkspaceConfig::default();
-
-    config.node.version = String::from("1.0.0");
-    config.node.package_manager = NodePackageManager::Pnpm;
-    config.node.pnpm = Some(PnpmConfig {
-        version: String::from("6.0.0"),
-    });
+    let config = WorkspaceConfig {
+        node: Some(NodeConfig {
+            version: String::from("1.0.0"),
+            package_manager: NodePackageManager::Pnpm,
+            pnpm: Some(PnpmConfig {
+                version: String::from("6.0.0"),
+            }),
+            ..NodeConfig::default()
+        }),
+        ..WorkspaceConfig::default()
+    };
 
     let toolchain = Toolchain::create_from_dir(base_dir.path(), &env::temp_dir(), &config)
         .await

--- a/crates/toolchain/tests/toolchain_test.rs
+++ b/crates/toolchain/tests/toolchain_test.rs
@@ -1,13 +1,17 @@
-use moon_config::WorkspaceConfig;
+use moon_config::{NodeConfig, WorkspaceConfig};
 use moon_toolchain::Toolchain;
 use predicates::prelude::*;
 use std::env;
 use std::path::{Path, PathBuf};
 
 async fn create_toolchain(base_dir: &Path) -> Toolchain {
-    let mut config = WorkspaceConfig::default();
-
-    config.node.version = String::from("1.0.0");
+    let config = WorkspaceConfig {
+        node: Some(NodeConfig {
+            version: String::from("1.0.0"),
+            ..NodeConfig::default()
+        }),
+        ..WorkspaceConfig::default()
+    };
 
     Toolchain::create_from_dir(base_dir, &env::temp_dir(), &config)
         .await

--- a/crates/toolchain/tests/yarn_test.rs
+++ b/crates/toolchain/tests/yarn_test.rs
@@ -30,7 +30,7 @@ async fn create_yarn_tool() -> (Toolchain, assert_fs::TempDir) {
 #[tokio::test]
 async fn generates_paths() {
     let (toolchain, temp_dir) = create_yarn_tool().await;
-    let yarn = toolchain.get_node().get_yarn().unwrap();
+    let yarn = toolchain.get_node().unwrap().get_yarn().unwrap();
 
     assert!(predicates::str::ends_with(
         PathBuf::from(".moon")

--- a/crates/toolchain/tests/yarn_test.rs
+++ b/crates/toolchain/tests/yarn_test.rs
@@ -1,4 +1,4 @@
-use moon_config::{NodePackageManager, WorkspaceConfig, YarnConfig};
+use moon_config::{NodeConfig, NodePackageManager, WorkspaceConfig, YarnConfig};
 use moon_lang_node::node;
 use moon_toolchain::{Executable, Installable, Toolchain};
 use predicates::prelude::*;
@@ -8,13 +8,17 @@ use std::path::PathBuf;
 async fn create_yarn_tool() -> (Toolchain, assert_fs::TempDir) {
     let base_dir = assert_fs::TempDir::new().unwrap();
 
-    let mut config = WorkspaceConfig::default();
-
-    config.node.version = String::from("1.0.0");
-    config.node.package_manager = NodePackageManager::Yarn;
-    config.node.yarn = Some(YarnConfig {
-        version: String::from("6.0.0"),
-    });
+    let config = WorkspaceConfig {
+        node: Some(NodeConfig {
+            version: String::from("1.0.0"),
+            package_manager: NodePackageManager::Yarn,
+            yarn: Some(YarnConfig {
+                version: String::from("6.0.0"),
+            }),
+            ..NodeConfig::default()
+        }),
+        ..WorkspaceConfig::default()
+    };
 
     let toolchain = Toolchain::create_from_dir(base_dir.path(), &env::temp_dir(), &config)
         .await

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,8 +10,8 @@
 
 #### ⚙️ Internal
 
-- The `SetupToolchain` action has been updated to be language/platform aware, and now supports
-  `SetupNodeToolchain` and `SetupSystemToolchain`.
+- The `SetupToolchain` action has been updated to be language/platform aware, and as such, was split
+  into `SetupNodeToolchain` and `SetupSystemToolchain`.
 
 ## 0.12.0
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+#### 💥 Breaking
+
+- The `node` setting in `.moon/workspace.yml` is now optional, allowing repos to opt-out of Node.js
+  support (in preparation for future languages support). This shouldn't affect you if the setting is
+  already explicitly defined.
+
+#### ⚙️ Internal
+
+- The `SetupToolchain` action has been updated to be language/platform aware, and now supports
+  `SetupNodeToolchain` and `SetupSystemToolchain`.
+
 ## 0.12.0
 
 #### 💥 Breaking

--- a/website/docs/commands/dep-graph.mdx
+++ b/website/docs/commands/dep-graph.mdx
@@ -31,7 +31,7 @@ The following output is an example of the graph in DOT format.
 
 ```dot
 digraph {
-    0 [ label="SetupToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
+    0 [ label="SetupNodeToolchain" style=filled, shape=oval, fillcolor=black, fontcolor=white]
     1 [ label="InstallNodeDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     2 [ label="SyncNodeProject(node)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     3 [ label="RunTarget(node:standard)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -46,13 +46,14 @@ everything in sync, and modifying project/language configuration to operate effe
 
 ## Action runner
 
-### What is `SetupToolchain`, `InstallNodeDeps`, `RunTarget`, etc?
+### What is `SetupNodeToolchain`, `InstallNodeDeps`, `RunTarget`, etc?
 
 When we run a [task](./concepts/task), we generate a dependency graph of nodes, known as actions.
 These labels are the actions in the graph, and break down as follows:
 
-- `SetupToolchain` - Sets up the [toolchain](./concepts/toolchain). Required for all other actions,
-  so acts as the root node.
+- `SetupNodeToolchain` - Sets up the Node.js [toolchain](./concepts/toolchain). Required for all
+  other actions, so acts like a root node.
+- `SetupSystemToolchain` - Currently a no operation.
 - `InstallNodeDeps` - Installs Node.js dependencies (`node_modules`) in the workspace root.
 - `InstallSystemDeps` - Currently a no operation.
 - `SyncNodeProject` - When a project's [`language`](./config/project#language) is "javascript" or


### PR DESCRIPTION
In preparation for other platforms/languages, this PR does 2 things:

- Makes `node` optional.
- Updates the `SetupToolchain` action to be platform specific. This has the added benefit of tasks only installing tools it needs.