### PR TITLE
deps: Update Cargo dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.21"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed5341b2301a26ab80be5cbdced622e80ed808483c52e45e3310a877d3b37d7"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
@@ -371,7 +371,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "terminal_size",
+ "terminal_size 0.2.1",
  "textwrap",
 ]
 
@@ -429,7 +429,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "terminal_size",
+ "terminal_size 0.1.17",
  "unicode-width",
  "winapi",
 ]
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
@@ -704,6 +704,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1002,7 +1023,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -1161,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc42b206e70d86ec03285b123e65a5458c92027d1fb2ae3555878b8113b3ddf"
+checksum = "bfddc9561e8baf264e0e45e197fd7696320026eb10a8180340debc27b18f535b"
 dependencies = [
  "console",
  "number_prefix",
@@ -1172,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.19.1"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc61e98be01e89296f3343a878e9f8ca75a494cb5aaf29df65ef55734aeb85f5"
+checksum = "58a931b01c76064c5be919faa2ef0dc570e9a889dcd1e5fef08a8ca6eb4d6c0b"
 dependencies = [
  "console",
  "linked-hash-map",
@@ -1191,6 +1212,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
 name = "ipnet"
@@ -1257,15 +1284,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -2002,7 +2035,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
  "hmac",
  "password-hash",
  "sha2",
@@ -2343,6 +2376,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.35.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af895b90e5c071badc3136fc10ff0bcfc98747eadbaf43ed8f214e07ba8f8477"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f31df3f50926cdf2855da5fd8812295c34752cb20438dae42a67f79e021ac3"
+checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2546,18 +2593,18 @@ checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -2730,6 +2777,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,11 +2794,11 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 dependencies = [
- "terminal_size",
+ "terminal_size 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -156,32 +156,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
- "generic-array 0.14.5",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "generic-array",
 ]
 
 [[package]]
@@ -209,12 +188,6 @@ name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -354,7 +327,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -528,7 +501,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
  "typenum",
 ]
 
@@ -620,20 +593,11 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer",
  "crypto-common",
  "subtle",
 ]
@@ -726,12 +690,6 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
@@ -925,15 +883,6 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
@@ -1023,7 +972,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.5",
+ "digest",
 ]
 
 [[package]]
@@ -1318,12 +1267,6 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
@@ -1900,12 +1843,6 @@ checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -2035,7 +1972,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
 dependencies = [
- "digest 0.10.5",
+ "digest",
  "hmac",
  "password-hash",
  "sha2",
@@ -2049,18 +1986,19 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
-version = "2.1.3"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
 dependencies = [
+ "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.1.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+checksum = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2068,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.1.3"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+checksum = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2081,13 +2019,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.1.3"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+checksum = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6"
 dependencies = [
- "maplit",
+ "once_cell",
  "pest",
- "sha-1",
+ "sha1",
 ]
 
 [[package]]
@@ -2481,18 +2419,18 @@ checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2574,18 +2512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,7 +2519,7 @@ checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest",
 ]
 
 [[package]]
@@ -2604,7 +2530,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest",
 ]
 
 [[package]]
@@ -2737,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4685e72cb35f0eb74319c8fe2d3b61e93da5609841cde2cb87fcc3bea56d20"
+checksum = "3df578c295f9ec044ff1c829daf31bb7581d5b3c2a7a3d87419afe1f2531438c"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,9 +630,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenvy"
-version = "0.15.3"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3db6fcad7c1fc4abdd99bf5276a4db30d6a819127903a709ed41e5ff016e84"
+checksum = "ed9155c8f4dc55c7470ae9da3f63c6785245093b3f6aeb0f5bf2e968efbba314"
 dependencies = [
  "dirs",
 ]
@@ -1176,9 +1176,9 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -2278,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "base64",
  "bytes",
@@ -2294,10 +2294,10 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "serde",
@@ -2413,9 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = ["crates/*"]
 default-members = ["crates/cli"]
 
 [workspace.dependencies]
+serde = { version = "1.0.145", features = ["derive"] }
 thiserror = "1.0.35"
 tokio = { version = "1.21.1", features = ["full"] }

--- a/crates/action-runner/Cargo.toml
+++ b/crates/action-runner/Cargo.toml
@@ -30,4 +30,4 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 moon_cache = { path = "../cache" }
-insta = "1.19.1"
+insta = "1.20.0"

--- a/crates/action-runner/Cargo.toml
+++ b/crates/action-runner/Cargo.toml
@@ -24,7 +24,7 @@ moon_vcs = { path = "../vcs" }
 moon_workspace = { path = "../workspace" }
 console = "0.15.1"
 petgraph = "0.6.2"
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 

--- a/crates/action/Cargo.toml
+++ b/crates/action/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 moon_utils = { path = "../utils" }
-clap = { version = "3.2.21", features = ["derive"] }
+clap = { version = "3.2.22", features = ["derive"] }
 serde = { version = "1.0.144", features = ["derive"] }

