### PR TITLE
docs: Build packages before deploying.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 jobs:
   deploy:
     name: Deploy
@@ -13,6 +14,7 @@ jobs:
         with:
           cache: yarn
       - run: yarn install --immutable
+      - run: yarn build
       - run: yarn workspace website run build
       - uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
This are now required because of the API pages.