### PR TITLE
fix: Fix alias scanning logging warnings.

### DIFF
--- a/.yarn/versions/654e700a.yml
+++ b/.yarn/versions/654e700a.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where alias warnings were logged while scanning the dependency graph.
+
 ## 0.14.0
 
 #### 🎉 Release


### PR DESCRIPTION
This change was a side-effect of the implicit dependency scanning where the alias logic was still running even when extracting aliases was disabled.