--- a/crates/action/Cargo.toml
+++ b/crates/action/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 moon_utils = { path = "../utils" }
 clap = { version = "3.2.22", features = ["derive"] }
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { workspace = true }

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -10,7 +10,7 @@ moon_constants = { path = "../constants" }
 moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }
 moon_utils = { path = "../utils" }
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { workspace = true }
 
 [dev-dependencies]
 assert_fs = "1.0.7"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -39,7 +39,7 @@ console = "0.15.1"
 dialoguer = "0.10.2"
 futures = "0.3.24"
 indicatif = "0.17.1"
-itertools = "0.10.4"
+itertools = "0.10.5"
 serde = { workspace = true }
 serde_json = "1.0.85"
 serde_yaml = "0.9.13"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,16 +33,16 @@ moon_utils = { path = "../utils" }
 moon_vcs = { path = "../vcs" }
 moon_workspace = { path = "../workspace" }
 async-recursion = "1.0.0"
-clap = { version = "3.2.21", features = ["derive", "env", "wrap_help"] }
+clap = { version = "3.2.22", features = ["derive", "env", "wrap_help"] }
 clap_lex = "0.2.4"
 console = "0.15.1"
 dialoguer = "0.10.2"
 futures = "0.3.24"
-indicatif = "0.17.0"
+indicatif = "0.17.1"
 itertools = "0.10.4"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
-serde_yaml = "0.9.11"
+serde_yaml = "0.9.13"
 strum = { version = "0.24.1", features = ["derive"] }
 tera = { version = "1.17.0", features = ["preserve_order"] }
 tokio = { workspace = true }
@@ -50,7 +50,7 @@ tokio = { workspace = true }
 [dev-dependencies]
 moon_cache = { path = "../cache" }
 assert_cmd = "2.0.4"
-insta = "1.19.1"
+insta = "1.20.0"
 predicates = "2.1.1"
 pretty_assertions = "1.3.0"
 serial_test = "0.9.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -40,11 +40,11 @@ dialoguer = "0.10.2"
 futures = "0.3.24"
 indicatif = "0.17.1"
 itertools = "0.10.4"
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { workspace = true }
 serde_json = "1.0.85"
 serde_yaml = "0.9.13"
 strum = { version = "0.24.1", features = ["derive"] }
