### PR TITLE
QOL: making test-coverage requires git>=2.28 for git's initial-step flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Contributions are always welcome, no matter how large or small!
 
 - Node.js >= v14.15
 - Rust >= 1.61
+- Git >= 2.28 (for `test-coverage`)
 
 ## Setup
 
@@ -116,7 +117,7 @@ Once installed, run `cargo make test-coverage`, which is a lengthy and time cons
 will build the binary in debug mode with instrumentation enabled, run all unit and integration
 tests, and generate _a ton_ of `*.profraw` files in the repository (do not commit these!).
 
-From here you can generate an HTML coverage report to `./coverage` with `cargo make generate-html` (note: requires `git>=2.28`).
+From here you can generate an HTML coverage report to `./coverage` with `cargo make generate-html`. 
 Open the `index.html` file to browse line-by-line coverage.
 
 Once done, run `cargo make clean-profraw` to cleanup and remove all the `*.profraw` files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ Once installed, run `cargo make test-coverage`, which is a lengthy and time cons
 will build the binary in debug mode with instrumentation enabled, run all unit and integration
 tests, and generate _a ton_ of `*.profraw` files in the repository (do not commit these!).
 
-From here you can generate an HTML coverage report to `./coverage` with `cargo make generate-html`.
+From here you can generate an HTML coverage report to `./coverage` with `cargo make generate-html` (note: requires `git>=2.28`).
 Open the `index.html` file to browse line-by-line coverage.
 
 Once done, run `cargo make clean-profraw` to cleanup and remove all the `*.profraw` files.


### PR DESCRIPTION
Cannot run test-coverage without git>=2.28, Ubuntu 20.04 users for example will currently only be pulling git=2.25 from apt.