### PR TITLE
new: Include more data in run reports.

### DIFF
--- a/.yarn/versions/334e6c8f.yml
+++ b/.yarn/versions/334e6c8f.yml
@@ -8,3 +8,7 @@ releases:
   '@moonrepo/core-macos-x64': minor
   '@moonrepo/core-windows-x64-msvc': minor
   '@moonrepo/types': patch
+
+declined:
+  - '@moonrepo/runtime'
+  - 'website'

--- a/.yarn/versions/334e6c8f.yml
+++ b/.yarn/versions/334e6c8f.yml
@@ -1,9 +1,10 @@
 releases:
-  "@moonrepo/cli": minor
-  "@moonrepo/core-linux-arm64-gnu": minor
-  "@moonrepo/core-linux-arm64-musl": minor
-  "@moonrepo/core-linux-x64-gnu": minor
-  "@moonrepo/core-linux-x64-musl": minor
-  "@moonrepo/core-macos-arm64": minor
-  "@moonrepo/core-macos-x64": minor
-  "@moonrepo/core-windows-x64-msvc": minor
+  '@moonrepo/cli': minor
+  '@moonrepo/core-linux-arm64-gnu': minor
+  '@moonrepo/core-linux-arm64-musl': minor
+  '@moonrepo/core-linux-x64-gnu': minor
+  '@moonrepo/core-linux-x64-musl': minor
+  '@moonrepo/core-macos-arm64': minor
+  '@moonrepo/core-macos-x64': minor
+  '@moonrepo/core-windows-x64-msvc': minor
+  '@moonrepo/types': patch