-tera = { version = "1.17.0", features = ["preserve_order"] }
+tera = { version = "1.17.1", features = ["preserve_order"] }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -26,7 +26,7 @@ reqwest = { version = "0.11.11", features = [
 schemars = "0.8.10"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = { version = "1.0.85", features = ["preserve_order"] }
-serde_yaml = "0.9.11"
+serde_yaml = "0.9.13"
 strum = { version = "0.24.1", features = ["derive"] }
 thiserror = { workspace = true }
 validator = { version = "0.16.0", features = ["derive"] }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -24,7 +24,7 @@ reqwest = { version = "0.11.11", features = [
   "native-tls-vendored",
 ] }
 schemars = "0.8.10"
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { workspace = true }
 serde_json = { version = "1.0.85", features = ["preserve_order"] }
 serde_yaml = "0.9.13"
 strum = { version = "0.24.1", features = ["derive"] }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -19,7 +19,7 @@ moon_lang_node = { path = "../lang-node" }
 moon_utils = { path = "../utils" }
 figment = { version = "0.10.7", features = ["test", "yaml"] }
 json = "0.12.4"
-reqwest = { version = "0.11.11", features = [
+reqwest = { version = "0.11.12", features = [
   "blocking",
   "native-tls-vendored",
 ] }

--- a/crates/error/Cargo.toml
+++ b/crates/error/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 regex = "1.6.0"
 serde_json = { version = "1.0.85", default-features = false }
-serde_yaml = { version = "0.9.11", default-features = false }
+serde_yaml = { version = "0.9.13", default-features = false }
 thiserror = { workspace = true }

--- a/crates/generator/Cargo.toml
+++ b/crates/generator/Cargo.toml
@@ -13,7 +13,7 @@ convert_case = "0.6.0"
 futures = "0.3.24"
 lazy_static = "1.4.0"
 serde_json = "1.0.85"
-tera = { version = "1.17.0", features = ["preserve_order"] }
+tera = { version = "1.17.1", features = ["preserve_order"] }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/hasher/Cargo.toml
+++ b/crates/hasher/Cargo.toml
@@ -8,4 +8,4 @@ moon_error = { path = "../error" }
 moon_task = { path = "../task" }
 moon_utils = { path = "../utils" }
 serde = { version = "1.0.144", features = ["derive"] }
-sha2 = "0.10.5"
+sha2 = "0.10.6"

--- a/crates/hasher/Cargo.toml
+++ b/crates/hasher/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 moon_error = { path = "../error" }
 moon_task = { path = "../task" }
 moon_utils = { path = "../utils" }
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { workspace = true }
 sha2 = "0.10.6"

--- a/crates/lang-node/Cargo.toml
+++ b/crates/lang-node/Cargo.toml
@@ -13,7 +13,7 @@ content_inspector = "0.2.4"
 json = "0.12.4"
 lazy_static = "1.4.0"
 regex = "1.6.0"
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { workspace = true }
 serde_json = { version = "1.0.85", features = ["preserve_order"] }
 serde_yaml = "0.9.13"
 

--- a/crates/lang-node/Cargo.toml
+++ b/crates/lang-node/Cargo.toml
@@ -20,6 +20,6 @@ serde_yaml = "0.9.13"
 [dev-dependencies]
 assert_fs = "1.0.7"
 pretty_assertions = "1.3.0"
-reqwest = { version = "0.11.11", features = ["blocking"] }
+reqwest = { version = "0.11.12", features = ["blocking"] }
 serial_test = "0.9.0"
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/lang-node/Cargo.toml
+++ b/crates/lang-node/Cargo.toml
@@ -15,7 +15,7 @@ lazy_static = "1.4.0"
 regex = "1.6.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = { version = "1.0.85", features = ["preserve_order"] }
-serde_yaml = "0.9.11"
+serde_yaml = "0.9.13"
 
 [dev-dependencies]
 assert_fs = "1.0.7"

--- a/crates/platform-node/Cargo.toml
+++ b/crates/platform-node/Cargo.toml
@@ -25,5 +25,5 @@ tokio = { workspace = true }
 [dev-dependencies]
 moon_cache = { path = "../cache" }
 moon_project_graph = { path = "../project-graph" }
-insta = "1.19.1"
+insta = "1.20.0"
 pretty_assertions = "1.3.0"

--- a/crates/platform-node/Cargo.toml
+++ b/crates/platform-node/Cargo.toml
@@ -19,7 +19,7 @@ moon_toolchain = { path = "../toolchain" }
 moon_utils = { path = "../utils" }
 moon_workspace = { path = "../workspace" }
 lazy_static = "1.4.0"
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/crates/platform-system/Cargo.toml
+++ b/crates/platform-system/Cargo.toml
@@ -10,4 +10,4 @@ moon_project = { path = "../project" }
 moon_task = { path = "../task" }
 moon_utils = { path = "../utils" }
 moon_workspace = { path = "../workspace" }
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { workspace = true }

--- a/crates/project-graph/Cargo.toml
+++ b/crates/project-graph/Cargo.toml
@@ -17,5 +17,5 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 moon_platform_node = { path = "../platform-node" }
-insta = "1.19.1"
+insta = "1.20.0"
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -10,7 +10,7 @@ moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }
 moon_task = { path = "../task" }
 moon_utils = { path = "../utils" }
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { workspace = true }
 strum = { version = "0.24.1", features = ["derive"] }
 thiserror = { workspace = true }
 

--- a/crates/task/Cargo.toml
+++ b/crates/task/Cargo.toml
@@ -9,6 +9,6 @@ moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }
 moon_utils = { path = "../utils" }
 common-path = "1.0.0"
-dotenvy = "0.15.3"
+dotenvy = "0.15.5"
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/task/Cargo.toml
+++ b/crates/task/Cargo.toml
@@ -10,5 +10,5 @@ moon_logger = { path = "../logger" }
 moon_utils = { path = "../utils" }
 common-path = "1.0.0"
 dotenvy = "0.15.3"
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -13,7 +13,7 @@ moon_lang_node = { path = "../lang-node" }
 moon_logger = { path = "../logger" }
 moon_utils = { path = "../utils" }
 async-trait = "0.1.57"
-reqwest = { version = "0.11.11", features = ["native-tls-vendored"] }
+reqwest = { version = "0.11.12", features = ["native-tls-vendored"] }
 sha2 = "0.10.6"
 thiserror = { workspace = true }
 

--- a/crates/toolchain/Cargo.toml
+++ b/crates/toolchain/Cargo.toml
@@ -14,7 +14,7 @@ moon_logger = { path = "../logger" }
 moon_utils = { path = "../utils" }
 async-trait = "0.1.57"
 reqwest = { version = "0.11.11", features = ["native-tls-vendored"] }
-sha2 = "0.10.5"
+sha2 = "0.10.6"
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -21,7 +21,7 @@ json_comments = "0.2.1"
 lazy_static = "1.4.0"
 pathdiff = "0.2.1"
 regex = "1.6.0"
-semver = "1.0.13"
+semver = "1.0.14"
 serde = { workspace = true }
 serde_json = { version = "1.0.85", features = ["preserve_order"] }
 shell-words = "1.1.0"

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "1.4.0"
 pathdiff = "0.2.1"
 regex = "1.6.0"
 semver = "1.0.13"
-serde = "1.0.144"
+serde = { workspace = true }
 serde_json = { version = "1.0.85", features = ["preserve_order"] }
 shell-words = "1.1.0"
 tokio = { workspace = true }


### PR DESCRIPTION
Minor stuff.

Clap v4 is out, but it's quite a change, so I'll do it in a PR by itself.