### PR TITLE
Fix typo for arm64 in targetToPackage

### DIFF
--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -6,8 +6,8 @@ export const { BINARY = process.platform === 'win32' ? 'moon.exe' : 'moon', TARG
 
 const targetToPackage = {
 	'aarch64-apple-darwin': 'core-macos-arm64',
-	'aarch64-unknown-linux-gnu': 'core-linux-x64-gnu',
-	'aarch64-unknown-linux-musl': 'core-linux-x64-musl',
+	'aarch64-unknown-linux-gnu': 'core-linux-arm64-gnu',
+	'aarch64-unknown-linux-musl': 'core-linux-arm64-musl',
 	'x86_64-apple-darwin': 'core-macos-x64',
 	'x86_64-pc-windows-msvc': 'core-windows-x64-msvc',
 	'x86_64-unknown-linux-gnu': 'core-linux-x64-gnu',


### PR DESCRIPTION
So I just discovered that the published arm64 npm packages don't actually have a `moon` binary file included in the package, and I tracked it down to a typo of mine in `targetToPackage`. 🙈 

Since the `x86_64` targets are listed last, it thankfully didn't actually publish arm packages as x86, but this typo did prevent the arm packages from actually releasing.