--- a/crates/action-runner/src/runner.rs
+++ b/crates/action-runner/src/runner.rs
@@ -385,6 +385,17 @@ impl ActionRunner {
     ) -> Result<(), ActionRunnerError> {
         if let Some(name) = &self.report_name {
             let workspace = self.workspace.read().await;
+            let duration = self.duration.unwrap();
+            let mut projected_duration = Duration::new(0, 0);
+
+            for action in actions {
+                if let Some(action_duration) = action.duration {
+                    projected_duration += action_duration;
+                }
+            }
+
+            let mut estimated_savings = projected_duration;
+            estimated_savings -= duration;
 
             workspace
                 .cache
@@ -393,7 +404,9 @@ impl ActionRunner {
                     RunReport {
                         actions,
                         context,
-                        total_duration: self.duration.unwrap(),
+                        duration,
+                        estimated_savings,
+                        projected_duration,
                     },
                 )
                 .await?;

--- a/crates/action-runner/src/runner.rs
+++ b/crates/action-runner/src/runner.rs
@@ -386,33 +386,10 @@ impl ActionRunner {
         if let Some(name) = &self.report_name {
             let workspace = self.workspace.read().await;
             let duration = self.duration.unwrap();
-            let mut projected_duration = Duration::new(0, 0);
-
-            for action in actions {
-                if let Some(action_duration) = action.duration {
-                    projected_duration += action_duration;
-                }
-            }
-
-            let mut estimated_savings = None;
-
-            // Avoid "overflow when subtracting durations"
-            if duration < projected_duration {
-                estimated_savings = Some(projected_duration - duration);
-            }
 
             workspace
                 .cache
-                .create_json_report(
-                    name,
-                    RunReport {
-                        actions,
-                        context,
-                        duration,
-                        estimated_savings,
-                        projected_duration,
-                    },
-                )
+                .create_json_report(name, RunReport::new(actions, context, duration))
                 .await?;
         }
 

--- a/crates/action-runner/src/runner.rs
+++ b/crates/action-runner/src/runner.rs
@@ -394,8 +394,12 @@ impl ActionRunner {
                 }
             }
 
-            let mut estimated_savings = projected_duration;
-            estimated_savings -= duration;
+            let mut estimated_savings = None;
+
+            // Avoid "overflow when subtracting durations"
+            if duration < projected_duration {
+                estimated_savings = Some(projected_duration - duration);
+            }
 
             workspace
                 .cache

--- a/crates/action-runner/src/runner.rs
+++ b/crates/action-runner/src/runner.rs
@@ -388,7 +388,14 @@ impl ActionRunner {
 
             workspace
                 .cache
-                .create_json_report(name, RunReport { actions, context })
+                .create_json_report(
+                    name,
+                    RunReport {
+                        actions,
+                        context,
+                        total_duration: self.duration.unwrap(),
+                    },
+                )
                 .await?;
         }
 

--- a/crates/cache/src/items.rs
+++ b/crates/cache/src/items.rs
@@ -91,7 +91,14 @@ pub struct RunReport<'a> {
 
     pub context: &'a ActionContext,
 
-    pub total_duration: Duration,
+    /// How long the runner took to execute all actions.
+    pub duration: Duration,
+
+    /// How much time was saved using the runner.
+    pub estimated_savings: Duration,
+
+    /// How long the actions would have taken to execute outside of the runner.
+    pub projected_duration: Duration,
 }
 
 #[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/cache/src/items.rs
+++ b/crates/cache/src/items.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 const LOG_TARGET: &str = "moon:cache:item";
 
@@ -85,10 +85,13 @@ impl<T: DeserializeOwned + Serialize> CacheItem<T> {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RunReport<'a> {
     pub actions: &'a Vec<Action>,
 
     pub context: &'a ActionContext,
+
+    pub total_duration: Duration,
 }
 
 #[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/cache/src/items.rs
+++ b/crates/cache/src/items.rs
@@ -95,7 +95,7 @@ pub struct RunReport<'a> {
     pub duration: Duration,
 
     /// How much time was saved using the runner.
-    pub estimated_savings: Duration,
+    pub estimated_savings: Option<Duration>,
 
     /// How long the actions would have taken to execute outside of the runner.
     pub projected_duration: Duration,

--- a/crates/cache/src/items.rs
+++ b/crates/cache/src/items.rs
@@ -1,5 +1,4 @@
 use crate::helpers::{is_readable, is_writable, to_millis};
-use moon_action::{Action, ActionContext};
 use moon_error::MoonError;
 use moon_logger::{color, trace};
 use moon_utils::fs;
@@ -7,7 +6,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 const LOG_TARGET: &str = "moon:cache:item";
 
@@ -82,23 +81,6 @@ impl<T: DeserializeOwned + Serialize> CacheItem<T> {
     pub fn to_millis(&self, time: SystemTime) -> u128 {
         to_millis(time)
     }
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RunReport<'a> {
-    pub actions: &'a Vec<Action>,
-
-    pub context: &'a ActionContext,
-
-    /// How long the runner took to execute all actions.
-    pub duration: Duration,
-
-    /// How much time was saved using the runner.
-    pub estimated_savings: Option<Duration>,
-
-    /// How long the actions would have taken to execute outside of the runner.
-    pub projected_duration: Duration,
 }
 
 #[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -1,8 +1,10 @@
 mod engine;
 mod helpers;
 mod items;
+mod reports;
 mod runfiles;
 
 pub use engine::CacheEngine;
 pub use helpers::*;
 pub use items::*;
+pub use reports::*;

--- a/crates/cache/src/reports.rs
+++ b/crates/cache/src/reports.rs
@@ -1,0 +1,47 @@
+use moon_action::{Action, ActionContext};
+use serde::Serialize;
+use std::time::Duration;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunReport<'a> {
+    pub actions: &'a Vec<Action>,
+
+    pub context: &'a ActionContext,
+
+    /// How long the runner took to execute all actions.
+    pub duration: Duration,
+
+    /// How much time was saved using the runner.
+    pub estimated_savings: Option<Duration>,
+
+    /// How long the actions would have taken to execute outside of the runner.
+    pub projected_duration: Duration,
+}
+
+impl<'a> RunReport<'a> {
+    pub fn new(actions: &'a Vec<Action>, context: &'a ActionContext, duration: Duration) -> Self {
+        let mut projected_duration = Duration::new(0, 0);
+
+        for action in actions {
+            if let Some(action_duration) = action.duration {
+                projected_duration += action_duration;
+            }
+        }
+
+        let mut estimated_savings = None;
+
+        // Avoid "overflow when subtracting durations"
+        if duration < projected_duration {
+            estimated_savings = Some(projected_duration - duration);
+        }
+
+        RunReport {
+            actions,
+            context,
+            duration,
+            estimated_savings,
+            projected_duration,
+        }
+    }
+}

--- a/packages/types/src/runner.ts
+++ b/packages/types/src/runner.ts
@@ -42,6 +42,6 @@ export interface RunReport {
 	actions: Action[];
 	context: ActionContext;
 	duration: Duration;
-	estimatedSavings: Duration;
+	estimatedSavings: Duration | null;
 	projectedDuration: Duration;
 }

--- a/packages/types/src/runner.ts
+++ b/packages/types/src/runner.ts
@@ -25,6 +25,7 @@ export interface Action {
 	createdAt: string;
 	duration: Duration | null;
 	error: string | null;
+	flaky: boolean;
 	label: string | null;
 	nodeIndex: number;
 	status: ActionStatus;
@@ -40,4 +41,7 @@ export interface ActionContext {
 export interface RunReport {
 	actions: Action[];
 	context: ActionContext;
+	duration: Duration;
+	estimatedSavings: Duration;
+	projectedDuration: Duration;
 }


### PR DESCRIPTION
Includes the total duration and data around how much time has been saved (estimated). This will then be used by the GH action.