### PR TITLE
fix: Fix creation time metadata failures in unsupported environments.

### DIFF
--- a/.yarn/versions/0179ff1c.yml
+++ b/.yarn/versions/0179ff1c.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/utils/src/fs.rs
+++ b/crates/utils/src/fs.rs
@@ -245,8 +245,13 @@ pub async fn remove_dir_stale_contents<P: AsRef<Path>>(
             if let Ok(metadata) = entry.metadata().await {
                 bytes = metadata.len();
 
-                // Not stale yet
-                if metadata.created()? > threshold {
+                if let Ok(filetime) = metadata.accessed().or_else(|_| metadata.created()) {
+                    if filetime > threshold {
+                        // Not stale yet
+                        continue;
+                    }
+                } else {
+                    // Not supported in environment
                     continue;
                 }
             }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### 🐞 Fixes
 
 - Fixed `init` templates being populated with the wrong default values.
+- Fixed the "creation time is not available for the filesystem" error when running in Docker.
 
 ## 0.12.0
 


### PR DESCRIPTION
Note to self, test moon in Docker.