### PR TITLE
internal: Rename platform enum to runtime.

### DIFF
--- a/crates/cache/src/engine.rs
+++ b/crates/cache/src/engine.rs
@@ -4,7 +4,7 @@ use crate::runfiles::CacheRunfile;
 use crate::DependenciesState;
 use moon_archive::{tar, untar};
 use moon_constants::CONFIG_DIRNAME;
-use moon_contract::SupportedPlatform;
+use moon_contract::Runtime;
 use moon_error::MoonError;
 use moon_logger::{color, debug, trace};
 use moon_utils::{fs, time};
@@ -63,7 +63,7 @@ impl CacheEngine {
 
     pub async fn cache_deps_state(
         &self,
-        platform: &SupportedPlatform,
+        platform: &Runtime,
         project_id: Option<&str>,
     ) -> Result<CacheItem<DependenciesState>, MoonError> {
         let name = format!("deps{}.json", platform);
@@ -106,7 +106,7 @@ impl CacheEngine {
 
     pub async fn cache_tool_state(
         &self,
-        platform: &SupportedPlatform,
+        platform: &Runtime,
     ) -> Result<CacheItem<ToolState>, MoonError> {
         CacheItem::load(
             self.states_dir

--- a/crates/cache/src/engine.rs
+++ b/crates/cache/src/engine.rs
@@ -63,10 +63,10 @@ impl CacheEngine {
 
     pub async fn cache_deps_state(
         &self,
-        platform: &Runtime,
+        runtime: &Runtime,
         project_id: Option<&str>,
     ) -> Result<CacheItem<DependenciesState>, MoonError> {
-        let name = format!("deps{}.json", platform);
+        let name = format!("deps{}.json", runtime);
 
         CacheItem::load(
             self.states_dir.join(if let Some(id) = project_id {
@@ -106,11 +106,11 @@ impl CacheEngine {
 
     pub async fn cache_tool_state(
         &self,
-        platform: &Runtime,
+        runtime: &Runtime,
     ) -> Result<CacheItem<ToolState>, MoonError> {
         CacheItem::load(
             self.states_dir
-                .join(format!("tool{}-{}.json", platform, platform.version())),
+                .join(format!("tool{}-{}.json", runtime, runtime.version())),
             ToolState::default(),
             0,
         )

--- a/crates/cache/tests/engine_test.rs
+++ b/crates/cache/tests/engine_test.rs
@@ -303,7 +303,7 @@ mod cache_run_target_state {
 
 mod cache_tool_state {
     use super::*;
-    use moon_contract::SupportedPlatform;
+    use moon_contract::Runtime;
 
     #[tokio::test]
     #[serial]
@@ -311,7 +311,7 @@ mod cache_tool_state {
         let dir = assert_fs::TempDir::new().unwrap();
         let cache = CacheEngine::create(dir.path()).await.unwrap();
         let item = cache
-            .cache_tool_state(&SupportedPlatform::Node("1.2.3".into()))
+            .cache_tool_state(&Runtime::Node("1.2.3".into()))
             .await
             .unwrap();
 
@@ -332,7 +332,7 @@ mod cache_tool_state {
 
         let cache = CacheEngine::create(dir.path()).await.unwrap();
         let item = cache
-            .cache_tool_state(&SupportedPlatform::Node("1.2.3".into()))
+            .cache_tool_state(&Runtime::Node("1.2.3".into()))
             .await
             .unwrap();
 
@@ -356,7 +356,7 @@ mod cache_tool_state {
             .unwrap();
 
         let cache = CacheEngine::create(dir.path()).await.unwrap();
-        let platform = SupportedPlatform::Node("4.5.6".into());
+        let platform = Runtime::Node("4.5.6".into());
         let item = run_with_env("read", || cache.cache_tool_state(&platform))
             .await
             .unwrap();
@@ -381,7 +381,7 @@ mod cache_tool_state {
             .unwrap();
 
         let cache = CacheEngine::create(dir.path()).await.unwrap();
-        let item = run_with_env("off", || cache.cache_tool_state(&SupportedPlatform::System))
+        let item = run_with_env("off", || cache.cache_tool_state(&Runtime::System))
             .await
             .unwrap();
 
@@ -396,7 +396,7 @@ mod cache_tool_state {
         let dir = assert_fs::TempDir::new().unwrap();
         let cache = CacheEngine::create(dir.path()).await.unwrap();
         let mut item = cache
-            .cache_tool_state(&SupportedPlatform::Node("7.8.9".into()))
+            .cache_tool_state(&Runtime::Node("7.8.9".into()))
             .await
             .unwrap();
 

--- a/crates/cache/tests/engine_test.rs
+++ b/crates/cache/tests/engine_test.rs
@@ -356,8 +356,8 @@ mod cache_tool_state {
             .unwrap();
 
         let cache = CacheEngine::create(dir.path()).await.unwrap();
-        let platform = Runtime::Node("4.5.6".into());
-        let item = run_with_env("read", || cache.cache_tool_state(&platform))
+        let runtime = Runtime::Node("4.5.6".into());
+        let item = run_with_env("read", || cache.cache_tool_state(&runtime))
             .await
             .unwrap();
 

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -1,5 +1,5 @@
 use crate::helpers::{create_progress_bar, load_workspace};
-use moon_contract::SupportedPlatform;
+use moon_contract::Runtime;
 use moon_runner::{ActionRunner, DepGraph};
 use moon_utils::is_test_env;
 
@@ -10,7 +10,7 @@ pub async fn setup() -> Result<(), Box<dyn std::error::Error>> {
     let mut dep_graph = DepGraph::default();
 
     if let Some(node) = &workspace.config.node {
-        let platform = SupportedPlatform::Node(node.version.to_owned());
+        let platform = Runtime::Node(node.version.to_owned());
 
         dep_graph.setup_tool(&platform);
 

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -10,12 +10,12 @@ pub async fn setup() -> Result<(), Box<dyn std::error::Error>> {
     let mut dep_graph = DepGraph::default();
 
     if let Some(node) = &workspace.config.node {
-        let platform = Runtime::Node(node.version.to_owned());
+        let runtime = Runtime::Node(node.version.to_owned());
 
-        dep_graph.setup_tool(&platform);
+        dep_graph.setup_tool(&runtime);
 
         if !is_test_env() {
-            dep_graph.install_deps(&platform)?;
+            dep_graph.install_deps(&runtime)?;
         }
     }
 

--- a/crates/cli/src/commands/sync.rs
+++ b/crates/cli/src/commands/sync.rs
@@ -10,7 +10,7 @@ pub async fn sync() -> Result<(), Box<dyn std::error::Error>> {
 
     for project_id in workspace.projects.ids() {
         let project = workspace.projects.load(&project_id)?;
-        let platform = graph.get_platform_from_project(&project, &workspace.projects);
+        let platform = graph.get_runtime_from_project(&project, &workspace.projects);
 
         graph.sync_project(&platform, &project, &workspace.projects)?;
         project_count += 1;

--- a/crates/cli/src/commands/sync.rs
+++ b/crates/cli/src/commands/sync.rs
@@ -10,9 +10,9 @@ pub async fn sync() -> Result<(), Box<dyn std::error::Error>> {
 
     for project_id in workspace.projects.ids() {
         let project = workspace.projects.load(&project_id)?;
-        let platform = graph.get_runtime_from_project(&project, &workspace.projects);
+        let runtime = graph.get_runtime_from_project(&project, &workspace.projects);
 
-        graph.sync_project(&platform, &project, &workspace.projects)?;
+        graph.sync_project(&runtime, &project, &workspace.projects)?;
         project_count += 1;
     }
 

--- a/crates/contract/src/platform.rs
+++ b/crates/contract/src/platform.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 pub trait Platform: Send + Sync {
     /// Return true if the current platform instance is for the supported platform enum.
-    fn is(&self, platform: &SupportedPlatform) -> bool;
+    fn is(&self, platform: &Runtime) -> bool;
 
     /// Determine if the provided project is within the platform's package manager
     /// workspace (not to be confused with moon's workspace).
@@ -70,32 +70,33 @@ pub trait Platformable {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum SupportedPlatform {
+pub enum Runtime {
     Node(String),
     System,
 }
 
-impl SupportedPlatform {
+impl Runtime {
     pub fn label(&self) -> String {
         match self {
-            SupportedPlatform::Node(version) => format!("Node.js v{}", version),
-            SupportedPlatform::System => "system".into(),
+            Runtime::Node(version) => format!("Node.js v{}", version),
+            Runtime::System => "system".into(),
         }
     }
 
     pub fn version(&self) -> String {
         match self {
-            SupportedPlatform::Node(version) => version.into(),
-            SupportedPlatform::System => "latest".into(),
+            Runtime::Node(version) => version.into(),
+            Runtime::System => "latest".into(),
         }
     }
 }
 
-impl fmt::Display for SupportedPlatform {
+impl fmt::Display for Runtime {
+    // Primarily used in action graph node labels
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            SupportedPlatform::Node(_) => write!(f, "Node"),
-            SupportedPlatform::System => write!(f, "System"),
+            Runtime::Node(_) => write!(f, "Node"),
+            Runtime::System => write!(f, "System"),
         }
     }
 }

--- a/crates/contract/src/platform.rs
+++ b/crates/contract/src/platform.rs
@@ -10,8 +10,8 @@ use std::fmt;
 use std::path::Path;
 
 pub trait Platform: Send + Sync {
-    /// Return true if the current platform instance is for the supported platform enum.
-    fn is(&self, platform: &Runtime) -> bool;
+    /// Return true if the current platform is for the provided runtime.
+    fn is(&self, runtime: &Runtime) -> bool;
 
     /// Determine if the provided project is within the platform's package manager
     /// workspace (not to be confused with moon's workspace).

--- a/crates/platform-node/src/actions/install_deps.rs
+++ b/crates/platform-node/src/actions/install_deps.rs
@@ -1,6 +1,6 @@
 use moon_action::{Action, ActionContext, ActionStatus};
 use moon_config::NodePackageManager;
-use moon_contract::SupportedPlatform;
+use moon_contract::Runtime;
 use moon_error::map_io_to_fs_error;
 use moon_error::MoonError;
 use moon_lang::has_vendor_installed_dependencies;
@@ -100,7 +100,7 @@ pub async fn install_deps(
     _action: &mut Action,
     context: &ActionContext,
     workspace: Arc<RwLock<Workspace>>,
-    platform: &SupportedPlatform,
+    platform: &Runtime,
     project_id: Option<&str>,
 ) -> Result<ActionStatus, WorkspaceError> {
     let workspace = workspace.read().await;

--- a/crates/platform-node/src/actions/install_deps.rs
+++ b/crates/platform-node/src/actions/install_deps.rs
@@ -100,11 +100,11 @@ pub async fn install_deps(
     _action: &mut Action,
     context: &ActionContext,
     workspace: Arc<RwLock<Workspace>>,
-    platform: &Runtime,
+    runtime: &Runtime,
     project_id: Option<&str>,
 ) -> Result<ActionStatus, WorkspaceError> {
     let workspace = workspace.read().await;
-    let node = workspace.toolchain.node.get_from_platform(platform)?;
+    let node = workspace.toolchain.node.get_for_runtime(runtime)?;
     let pm = node.get_package_manager();
     let lock_filename = pm.get_lock_filename();
     let manifest_filename = pm.get_manifest_filename();
@@ -139,7 +139,7 @@ pub async fn install_deps(
     let mut last_modified = 0;
     let mut cache = workspace
         .cache
-        .cache_deps_state(platform, project_id)
+        .cache_deps_state(runtime, project_id)
         .await?;
 
     if lock_filepath.exists() {
@@ -156,7 +156,7 @@ pub async fn install_deps(
         debug!(
             target: LOG_TARGET,
             "Installing {} dependencies in {}",
-            platform.label(),
+            runtime.label(),
             color::path(&working_dir)
         );
 

--- a/crates/platform-node/src/actions/run_target.rs
+++ b/crates/platform-node/src/actions/run_target.rs
@@ -92,7 +92,7 @@ pub async fn create_target_command(
     // If a version override exists, use it for the cmmand
     if let Some(node_config) = &project.config.workspace.node {
         if let Some(version_override) = &node_config.version {
-            node = workspace.toolchain.node.get_version(version_override)?;
+            node = workspace.toolchain.node.get_for_version(version_override)?;
         }
     }
 

--- a/crates/platform-node/src/lib.rs
+++ b/crates/platform-node/src/lib.rs
@@ -53,8 +53,8 @@ pub struct NodePlatform {
 }
 
 impl Platform for NodePlatform {
-    fn is(&self, platform: &Runtime) -> bool {
-        matches!(platform, Runtime::Node(_))
+    fn is(&self, runtime: &Runtime) -> bool {
+        matches!(runtime, Runtime::Node(_))
     }
 
     fn is_project_in_package_manager_workspace(

--- a/crates/platform-node/src/lib.rs
+++ b/crates/platform-node/src/lib.rs
@@ -7,7 +7,7 @@ use moon_config::{
     DependencyConfig, DependencyScope, NodeProjectAliasFormat, ProjectConfig, ProjectID,
     ProjectsAliasesMap, ProjectsSourcesMap, TasksConfigsMap, WorkspaceConfig,
 };
-use moon_contract::{Platform, SupportedPlatform};
+use moon_contract::{Platform, Runtime};
 use moon_error::MoonError;
 use moon_lang_node::node::{get_package_manager_workspaces, parse_package_name};
 use moon_lang_node::package::PackageJson;
@@ -53,8 +53,8 @@ pub struct NodePlatform {
 }
 
 impl Platform for NodePlatform {
-    fn is(&self, platform: &SupportedPlatform) -> bool {
-        matches!(platform, SupportedPlatform::Node(_))
+    fn is(&self, platform: &Runtime) -> bool {
+        matches!(platform, Runtime::Node(_))
     }
 
     fn is_project_in_package_manager_workspace(

--- a/crates/platform-system/src/lib.rs
+++ b/crates/platform-system/src/lib.rs
@@ -8,7 +8,7 @@ use moon_contract::{Platform, Runtime};
 pub struct SystemPlatform;
 
 impl Platform for SystemPlatform {
-    fn is(&self, platform: &Runtime) -> bool {
-        matches!(platform, Runtime::System)
+    fn is(&self, runtime: &Runtime) -> bool {
+        matches!(runtime, Runtime::System)
     }
 }

--- a/crates/platform-system/src/lib.rs
+++ b/crates/platform-system/src/lib.rs
@@ -2,13 +2,13 @@ pub mod actions;
 mod hasher;
 
 pub use hasher::SystemTargetHasher;
-use moon_contract::{Platform, SupportedPlatform};
+use moon_contract::{Platform, Runtime};
 
 #[derive(Default)]
 pub struct SystemPlatform;
 
 impl Platform for SystemPlatform {
-    fn is(&self, platform: &SupportedPlatform) -> bool {
-        matches!(platform, SupportedPlatform::System)
+    fn is(&self, platform: &Runtime) -> bool {
+        matches!(platform, Runtime::System)
     }
 }

--- a/crates/runner/src/actions/setup_toolchain.rs
+++ b/crates/runner/src/actions/setup_toolchain.rs
@@ -1,6 +1,6 @@
 use moon_action::{Action, ActionContext, ActionStatus};
 use moon_config::NodeConfig;
-use moon_contract::SupportedPlatform;
+use moon_contract::Runtime;
 use moon_logger::debug;
 use moon_toolchain::tools::node::NodeTool;
 use moon_workspace::{Workspace, WorkspaceError};
@@ -14,9 +14,9 @@ pub async fn setup_toolchain(
     _action: &mut Action,
     _context: &ActionContext,
     workspace: Arc<RwLock<Workspace>>,
-    platform: &SupportedPlatform,
+    platform: &Runtime,
 ) -> Result<ActionStatus, WorkspaceError> {
-    if matches!(platform, SupportedPlatform::System) {
+    if matches!(platform, Runtime::System) {
         return Ok(ActionStatus::Skipped);
     }
 
@@ -39,7 +39,7 @@ pub async fn setup_toolchain(
 
     // Install and setup the specific tool + version in the toolchain!
     let installed = match platform {
-        SupportedPlatform::Node(version) => {
+        Runtime::Node(version) => {
             let node = &mut workspace.toolchain.node;
 
             // The workspace version is pre-registered when the toolchain

--- a/crates/runner/src/actions/setup_toolchain.rs
+++ b/crates/runner/src/actions/setup_toolchain.rs
@@ -14,20 +14,20 @@ pub async fn setup_toolchain(
     _action: &mut Action,
     _context: &ActionContext,
     workspace: Arc<RwLock<Workspace>>,
-    platform: &Runtime,
+    runtime: &Runtime,
 ) -> Result<ActionStatus, WorkspaceError> {
-    if matches!(platform, Runtime::System) {
+    if matches!(runtime, Runtime::System) {
         return Ok(ActionStatus::Skipped);
     }
 
     debug!(
         target: LOG_TARGET,
         "Setting up {} toolchain",
-        platform.label()
+        runtime.label()
     );
 
     let mut workspace = workspace.write().await;
-    let mut cache = workspace.cache.cache_tool_state(platform).await?;
+    let mut cache = workspace.cache.cache_tool_state(runtime).await?;
     let toolchain_paths = workspace.toolchain.get_paths();
 
     // Only check the versions every 12 hours, as checking every
@@ -38,7 +38,7 @@ pub async fn setup_toolchain(
         || (cache.item.last_version_check_time + HOUR_MILLIS * 12) <= now;
 
     // Install and setup the specific tool + version in the toolchain!
-    let installed = match platform {
+    let installed = match runtime {
         Runtime::Node(version) => {
             let node = &mut workspace.toolchain.node;
 

--- a/crates/runner/src/dep_graph.rs
+++ b/crates/runner/src/dep_graph.rs
@@ -368,10 +368,10 @@ impl DepGraph {
         // But we need to wait on all dependent nodes
         for dep_id in project_graph.get_dependencies_of(project)? {
             let dep_project = project_graph.load(&dep_id)?;
-            let dep_platform = self.get_runtime_from_project(&dep_project, project_graph);
+            let dep_runtime = self.get_runtime_from_project(&dep_project, project_graph);
 
             let sync_dep_project_index =
-                self.sync_project(&dep_platform, &dep_project, project_graph)?;
+                self.sync_project(&dep_runtime, &dep_project, project_graph)?;
 
             self.graph
                 .add_edge(sync_project_index, sync_dep_project_index, ());
@@ -457,9 +457,9 @@ impl DepGraph {
         );
 
         // We should install deps & sync projects *before* running targets
-        let platform = self.get_runtime_from_project(project, project_graph);
-        let install_deps_index = self.install_project_deps(&platform, project, project_graph)?;
-        let sync_project_index = self.sync_project(&platform, project, project_graph)?;
+        let runtime = self.get_runtime_from_project(project, project_graph);
+        let install_deps_index = self.install_project_deps(&runtime, project, project_graph)?;
+        let sync_project_index = self.sync_project(&runtime, project, project_graph)?;
         let run_target_index = self.get_or_insert_node(node);
 
         self.graph

--- a/crates/runner/src/dep_graph.rs
+++ b/crates/runner/src/dep_graph.rs
@@ -1,7 +1,7 @@
 use crate::errors::DepGraphError;
 use crate::node::ActionNode;
 use moon_config::{default_node_version, ProjectLanguage, ProjectWorkspaceNodeConfig};
-use moon_contract::SupportedPlatform;
+use moon_contract::Runtime;
 use moon_logger::{color, debug, map_list, trace};
 use moon_project::Project;
 use moon_project_graph::ProjectGraph;
@@ -64,7 +64,7 @@ impl DepGraph {
         &self,
         project: &Project,
         project_graph: &ProjectGraph,
-    ) -> SupportedPlatform {
+    ) -> Runtime {
         match &project.config.language {
             ProjectLanguage::JavaScript | ProjectLanguage::TypeScript => {
                 let version = match &project.config.workspace.node {
@@ -78,16 +78,13 @@ impl DepGraph {
                     },
                 };
 
-                SupportedPlatform::Node(version)
+                Runtime::Node(version)
             }
-            _ => SupportedPlatform::System,
+            _ => Runtime::System,
         }
     }
 
-    pub fn install_deps(
-        &mut self,
-        platform: &SupportedPlatform,
-    ) -> Result<NodeIndex, DepGraphError> {
+    pub fn install_deps(&mut self, platform: &Runtime) -> Result<NodeIndex, DepGraphError> {
         let node = ActionNode::InstallDeps(platform.clone());
 
         if let Some(index) = self.get_index_from_node(&node) {
@@ -111,7 +108,7 @@ impl DepGraph {
 
     pub fn install_project_deps(
         &mut self,
-        platform: &SupportedPlatform,
+        platform: &Runtime,
         project: &Project,
         project_graph: &ProjectGraph,
     ) -> Result<NodeIndex, DepGraphError> {
@@ -261,7 +258,7 @@ impl DepGraph {
         Ok((qualified_targets, inserted_count))
     }
 
-    pub fn setup_tool(&mut self, platform: &SupportedPlatform) -> NodeIndex {
+    pub fn setup_tool(&mut self, platform: &Runtime) -> NodeIndex {
         let node = ActionNode::SetupTool(platform.clone());
 
         if let Some(index) = self.get_index_from_node(&node) {
@@ -345,7 +342,7 @@ impl DepGraph {
 
     pub fn sync_project(
         &mut self,
-        platform: &SupportedPlatform,
+        platform: &Runtime,
         project: &Project,
         project_graph: &ProjectGraph,
     ) -> Result<NodeIndex, DepGraphError> {

--- a/crates/runner/src/emitter.rs
+++ b/crates/runner/src/emitter.rs
@@ -1,7 +1,7 @@
 use crate::subscribers::local_cache::LocalCacheSubscriber;
 use crate::ActionNode;
 use moon_action::Action;
-use moon_contract::{handle_flow, SupportedPlatform};
+use moon_contract::{handle_flow, Runtime};
 use moon_error::MoonError;
 use moon_project::Project;
 use moon_task::Task;
@@ -27,21 +27,21 @@ pub enum Event<'e> {
 
     // Installing deps
     DependenciesInstalling {
-        platform: &'e SupportedPlatform,
+        platform: &'e Runtime,
         project_id: Option<&'e str>,
     },
     DependenciesInstalled {
-        platform: &'e SupportedPlatform,
+        platform: &'e Runtime,
         project_id: Option<&'e str>,
     },
 
     // Syncing projects
     ProjectSyncing {
-        platform: &'e SupportedPlatform,
+        platform: &'e Runtime,
         project_id: &'e str,
     },
     ProjectSynced {
-        platform: &'e SupportedPlatform,
+        platform: &'e Runtime,
         project_id: &'e str,
     },
 
@@ -93,10 +93,10 @@ pub enum Event<'e> {
 
     // Installing a tool
     ToolInstalling {
-        platform: &'e SupportedPlatform,
+        platform: &'e Runtime,
     },
     ToolInstalled {
-        platform: &'e SupportedPlatform,
+        platform: &'e Runtime,
     },
 }
 

--- a/crates/runner/src/emitter.rs
+++ b/crates/runner/src/emitter.rs
@@ -27,22 +27,22 @@ pub enum Event<'e> {
 
     // Installing deps
     DependenciesInstalling {
-        platform: &'e Runtime,
         project_id: Option<&'e str>,
+        runtime: &'e Runtime,
     },
     DependenciesInstalled {
-        platform: &'e Runtime,
         project_id: Option<&'e str>,
+        runtime: &'e Runtime,
     },
 
     // Syncing projects
     ProjectSyncing {
-        platform: &'e Runtime,
         project_id: &'e str,
+        runtime: &'e Runtime,
     },
     ProjectSynced {
-        platform: &'e Runtime,
         project_id: &'e str,
+        runtime: &'e Runtime,
     },
 
     // Runner
@@ -93,10 +93,10 @@ pub enum Event<'e> {
 
     // Installing a tool
     ToolInstalling {
-        platform: &'e Runtime,
+        runtime: &'e Runtime,
     },
     ToolInstalled {
-        platform: &'e Runtime,
+        runtime: &'e Runtime,
     },
 }
 

--- a/crates/runner/src/node.rs
+++ b/crates/runner/src/node.rs
@@ -1,7 +1,15 @@
+use crate::actions;
+use crate::emitter::{Event, RunnerEmitter};
+use crate::errors::ActionRunnerError;
+use moon_action::{Action, ActionContext, ActionStatus};
 use moon_contract::Runtime;
+use moon_platform_node::actions as node_actions;
 use moon_project::ProjectID;
 use moon_task::TargetID;
+use moon_workspace::Workspace;
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 #[derive(Clone, Debug, Eq)]
 pub enum ActionNode {
@@ -40,6 +48,142 @@ impl ActionNode {
                 _ => format!("Setup{}Tool", platform),
             },
             ActionNode::SyncProject(platform, id) => format!("Sync{}Project({})", platform, id),
+        }
+    }
+
+    pub async fn run(
+        &self,
+        action: &mut Action,
+        context: &ActionContext,
+        workspace: Arc<RwLock<Workspace>>,
+        emitter: Arc<RwLock<RunnerEmitter>>,
+    ) -> Result<ActionStatus, ActionRunnerError> {
+        let local_emitter = Arc::clone(&emitter);
+        let local_emitter = local_emitter.read().await;
+
+        match self {
+            // Install dependencies in the workspace root
+            ActionNode::InstallDeps(runtime) => {
+                local_emitter
+                    .emit(Event::DependenciesInstalling {
+                        project_id: None,
+                        runtime,
+                    })
+                    .await?;
+
+                let install_result = match runtime {
+                    Runtime::Node(_) => {
+                        node_actions::install_deps(action, context, workspace, runtime, None)
+                            .await
+                            .map_err(ActionRunnerError::Workspace)
+                    }
+                    _ => Ok(ActionStatus::Passed),
+                };
+
+                local_emitter
+                    .emit(Event::DependenciesInstalled {
+                        project_id: None,
+                        runtime,
+                    })
+                    .await?;
+
+                install_result
+            }
+
+            // Install dependencies in the project root
+            ActionNode::InstallProjectDeps(runtime, project_id) => {
+                local_emitter
+                    .emit(Event::DependenciesInstalling {
+                        project_id: Some(project_id),
+                        runtime,
+                    })
+                    .await?;
+
+                let install_result = match runtime {
+                    Runtime::Node(_) => node_actions::install_deps(
+                        action,
+                        context,
+                        workspace,
+                        runtime,
+                        Some(project_id),
+                    )
+                    .await
+                    .map_err(ActionRunnerError::Workspace),
+                    _ => Ok(ActionStatus::Passed),
+                };
+
+                local_emitter
+                    .emit(Event::DependenciesInstalled {
+                        project_id: Some(project_id),
+                        runtime,
+                    })
+                    .await?;
+
+                install_result
+            }
+
+            // Run a task within a project
+            ActionNode::RunTarget(target_id) => {
+                local_emitter
+                    .emit(Event::TargetRunning { target_id })
+                    .await?;
+
+                let run_result = actions::run_target(
+                    action,
+                    context,
+                    workspace,
+                    Arc::clone(&emitter),
+                    target_id,
+                )
+                .await;
+
+                local_emitter.emit(Event::TargetRan { target_id }).await?;
+
+                run_result
+            }
+
+            // Setup and install the specific tool
+            ActionNode::SetupTool(runtime) => {
+                local_emitter
+                    .emit(Event::ToolInstalling { runtime })
+                    .await?;
+
+                let tool_result = actions::setup_toolchain(action, context, workspace, runtime)
+                    .await
+                    .map_err(ActionRunnerError::Workspace);
+
+                local_emitter.emit(Event::ToolInstalled { runtime }).await?;
+
+                tool_result
+            }
+
+            // Sync a project within the graph
+            ActionNode::SyncProject(runtime, project_id) => {
+                local_emitter
+                    .emit(Event::ProjectSyncing {
+                        project_id,
+                        runtime,
+                    })
+                    .await?;
+
+                let sync_result = match runtime {
+                    Runtime::Node(_) => {
+                        node_actions::sync_project(action, context, workspace, project_id)
+                            .await
+                            .map_err(ActionRunnerError::Workspace)
+                    }
+                    _ => Ok(ActionStatus::Passed),
+                };
+
+                local_emitter
+                    .emit(Event::ProjectSynced {
+                        project_id,
+                        runtime,
+                    })
+                    .await?;
+
+                sync_result
+            }
         }
     }
 }

--- a/crates/runner/src/node.rs
+++ b/crates/runner/src/node.rs
@@ -1,4 +1,4 @@
-use moon_contract::SupportedPlatform;
+use moon_contract::Runtime;
 use moon_project::ProjectID;
 use moon_task::TargetID;
 use std::hash::{Hash, Hasher};
@@ -6,37 +6,37 @@ use std::hash::{Hash, Hasher};
 #[derive(Clone, Debug, Eq)]
 pub enum ActionNode {
     /// Install tool dependencies in the workspace root.
-    InstallDeps(SupportedPlatform),
+    InstallDeps(Runtime),
 
     /// Install tool dependencies in the project root.
-    InstallProjectDeps(SupportedPlatform, ProjectID),
+    InstallProjectDeps(Runtime, ProjectID),
 
     /// Run a target (project task).
     RunTarget(TargetID),
 
     /// Setup a tool + version for the provided platform.
-    SetupTool(SupportedPlatform),
+    SetupTool(Runtime),
 
     /// Sync a project with language specific semantics.
-    SyncProject(SupportedPlatform, ProjectID),
+    SyncProject(Runtime, ProjectID),
 }
 
 impl ActionNode {
     pub fn label(&self) -> String {
         match self {
             ActionNode::InstallDeps(platform) => match platform {
-                SupportedPlatform::Node(version) => format!("Install{}Deps({})", platform, version),
+                Runtime::Node(version) => format!("Install{}Deps({})", platform, version),
                 _ => format!("Install{}Deps", platform),
             },
             ActionNode::InstallProjectDeps(platform, id) => match platform {
-                SupportedPlatform::Node(version) => {
+                Runtime::Node(version) => {
                     format!("Install{}DepsInProject({}, {})", platform, version, id)
                 }
                 _ => format!("Install{}DepsInProject({})", platform, id),
             },
             ActionNode::RunTarget(id) => format!("RunTarget({})", id),
             ActionNode::SetupTool(platform) => match platform {
-                SupportedPlatform::Node(version) => format!("Setup{}Tool({})", platform, version),
+                Runtime::Node(version) => format!("Setup{}Tool({})", platform, version),
                 _ => format!("Setup{}Tool", platform),
             },
             ActionNode::SyncProject(platform, id) => format!("Sync{}Project({})", platform, id),

--- a/crates/runner/src/runner.rs
+++ b/crates/runner/src/runner.rs
@@ -6,7 +6,7 @@ use crate::node::ActionNode;
 use console::Term;
 use moon_action::{Action, ActionContext, ActionStatus};
 use moon_cache::RunReport;
-use moon_contract::SupportedPlatform;
+use moon_contract::Runtime;
 use moon_error::MoonError;
 use moon_logger::{color, debug, error, trace};
 use moon_platform_node::actions as node_actions;
@@ -43,7 +43,7 @@ async fn run_action(
                 .await?;
 
             let install_result = match platform {
-                SupportedPlatform::Node(_) => {
+                Runtime::Node(_) => {
                     node_actions::install_deps(action, context, workspace, platform, None)
                         .await
                         .map_err(ActionRunnerError::Workspace)
@@ -71,7 +71,7 @@ async fn run_action(
                 .await?;
 
             let install_result = match platform {
-                SupportedPlatform::Node(_) => node_actions::install_deps(
+                Runtime::Node(_) => node_actions::install_deps(
                     action,
                     context,
                     workspace,
@@ -135,7 +135,7 @@ async fn run_action(
                 .await?;
 
             let sync_result = match platform {
-                SupportedPlatform::Node(_) => {
+                Runtime::Node(_) => {
                     node_actions::sync_project(action, context, workspace, project_id)
                         .await
                         .map_err(ActionRunnerError::Workspace)

--- a/crates/runner/src/runner.rs
+++ b/crates/runner/src/runner.rs
@@ -1,4 +1,3 @@
-use crate::actions;
 use crate::dep_graph::DepGraph;
 use crate::emitter::{Event, RunnerEmitter};
 use crate::errors::{ActionRunnerError, DepGraphError};
@@ -6,10 +5,8 @@ use crate::node::ActionNode;
 use console::Term;
 use moon_action::{Action, ActionContext, ActionStatus};
 use moon_cache::RunReport;
-use moon_contract::Runtime;
 use moon_error::MoonError;
 use moon_logger::{color, debug, error, trace};
-use moon_platform_node::actions as node_actions;
 use moon_terminal::{replace_style_tokens, ExtendedTerm};
 use moon_utils::time;
 use moon_workspace::Workspace;
@@ -29,130 +26,7 @@ async fn run_action(
     workspace: Arc<RwLock<Workspace>>,
     emitter: Arc<RwLock<RunnerEmitter>>,
 ) -> Result<(), ActionRunnerError> {
-    let local_emitter = Arc::clone(&emitter);
-    let local_emitter = local_emitter.read().await;
-
-    let result = match node {
-        // Install dependencies in the workspace root
-        ActionNode::InstallDeps(runtime) => {
-            local_emitter
-                .emit(Event::DependenciesInstalling {
-                    project_id: None,
-                    runtime,
-                })
-                .await?;
-
-            let install_result = match runtime {
-                Runtime::Node(_) => {
-                    node_actions::install_deps(action, context, workspace, runtime, None)
-                        .await
-                        .map_err(ActionRunnerError::Workspace)
-                }
-                _ => Ok(ActionStatus::Passed),
-            };
-
-            local_emitter
-                .emit(Event::DependenciesInstalled {
-                    project_id: None,
-                    runtime,
-                })
-                .await?;
-
-            install_result
-        }
-
-        // Install dependencies in the project root
-        ActionNode::InstallProjectDeps(runtime, project_id) => {
-            local_emitter
-                .emit(Event::DependenciesInstalling {
-                    project_id: Some(project_id),
-                    runtime,
-                })
-                .await?;
-
-            let install_result = match runtime {
-                Runtime::Node(_) => node_actions::install_deps(
-                    action,
-                    context,
-                    workspace,
-                    runtime,
-                    Some(project_id),
-                )
-                .await
-                .map_err(ActionRunnerError::Workspace),
-                _ => Ok(ActionStatus::Passed),
-            };
-
-            local_emitter
-                .emit(Event::DependenciesInstalled {
-                    project_id: Some(project_id),
-                    runtime,
-                })
-                .await?;
-
-            install_result
-        }
-
-        // Run a task within a project
-        ActionNode::RunTarget(target_id) => {
-            local_emitter
-                .emit(Event::TargetRunning { target_id })
-                .await?;
-
-            let run_result =
-                actions::run_target(action, context, workspace, Arc::clone(&emitter), target_id)
-                    .await;
-
-            local_emitter.emit(Event::TargetRan { target_id }).await?;
-
-            run_result
-        }
-
-        // Setup and install the specific tool
-        ActionNode::SetupTool(runtime) => {
-            local_emitter
-                .emit(Event::ToolInstalling { runtime })
-                .await?;
-
-            let tool_result = actions::setup_toolchain(action, context, workspace, runtime)
-                .await
-                .map_err(ActionRunnerError::Workspace);
-
-            local_emitter.emit(Event::ToolInstalled { runtime }).await?;
-
-            tool_result
-        }
-
-        // Sync a project within the graph
-        ActionNode::SyncProject(runtime, project_id) => {
-            local_emitter
-                .emit(Event::ProjectSyncing {
-                    project_id,
-                    runtime,
-                })
-                .await?;
-
-            let sync_result = match runtime {
-                Runtime::Node(_) => {
-                    node_actions::sync_project(action, context, workspace, project_id)
-                        .await
-                        .map_err(ActionRunnerError::Workspace)
-                }
-                _ => Ok(ActionStatus::Passed),
-            };
-
-            local_emitter
-                .emit(Event::ProjectSynced {
-                    project_id,
-                    runtime,
-                })
-                .await?;
-
-            sync_result
-        }
-    };
-
-    match result {
+    match node.run(action, context, workspace, emitter).await {
         Ok(status) => {
             action.done(status);
         }

--- a/crates/runner/tests/dep_graph_test.rs
+++ b/crates/runner/tests/dep_graph_test.rs
@@ -406,9 +406,9 @@ mod sync_project {
     fn sync_projects(graph: &mut DepGraph, projects: &ProjectGraph, ids: &[&str]) {
         for id in ids {
             let project = projects.load(id).unwrap();
-            let platform = graph.get_runtime_from_project(&project, projects);
+            let runtime = graph.get_runtime_from_project(&project, projects);
 
-            graph.sync_project(&platform, &project, projects).unwrap();
+            graph.sync_project(&runtime, &project, projects).unwrap();
         }
     }
 

--- a/crates/runner/tests/dep_graph_test.rs
+++ b/crates/runner/tests/dep_graph_test.rs
@@ -406,7 +406,7 @@ mod sync_project {
     fn sync_projects(graph: &mut DepGraph, projects: &ProjectGraph, ids: &[&str]) {
         for id in ids {
             let project = projects.load(id).unwrap();
-            let platform = graph.get_platform_from_project(&project, projects);
+            let platform = graph.get_runtime_from_project(&project, projects);
 
             graph.sync_project(&platform, &project, projects).unwrap();
         }

--- a/crates/toolchain/src/manager.rs
+++ b/crates/toolchain/src/manager.rs
@@ -1,15 +1,15 @@
 use crate::{Tool, ToolchainError};
-use moon_contract::SupportedPlatform;
+use moon_contract::Runtime;
 use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct ToolManager<T: Tool> {
     cache: HashMap<String, T>,
-    platform: SupportedPlatform, // Default workspace version
+    platform: Runtime, // Default workspace version
 }
 
 impl<T: Tool> ToolManager<T> {
-    pub fn new(platform: SupportedPlatform) -> Self {
+    pub fn new(platform: Runtime) -> Self {
         ToolManager {
             cache: HashMap::new(),
             platform,
@@ -20,9 +20,9 @@ impl<T: Tool> ToolManager<T> {
         self.get_from_platform(&self.platform)
     }
 
-    pub fn get_from_platform(&self, platform: &SupportedPlatform) -> Result<&T, ToolchainError> {
+    pub fn get_from_platform(&self, platform: &Runtime) -> Result<&T, ToolchainError> {
         match &platform {
-            SupportedPlatform::Node(version) => self.get_version(version),
+            Runtime::Node(version) => self.get_version(version),
             _ => panic!("Unsupported toolchain platform."),
         }
     }
@@ -48,7 +48,7 @@ impl<T: Tool> ToolManager<T> {
         if self.cache.is_empty() && root {
             #[allow(clippy::single_match)]
             match &mut self.platform {
-                SupportedPlatform::Node(ref mut version) => {
+                Runtime::Node(ref mut version) => {
                     *version = tool.get_version();
                 }
                 _ => {

--- a/crates/toolchain/src/manager.rs
+++ b/crates/toolchain/src/manager.rs
@@ -5,33 +5,33 @@ use std::collections::HashMap;
 #[derive(Debug)]
 pub struct ToolManager<T: Tool> {
     cache: HashMap<String, T>,
-    platform: Runtime, // Default workspace version
+    runtime: Runtime, // Default workspace version
 }
 
 impl<T: Tool> ToolManager<T> {
-    pub fn new(platform: Runtime) -> Self {
+    pub fn new(runtime: Runtime) -> Self {
         ToolManager {
             cache: HashMap::new(),
-            platform,
+            runtime,
         }
     }
 
     pub fn get(&self) -> Result<&T, ToolchainError> {
-        self.get_from_platform(&self.platform)
+        self.get_for_runtime(&self.runtime)
     }
 
-    pub fn get_from_platform(&self, platform: &Runtime) -> Result<&T, ToolchainError> {
-        match &platform {
-            Runtime::Node(version) => self.get_version(version),
-            _ => panic!("Unsupported toolchain platform."),
+    pub fn get_for_runtime(&self, runtime: &Runtime) -> Result<&T, ToolchainError> {
+        match &runtime {
+            Runtime::Node(version) => self.get_for_version(version),
+            _ => panic!("Unsupported toolchain runtime."),
         }
     }
 
-    pub fn get_version(&self, version: &str) -> Result<&T, ToolchainError> {
+    pub fn get_for_version(&self, version: &str) -> Result<&T, ToolchainError> {
         if !self.has(version) {
             return Err(ToolchainError::MissingTool(format!(
                 "{} v{}",
-                self.platform, version
+                self.runtime, version
             )));
         }
 
@@ -47,7 +47,7 @@ impl<T: Tool> ToolManager<T> {
         // workspace tool. If so, update the default version within the platform.
         if self.cache.is_empty() && root {
             #[allow(clippy::single_match)]
-            match &mut self.platform {
+            match &mut self.runtime {
                 Runtime::Node(ref mut version) => {
                     *version = tool.get_version();
                 }

--- a/crates/toolchain/src/toolchain.rs
+++ b/crates/toolchain/src/toolchain.rs
@@ -4,7 +4,7 @@ use crate::manager::ToolManager;
 use crate::tools::node::NodeTool;
 use moon_config::WorkspaceConfig;
 use moon_constants::CONFIG_DIRNAME;
-use moon_contract::SupportedPlatform;
+use moon_contract::Runtime;
 use moon_logger::{color, debug, trace};
 use moon_utils::{fs, path};
 use std::path::{Path, PathBuf};
@@ -60,7 +60,7 @@ impl Toolchain {
         let mut toolchain = Toolchain {
             dir,
             // Tools
-            node: ToolManager::new(SupportedPlatform::Node("latest".into())),
+            node: ToolManager::new(Runtime::Node("latest".into())),
         };
 
         let paths = toolchain.get_paths();

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -8,6 +8,9 @@
   - Projects can now override the workspace configured Node.js version on a per-project basis using
     the new `workspace.node.version` setting in `moon.yml`. However, this does not override the
     package manager!
+  - Package managers workspaces (via `package.json`) are no longer required. When not enabled, or a
+    project is not within the workspace, it will install dependencies directly within the project
+    root, and will utilize its own lockfile.
 - Generator
   - Template files can now be suffixed with `.tera` or `.twig` for syntax highlighting.
 - Runner
@@ -15,6 +18,10 @@
     can be toggled with the `runner.logRunningCommand` setting.
   - The dedupe command will now be displayed when running if the `node.dedupeOnLockfileChange`
     setting is enabled.
+
+#### 📚 Docs
+
+- Config file settings will now link to their API types.
 
 #### ⚙️ Internal
 

--- a/website/docs/terminology.md
+++ b/website/docs/terminology.md
@@ -2,36 +2,38 @@
 title: Terminology
 ---
 
-| Term                          | Description                                                                                                                                |
-| :---------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------- |
-| Action                        | A node within the dependency graph that gets executed by the action runner.                                                                |
-| Action runner                 | Executes actions from our dependency graph in topological order.                                                                           |
-| Affected                      | Touched by an explicit set of inputs or sources.                                                                                           |
-| Cache                         | Files and outputs that are stored on the file system to provide incremental builds and increased performance.                              |
-| CI                            | Continuous integration. An environment where tests, builds, lints, etc, are continuously ran on every pull/merge request.                  |
-| Dependency graph              | A directed acyclic graph (DAG) of targets to run and their dependencies.                                                                   |
-| Downstream                    | Dependents or consumers of the item in question.                                                                                           |
-| [Generator](./guides/codegen) | Generates code from pre-defined templates.                                                                                                 |
-| Hash                          | A unique SHA256 identifier that represents the result of a ran task.                                                                       |
-| Hashing                       | The mechanism of generating a hash based on multiple sources: inputs, dependencies, configs, etc.                                          |
-| LTS                           | Long-term support.                                                                                                                         |
-| Package manager               | Installs and manages dependencies for a specific tool (`npm`), using a manifest file (`package.json`).                                     |
-| Primary target                | The target that was explicitly ran, and is the dependee of transitive targets.                                                             |
-| [Project][project]            | An collection of source and test files, configurations, a manifest and dependencies, and much more. Exists within a [workspace][workspace] |
-| Revision                      | In the context of a VCS: a branch, revision, commit, hash, or point in history.                                                            |
-| [Target][target]              | A label and reference to a task within the project, in the format of `project:task`.                                                       |
-| [Task][task]                  | A command to run within the context of and configured in a [project][project].                                                             |
-| Template                      | A collection of files that get scaffolded by a generator.                                                                                  |
-| Template file                 | An individual file within a template.                                                                                                      |
-| Template variable             | A value that is interpolated within a template file and its file system path.                                                              |
-| [Token][token]                | A value within task configuration that is substituted at runtime.                                                                          |
-| Tool                          | A programming language or package manager within the [toolchain][toolchain].                                                               |
-| Touched                       | A file that has been created, modified, deleted, or changed in any way.                                                                    |
-| [Toolchain][toolchain]        | Installs and manages tools within the [workspace][workspace].                                                                              |
-| Transitive target             | A target that is the dependency of the primary target, and must be ran before the primary.                                                 |
-| Upstream                      | Dependencies or producers of the item in question.                                                                                         |
-| VCS                           | Version control system (like git or svn).                                                                                                  |
-| [Workspace][workspace]        | Root of the moon installation, and houses one or many [projects][project]. _Also refers to package manager workspaces (like Yarn)._        |
+| Term                          | Description                                                                                                                                             |
+| :---------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Action                        | A node within the dependency graph that gets executed by the action runner.                                                                             |
+| Action runner                 | Executes actions from our dependency graph in topological order.                                                                                        |
+| Affected                      | Touched by an explicit set of inputs or sources.                                                                                                        |
+| Cache                         | Files and outputs that are stored on the file system to provide incremental builds and increased performance.                                           |
+| CI                            | Continuous integration. An environment where tests, builds, lints, etc, are continuously ran on every pull/merge request.                               |
+| Dependency graph              | A directed acyclic graph (DAG) of targets to run and their dependencies.                                                                                |
+| Downstream                    | Dependents or consumers of the item in question.                                                                                                        |
+| [Generator](./guides/codegen) | Generates code from pre-defined templates.                                                                                                              |
+| Hash                          | A unique SHA256 identifier that represents the result of a ran task.                                                                                    |
+| Hashing                       | The mechanism of generating a hash based on multiple sources: inputs, dependencies, configs, etc.                                                       |
+| LTS                           | Long-term support.                                                                                                                                      |
+| Package manager               | Installs and manages dependencies for a specific tool (`npm`), using a manifest file (`package.json`).                                                  |
+| Platform                      | An internal concept representing the integration of a programming language (tool) within moon, and also the environment + language that a task runs in. |
+| Primary target                | The target that was explicitly ran, and is the dependee of transitive targets.                                                                          |
+| [Project][project]            | An collection of source and test files, configurations, a manifest and dependencies, and much more. Exists within a [workspace][workspace]              |
+| Revision                      | In the context of a VCS: a branch, revision, commit, hash, or point in history.                                                                         |
+| Runtime                       | An internal concept representing the platform + version of a tool.                                                                                      |
+| [Target][target]              | A label and reference to a task within the project, in the format of `project:task`.                                                                    |
+| [Task][task]                  | A command to run within the context of and configured in a [project][project].                                                                          |
+| Template                      | A collection of files that get scaffolded by a generator.                                                                                               |
+| Template file                 | An individual file within a template.                                                                                                                   |
+| Template variable             | A value that is interpolated within a template file and its file system path.                                                                           |
+| [Token][token]                | A value within task configuration that is substituted at runtime.                                                                                       |
+| Tool                          | A programming language or package manager within the [toolchain][toolchain].                                                                            |
+| [Toolchain][toolchain]        | Installs and manages tools within the [workspace][workspace].                                                                                           |
+| Transitive target             | A target that is the dependency of the primary target, and must be ran before the primary.                                                              |
+| Touched                       | A file that has been created, modified, deleted, or changed in any way.                                                                                 |
+| Upstream                      | Dependencies or producers of the item in question.                                                                                                      |
+| VCS                           | Version control system (like git or svn).                                                                                                               |
+| [Workspace][workspace]        | Root of the moon installation, and houses one or many [projects][project]. _Also refers to package manager workspaces (like Yarn)._                     |
 
 [project]: ./concepts/project
 [target]: ./concepts/target


### PR DESCRIPTION
The term platform was being overloaded. This refactors the enum to use "runtime" which is a combination of platform + version.