### PR TITLE
new: Improve output prefixes when streaming concurrent tasks.

### DIFF
--- a/crates/action-runner/src/actions/run_target.rs
+++ b/crates/action-runner/src/actions/run_target.rs
@@ -326,6 +326,7 @@ impl<'a> TargetRunner<'a> {
         let attempt_total = self.task.options.retry_count + 1;
         let mut attempt_index = 1;
         let mut attempts = vec![];
+        let primary_longest_width = context.primary_targets.iter().map(|t| t.len()).max();
         let is_primary = context.primary_targets.contains(&self.task.target);
         let is_real_ci = is_ci() && !is_test_env();
         let output;
@@ -365,7 +366,11 @@ impl<'a> TargetRunner<'a> {
             self.flush_output()?;
 
             let possible_output = if should_stream_output {
-                command.exec_stream_and_capture_output(stream_prefix).await
+                if let Some(prefix) = stream_prefix {
+                    command.set_prefix(prefix, primary_longest_width);
+                }
+
+                command.exec_stream_and_capture_output().await
             } else {
                 command.exec_capture_output().await
             };

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -1064,10 +1064,10 @@ mod multi_run {
 
         let output = get_assert_output(&assert);
 
-        assert!(predicate::str::contains("[node:cjs] stdout").eval(&output));
-        assert!(predicate::str::contains("[node:mjs] stdout").eval(&output));
-        assert!(predicate::str::contains("[node:cjs] stderr").eval(&output));
-        assert!(predicate::str::contains("[node:mjs] stderr").eval(&output));
+        assert!(predicate::str::contains("node:cjs | stdout").eval(&output));
+        assert!(predicate::str::contains("node:mjs | stdout").eval(&output));
+        assert!(predicate::str::contains("node:cjs | stderr").eval(&output));
+        assert!(predicate::str::contains("node:mjs | stderr").eval(&output));
     }
 }
 

--- a/crates/cli/tests/snapshots/run_test__output_styles__stream.snap
+++ b/crates/cli/tests/snapshots/run_test__output_styles__stream.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/cli/tests/run_test.rs
-assertion_line: 1040
+assertion_line: 1048
 expression: get_assert_output(&assert)
 ---
 ▪▪▪▪ npm install
 ▪▪▪▪ outputStyles:stream
-[outputStyles:stream] stdout
+outputStyles:stream        | stdout
 ▪▪▪▪ outputStyles:stream (100ms)
 ▪▪▪▪ outputStyles:streamPrimary (no op)
 
 Tasks: 2 completed
  Time: 100ms
 
-[outputStyles:stream] stderr
+outputStyles:stream        | stderr
 
 

--- a/crates/logger/src/lib.rs
+++ b/crates/logger/src/lib.rs
@@ -4,7 +4,7 @@ mod logger;
 pub use logger::Logger;
 
 // Re-export so that consumers dont need to install these crates
-pub use console::{measure_text_width, pad_str, pad_str_with, strip_ansi_codes};
+pub use console::{measure_text_width, pad_str, pad_str_with, strip_ansi_codes, Alignment};
 pub use log::{debug, error, info, max_level, trace, warn, LevelFilter};
 
 pub fn logging_enabled() -> bool {

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -1,4 +1,4 @@
-use crate::{is_ci, path};
+use crate::{is_ci, is_test_env, path};
 use moon_error::{map_io_to_process_error, MoonError};
 use moon_logger::{color, logging_enabled, pad_str, trace, Alignment};
 use std::env;
@@ -335,7 +335,7 @@ impl Command {
     }
 
     pub fn set_prefix(&mut self, prefix: &str, width: Option<usize>) -> &mut Command {
-        if is_ci() {
+        if is_ci() && !is_test_env() {
             self.prefix = Some(color::muted(format!("[{}]", prefix)));
         } else {
             self.prefix = Some(format!(

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -1,6 +1,6 @@
-use crate::path;
+use crate::{is_ci, path};
 use moon_error::{map_io_to_process_error, MoonError};
-use moon_logger::{color, logging_enabled, trace};
+use moon_logger::{color, logging_enabled, pad_str, trace, Alignment};
 use std::env;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -64,6 +64,9 @@ pub struct Command {
 
     /// Convert non-zero exits to errors.
     error: bool,
+
+    /// Prefix to prepend to all log lines.
+    prefix: Option<String>,
 }
 
 // This is rather annoying that we have to re-implement all these methods,
@@ -95,6 +98,7 @@ impl Command {
             bin: bin_name,
             cmd,
             error: true,
+            prefix: None,
         }
     }
 
@@ -200,10 +204,7 @@ impl Command {
     }
 
     #[track_caller]
-    pub async fn exec_stream_and_capture_output<T: AsRef<str>>(
-        &mut self,
-        prefix: Option<T>,
-    ) -> Result<Output, MoonError> {
+    pub async fn exec_stream_and_capture_output(&mut self) -> Result<Output, MoonError> {
         self.log_command_info(None);
 
         let mut child = self
@@ -228,10 +229,7 @@ impl Command {
         let captured_stderr_clone = Arc::clone(&captured_stderr);
         let captured_stdout_clone = Arc::clone(&captured_stdout);
 
-        let prefix: Arc<str> = prefix
-            .map(|p| color::muted(format!("[{}]", p.as_ref())))
-            .unwrap_or_default()
-            .into();
+        let prefix: Arc<str> = self.prefix.clone().unwrap_or_default().into();
         let stderr_prefix = Arc::clone(&prefix);
         let stdout_prefix = Arc::clone(&prefix);
 
@@ -333,6 +331,24 @@ impl Command {
 
     pub fn no_error_on_failure(&mut self) -> &mut Command {
         self.error = false;
+        self
+    }
+
+    pub fn set_prefix(&mut self, prefix: &str, width: Option<usize>) -> &mut Command {
+        if is_ci() {
+            self.prefix = Some(color::muted(format!("[{}]", prefix)));
+        } else {
+            self.prefix = Some(format!(
+                "{} {}",
+                color::log_target(if let Some(width) = width {
+                    pad_str(prefix, width, Alignment::Left, None).to_string()
+                } else {
+                    prefix.to_owned()
+                }),
+                color::muted("|")
+            ));
+        }
+
         self
     }
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- When running multiple targets in parallel, we've reworked the output prefix to be uniform amongst
+  all targets, and to be colored to uniquely identify each target.
+- Updated run reports (via `--report`) to include additional information, like the total duration,
+  and estimated time savings.
+
 ## 0.14.0
 
 #### 🎉 Release


### PR DESCRIPTION
As the title states. The prefixes will now be uniform in width, and be colored to differentiate based on target. It now looks something like the following:

<img width="1057" alt="Screen Shot 2022-09-16 at 4 38 32 PM" src="https://user-images.githubusercontent.com/143744/190830781-952dc5a1-b1a7-4ae1-b017-e51ad2b79090.png">

