### PR TITLE
breaking: Drop `cmd.exe` for Windows. Rework Windows shell.

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,4 +1,4 @@
-# Trigger CI: 4
+# Trigger CI: 5
 
 $schema: '../schemas/workspace.json'
 

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -4,6 +4,7 @@ pub mod path;
 pub mod process;
 pub mod regex;
 pub mod semver;
+pub mod shell;
 pub mod test;
 pub mod time;
 

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -1,5 +1,4 @@
-use crate::shell;
-use crate::{is_ci, is_test_env, path};
+use crate::{is_ci, is_test_env, path, shell};
 use moon_error::{map_io_to_process_error, MoonError};
 use moon_logger::{color, logging_enabled, pad_str, trace, Alignment};
 use std::ffi::{OsStr, OsString};

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -23,7 +23,6 @@ pub fn output_to_trimmed_string(data: &[u8]) -> String {
     output_to_string(data).trim().to_owned()
 }
 
-#[derive(Debug)]
 pub struct Command {
     bin: String,
 

--- a/crates/utils/src/process.rs
+++ b/crates/utils/src/process.rs
@@ -300,8 +300,8 @@ impl Command {
 
     pub fn get_input_line(&self) -> String {
         String::from_utf8(self.input.clone())
-                .unwrap_or_default()
-                .replace('\n', " ")
+            .unwrap_or_default()
+            .replace('\n', " ")
     }
 
     pub fn inherit_colors(&mut self) -> &mut Command {
@@ -377,7 +377,7 @@ impl Command {
         let (mut command_line, working_dir) = self.get_command_line();
 
         if !self.input.is_empty() {
-            if command_line.ends_with("-") {
+            if command_line.ends_with('-') {
                 command_line = format!("{} {}", command_line, self.get_input_line());
             } else {
                 command_line = format!("{} - {}", command_line, self.get_input_line());

--- a/crates/utils/src/shell.rs
+++ b/crates/utils/src/shell.rs
@@ -29,7 +29,7 @@ pub fn create_windows_shell() -> (String, TokioCommand) {
     let mut cmd = TokioCommand::new(&shell);
     cmd.arg("-NonInteractive");
 
-    // We'll pass the command args via stdin, so that paths weird special
+    // We'll pass the command args via stdin, so that paths with special
     // characters and spaces resolve correctly.
     // https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.2#-command---c
     cmd.arg("-Command");

--- a/crates/utils/src/shell.rs
+++ b/crates/utils/src/shell.rs
@@ -1,0 +1,39 @@
+use cached::proc_macro::cached;
+use std::env;
+use tokio::process::Command as TokioCommand;
+
+#[cached]
+fn is_program_on_path(program_name: String) -> bool {
+    let system_path = match env::var_os("PATH") {
+        Some(x) => x,
+        None => return false,
+    };
+
+    for path_dir in env::split_paths(&system_path) {
+        if path_dir.join(&program_name).exists() {
+            return true;
+        }
+    }
+
+    false
+}
+
+// https://thinkpowershell.com/decision-to-switch-to-powershell-core-pwsh/
+pub fn create_windows_shell() -> (String, TokioCommand) {
+    let shell = if is_program_on_path("pwsh.exe".into()) {
+        "pwsh.exe".into()
+    } else {
+        "powershell.exe".into()
+    };
+
+    let mut cmd = TokioCommand::new(&shell);
+    cmd.arg("-NonInteractive");
+
+    // We'll pass the command args via stdin, so that paths weird special
+    // characters and spaces resolve correctly.
+    // https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.2#-command---c
+    cmd.arg("-Command");
+    cmd.arg("-");
+
+    (shell, cmd)
+}

--- a/crates/utils/src/shell.rs
+++ b/crates/utils/src/shell.rs
@@ -28,6 +28,8 @@ pub fn create_windows_shell() -> (String, TokioCommand) {
 
     let mut cmd = TokioCommand::new(&shell);
     cmd.arg("-NonInteractive");
+    cmd.arg("-NoLogo");
+    cmd.arg("-NoProfile");
 
     // We'll pass the command args via stdin, so that paths with special
     // characters and spaces resolve correctly.

--- a/crates/vcs/src/git.rs
+++ b/crates/vcs/src/git.rs
@@ -165,7 +165,8 @@ impl Vcs for Git {
 
         let output = self
             .create_command(vec!["hash-object", "--stdin-paths"])
-            .exec_capture_output_with_input(&objects.join("\n"))
+            .input(objects.join("\n").as_bytes())
+            .exec_capture_output()
             .await?;
         let output = output_to_trimmed_string(&output.stdout);
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,12 @@
 - Updated run reports (via `--report`) to include additional information, like the total duration,
   and estimated time savings.
 
+#### ⚙️ Internal
+
+- Windows:
+  - Will always use PowerShell and avoids `cmd.exe` entirely.
+  - Reworked commands that run through PowerShell to pass arguments via stdin.
+
 ## 0.14.1
 
 #### 🐞 Fixes

--- a/tests/fixtures/cases/system-windows/moon.yml
+++ b/tests/fixtures/cases/system-windows/moon.yml
@@ -2,46 +2,37 @@ language: bash
 
 tasks:
   bat:
-    command: cmd
-    args: ./standard.bat
+    command: cmd.exe /q /c ./standard.bat
     type: system
   exitNonZero:
-    command: cmd
-    args: ./exitNonZero.bat
+    command: cmd.exe /q /c ./exitNonZero.bat
     type: system
   exitZero:
-    command: cmd.exe
-    args: ./exitZero.bat
+    command: cmd.exe /q /c ./exitZero.bat
     type: system
   passthroughArgs:
-    command: cmd
-    args: ./passthroughArgs.bat
+    command: cmd /q /c ./passthroughArgs.bat
     type: system
   envVars:
-    command: cmd
-    args: ./envVars.bat
+    command: cmd.exe /q /c ./envVars.bat
     env:
       MOON_FOO: abc
       MOON_BAR: '123'
       MOON_BAZ: 'true'
     type: system
   envVarsMoon:
-    command: cmd.exe
-    args: ./envVarsMoon.bat
+    command: cmd /q /c ./envVarsMoon.bat
     type: system
   runFromProject:
-    command: cmd
-    args: ./cwd.bat
+    command: cmd.exe /q /c ./cwd.bat
     type: system
   runFromWorkspace:
-    command: cmd.exe
-    args: ./system-windows/cwd.bat
+    command: cmd /q /c ./system-windows/cwd.bat
     type: system
     options:
       runFromWorkspaceRoot: true
   retryCount:
-    command: cmd
-    args: ./exitNonZero.bat
+    command: cmd.exe /q /c ./exitNonZero.bat
     type: system
     options:
       retryCount: 3

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -25,10 +25,11 @@ acronym, as it embraces what moon is trying to solve:
 ### Will moon support other languages besides JavaScript?
 
 Yes! Although we're focusing right now on JavaScript (and TypeScript, Node.js), we've designed moon
-to be language agnostic and easily pluggable in the future.
+to be language agnostic and easily pluggable in the future. If we're to guess which language would
+be next, it would most likely be Ruby to support React Native based applications.
 
-If we're to guess which language would be next, it would most likely be Ruby to support React Native
-based applications.
+With that being said, for languages not supported in our toolchain, you can still execute them
+within at task by setting the [type to system](./config/project#type).
 
 ### Will moon support continuous deployment?
 
@@ -126,6 +127,27 @@ alternatives:
 - Create a task for each command, and run them concurrently with [`moon run`](./commands/run).
 - Wrap all commands in an external file, and execute that file instead. Refer to the
   [piping question](#how-to-pipe-or-redirect-tasks) above for an example.
+
+### How to run tasks in a shell?
+
+By default, all tasks _do not_ run in a shell, as we interact with and execute a tool's binary
+directly within the toolchain. We also provide no built-in support for shells, but that doesn't mean
+you can't use them. Since tasks can execute any commands available on your system, you can implement
+the shell manually like so:
+
+```yaml title="moon.yml"
+tasks:
+  bash:
+    command: 'bash -c some-command'
+    type: 'system'
+  # Windows
+  cmd:
+    command: 'cmd.exe /d /s /c some-command'
+    type: 'system'
+  pwsh:
+    command: 'pwsh.exe -c some-command'
+    type: 'system'
+```
 
 ## JavaScript ecosystem
 

--- a/website/src/components/ComparisonTable.tsx
+++ b/website/src/components/ComparisonTable.tsx
@@ -126,9 +126,9 @@ const projectsRows: Comparison[] = [
 	{
 		feature: 'Dependencies on other projects',
 		support: {
-			moon: [SUPPORTED, 'explicitly defined or migrated from `package.json`'],
-			nx: [SUPPORTED, 'inferred from `package.json` or via `implicitDependencies`'],
-			turborepo: [SUPPORTED, 'inferred from `package.json`'],
+			moon: [SUPPORTED, 'implicit from `package.json` or explicit in `moon.yml`'],
+			nx: [SUPPORTED, 'implicit from `package.json` or explicit in `project.json`'],
+			turborepo: [SUPPORTED, 'implicit from `package.json`'],
 		},
 	},
 	{
@@ -426,6 +426,12 @@ const generatorRows: Comparison[] = [
 		support: {
 			moon: [SUPPORTED, 'via `template.yml`'],
 			nx: SUPPORTED,
+		},
+	},
+	{
+		feature: 'Template files support frontmatter',
+		support: {
+			moon: SUPPORTED,
 		},
 	},
 	{


### PR DESCRIPTION
We're still seeing issues for Windows file paths that contain spaces and special characters not executing. 

`cmd.exe` doesn't handle this very well, and it's been a crazy amount of work to get working in Rust. So instead of supporting `cmd.exe`, I'm simply going to drop it for `powershell.exe`, which has existed for a long time. The newer `pwsh.exe` will be used if detected.

However, PS still has problems with file paths as arguments, so to work around this, arguments will now be passed via stdin.