### PR TITLE
new: Allow template variables to be defined with CLI arguments.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87eba3c8c7f42ef17f6c659fc7416d0f4758cd3e58861ee63c5fa4a4dde649e4"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1421,6 +1421,7 @@ version = "0.13.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "clap_lex",
  "console",
  "dialoguer",
  "indicatif",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,6 +33,7 @@ moon_utils = { path = "../utils" }
 moon_vcs = { path = "../vcs" }
 moon_workspace = { path = "../workspace" }
 clap = { version = "3.2.19", features = ["derive", "env", "wrap_help"] }
+clap_lex = "0.2.4"
 console = "0.15.1"
 dialoguer = "0.10.2"
 indicatif = "0.17.0"

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -229,7 +229,8 @@ pub enum Commands {
     #[clap(
         name = "generate",
         about = "Generate and scaffold files from a pre-defined template.",
-        alias = "g"
+        alias = "g",
+        rename_all = "camelCase"
     )]
     Generate {
         #[clap(help = "Name of template to generate")]
@@ -252,6 +253,10 @@ pub enum Commands {
 
         #[clap(long, help = "Create a new template")]
         template: bool,
+
+        // Variable args (after --)
+        #[clap(last = true, help = "Arguments to define as variable values")]
+        vars: Vec<String>,
     },
 
     // RUNNER

--- a/crates/cli/src/commands/generate.rs
+++ b/crates/cli/src/commands/generate.rs
@@ -34,15 +34,11 @@ fn format_var_name(name: &str) -> String {
 fn parse_var_args(vars: &[String]) -> HashMap<String, String> {
     let mut custom_vars = HashMap::new();
 
-    dbg!(&vars);
-
     let lexer = clap_lex::RawArgs::new(vars);
     let mut cursor = lexer.cursor();
     let mut previous_name: Option<String> = None;
 
     while let Some(arg) = lexer.next(&mut cursor) {
-        dbg!(&arg);
-
         // --name, --name=value
         if let Some((long, maybe_value)) = arg.to_long() {
             match long {
@@ -101,8 +97,6 @@ fn parse_var_args(vars: &[String]) -> HashMap<String, String> {
             );
         }
     }
-
-    dbg!(&custom_vars);
 
     custom_vars
 }
@@ -189,7 +183,9 @@ fn gather_variables(
             TemplateVariable::Number(var) => {
                 let required = var.required.unwrap_or_default();
                 let default: i32 = match custom_vars.get(name) {
-                    Some(val) => val.parse::<i32>().unwrap_or(var.default),
+                    Some(val) => val.parse::<i32>().map_err(|e| {
+                        GeneratorError::FailedToParseArgVar(name.to_owned(), e.to_string())
+                    })?,
                     None => var.default,
                 };
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -94,6 +94,7 @@ pub async fn run_cli() {
             dry_run,
             force,
             template,
+            vars,
         } => {
             generate(
                 name,
@@ -103,6 +104,7 @@ pub async fn run_cli() {
                     dry_run: *dry_run,
                     force: *force,
                     template: *template,
+                    vars: vars.clone(),
                 },
             )
             .await

--- a/crates/cli/tests/generate_test.rs
+++ b/crates/cli/tests/generate_test.rs
@@ -50,7 +50,7 @@ fn doesnt_generate_files_when_dryrun() {
         .arg("generate")
         .arg("standard")
         .arg("./test")
-        .arg("--dry-run")
+        .arg("--dryRun")
         .assert();
 
     assert_snapshot!(get_path_safe_output(&assert));

--- a/crates/cli/tests/generate_test.rs
+++ b/crates/cli/tests/generate_test.rs
@@ -176,3 +176,19 @@ fn interpolates_destination_path() {
     // file-[stringNotEmpty]-[number].txt
     assert!(fixture.path().join("./test/file-default-0.txt").exists());
 }
+
+#[test]
+fn errors_when_parsing_custom_var_types() {
+    let fixture = create_sandbox("generator");
+
+    let assert = create_moon_command(fixture.path())
+        .arg("generate")
+        .arg("vars")
+        .arg("./test")
+        .arg("--defaults")
+        .arg("--")
+        .arg("--number=abc")
+        .assert();
+
+    assert_snapshot!(get_path_safe_output(&assert));
+}

--- a/crates/cli/tests/generate_test.rs
+++ b/crates/cli/tests/generate_test.rs
@@ -129,6 +129,37 @@ fn renders_and_interpolates_templates() {
 }
 
 #[test]
+fn renders_with_custom_vars_via_args() {
+    let fixture = create_sandbox("generator");
+
+    let assert = create_moon_command(fixture.path())
+        .arg("generate")
+        .arg("vars")
+        .arg("./test")
+        .arg("--defaults")
+        .arg("--")
+        .args([
+            "--no-boolTrue",
+            "--boolFalse",
+            "--string=abc",
+            "--stringNotEmpty",
+            "xyz",
+            "--number=123",
+            "--numberNotEmpty",
+            "456",
+            "--enum=c",
+            "--multenumNotEmpty",
+            "a",
+        ])
+        .assert();
+
+    assert.success();
+
+    assert_snapshot!(fs::read_to_string(fixture.path().join("./test/expressions.txt")).unwrap());
+    assert_snapshot!(fs::read_to_string(fixture.path().join("./test/control.txt")).unwrap());
+}
+
+#[test]
 fn interpolates_destination_path() {
     let fixture = create_sandbox("generator");
 

--- a/crates/cli/tests/snapshots/generate_test__errors_when_parsing_custom_var_types.snap
+++ b/crates/cli/tests/snapshots/generate_test__errors_when_parsing_custom_var_types.snap
@@ -1,0 +1,16 @@
+---
+source: crates/cli/tests/generate_test.rs
+assertion_line: 193
+expression: get_path_safe_output(&assert)
+---
+
+Variable testing 
+A template for testing all variable config combinations.
+
+
+ ERROR 
+
+Failed to parse variable argument --number: invalid digit found in string
+
+
+

--- a/crates/cli/tests/snapshots/generate_test__renders_with_custom_vars_via_args-2.snap
+++ b/crates/cli/tests/snapshots/generate_test__renders_with_custom_vars_via_args-2.snap
@@ -1,0 +1,23 @@
+---
+source: crates/cli/tests/generate_test.rs
+assertion_line: 159
+expression: "fs::read_to_string(fixture.path().join(\"./test/control.txt\")).unwrap()"
+---
+
+Should NOT show
+
+
+Looping multenum:
+
+1. a
+
+
+Including partial:
+THIS WAS INCLUDED
+
+
+Filters:
+XYZ
+246
+1
+

--- a/crates/cli/tests/snapshots/generate_test__renders_with_custom_vars_via_args.snap
+++ b/crates/cli/tests/snapshots/generate_test__renders_with_custom_vars_via_args.snap
@@ -1,0 +1,23 @@
+---
+source: crates/cli/tests/generate_test.rs
+assertion_line: 158
+expression: "fs::read_to_string(fixture.path().join(\"./test/expressions.txt\")).unwrap()"
+---
+boolTrue = false
+boolFalse = true
+string = abc
+stringNotEmpty = xyz
+stringReq = 
+stringReqNotEmpty = default
+number = 123
+numberNotEmpty = 456
+numberReq = 0
+numberReqNotEmpty = 123
+enum = c
+enumNotEmpty = b
+enumInvalidDefault = a
+multenum = [a]
+multenumNotEmpty = [a]
+multenumInvalidDefault = [a]
+noPrompt = 456
+

--- a/crates/generator/src/errors.rs
+++ b/crates/generator/src/errors.rs
@@ -9,6 +9,9 @@ pub enum GeneratorError {
     #[error("A template with the name <id>{0}</id> already exists at <path>{1}</path>.")]
     ExistingTemplate(String, PathBuf),
 
+    #[error("Failed to parse variable argument --{0}: {1}")]
+    FailedToParseArgVar(String, String),
+
     #[error(
         "Failed to validate <file>{}</file> schema.\n\n{0}",
         constants::CONFIG_WORKSPACE_FILENAME

--- a/website/docs/commands/generate.mdx
+++ b/website/docs/commands/generate.mdx
@@ -10,6 +10,9 @@ pre-defined template of the same name. Templates are located based on the
 # Generate code from a template to a target directory
 $ moon generate npm-package ./packages/example
 
+# Generate code while declaring custom variable values
+$ moon generate npm-package ./packages/example -- --name "@company/example"
+
 # Create a new template
 $ moon generate react-app --template
 ```
@@ -22,6 +25,7 @@ $ moon generate react-app --template
 - `<name>` - Name of the template to generate.
 - `[dest]` - Destination to write files to, relative from the current working directory. If not
   defined, will be prompted during generation.
+- `[-- <vars>]` - Additional arguments to override default variable values.
 
 ### Options
 

--- a/website/docs/commands/generate.mdx
+++ b/website/docs/commands/generate.mdx
@@ -26,6 +26,6 @@ $ moon generate react-app --template
 ### Options
 
 - `--defaults` - Use the default value of all variables instead of prompting the user.
-- `--dry-run` - Run entire generator process without writing files.
+- `--dryRun` - Run entire generator process without writing files.
 - `--force` - Force overwrite any existing files at the destination.
 - `--template` - Create a new template with the provided name.

--- a/website/src/components/ComparisonTable.tsx
+++ b/website/src/components/ComparisonTable.tsx
@@ -473,7 +473,7 @@ const generatorRows: Comparison[] = [
 	{
 		feature: 'Can define variable values via command line args',
 		support: {
-			// moon: SUPPORTED,
+			moon: SUPPORTED,
 		},
 	},
 	{
@@ -484,7 +484,7 @@ const generatorRows: Comparison[] = [
 		},
 	},
 	{
-		feature: 'Supports render helpers / built-ins',
+		feature: 'Supports render helpers, filters, and built-ins',
 		support: {
 			moon: SUPPORTED,
 			nx: SUPPORTED,


### PR DESCRIPTION
As the title states. Any arguments defined after `--` when running `moon generate` will be considered template variables.