### PR TITLE
docs: Add links to API types for config settings.

### DIFF
--- a/packages/types/src/template-config.ts
+++ b/packages/types/src/template-config.ts
@@ -1,31 +1,29 @@
 // template.yml
 
-export interface TemplateBooleanVariableConfig {
-	default: boolean;
+export interface TemplateVariableConfig<T> {
+	default: T;
 	prompt: string | null;
 	required: boolean | null;
+}
+
+export interface TemplateBooleanVariableConfig
+	extends Omit<TemplateVariableConfig<boolean>, 'required'> {
 	type: 'boolean';
 }
 
-export interface TemplateEnumVariableConfig {
-	default: string;
+export interface TemplateEnumVariableConfig
+	extends Omit<TemplateVariableConfig<string>, 'prompt' | 'required'> {
 	multiple: boolean | null;
 	prompt: string;
 	type: 'enum';
 	values: string[];
 }
 
-export interface TemplateNumberVariableConfig {
-	default: number;
-	prompt: string | null;
-	required: boolean | null;
+export interface TemplateNumberVariableConfig extends TemplateVariableConfig<number> {
 	type: 'number';
 }
 
-export interface TemplateStringVariableConfig {
-	default: string;
-	prompt: string | null;
-	required: boolean | null;
+export interface TemplateStringVariableConfig extends TemplateVariableConfig<string> {
 	type: 'string';
 }
 
@@ -37,7 +35,7 @@ export type TemplateVariable =
 
 export interface TemplateConfig {
 	description: string;
-	tite: string;
+	title: string;
 	variables: Record<string, TemplateVariable>;
 }
 

--- a/website/docs/config/global-project.mdx
+++ b/website/docs/config/global-project.mdx
@@ -2,6 +2,7 @@
 title: .moon/project.yml
 ---
 
+import HeadingApiLink from '@site/src/components/Docs/HeadingApiLink';
 import VersionLabel from '@site/src/components/Docs/VersionLabel';
 
 The `.moon/project.yml` file configures file groups and tasks that are inherited by _every_ project
@@ -10,7 +11,7 @@ in the workspace. Projects can override or merge with these settings within thei
 
 ## `extends`<VersionLabel version="0.4" />
 
-> `string`
+<HeadingApiLink to="/api/types/interface/GlobalProjectConfig#extends" />
 
 Defines an external `.moon/project.yml` to extend and inherit settings from. Perfect for reusability
 and sharing configuration across repositories and projects. When defined, this setting must be an
@@ -30,7 +31,7 @@ values _are not_ deep merged!
 
 ## `fileGroups`
 
-> `Record<string, string[]>`
+<HeadingApiLink to="/api/types/interface/GlobalProjectConfig#fileGroups" />
 
 > For more information on file group configuration, refer to the
 > [`fileGroups`](./project#filegroups) section in the [`moon.yml`](./project) doc.
@@ -62,7 +63,7 @@ fileGroups:
 
 ## `tasks`
 
-> `Record<string, TaskConfig>`
+<HeadingApiLink to="/api/types/interface/GlobalProjectConfig#tasks" />
 
 > For more information on task configuration, refer to the [`tasks`](./project#tasks) section in the
 > [`moon.yml`](./project) doc.

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -396,7 +396,7 @@ tasks:
 
 ### `options`
 
-<HeadingApiLink to="/api/types/interface/TaskOptionsConfig" />
+<HeadingApiLink to="/api/types/interface/TaskConfig#options" />
 
 The `options` field is an object of configurable options that can be used to modify the task and its
 execution. The following fields can be provided, with merge related fields supporting all
@@ -599,6 +599,8 @@ tasks:
 Dictates how a project interacts with settings defined at the workspace-level.
 
 ## `workspace`
+
+<HeadingApiLink to="/api/types/interface/ProjectConfig#workspace" />
 
 ### `inheritedTasks`
 

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -3,6 +3,7 @@ title: moon.yml
 toc_max_heading_level: 6
 ---
 
+import HeadingApiLink from '@site/src/components/Docs/HeadingApiLink';
 import RequiredLabel from '@site/src/components/Docs/RequiredLabel';
 import VersionLabel from '@site/src/components/Docs/VersionLabel';
 
@@ -13,7 +14,7 @@ project-level. When used, this file must exist in a project's root, as configure
 
 ## `dependsOn`<VersionLabel updated version="0.9" />
 
-> `(ProjectID | DependencyConfig)[]`
+<HeadingApiLink to="/api/types/interface/ProjectConfig#dependsOn" />
 
 Explicitly defines _other_ projects that _this_ project depends on, primarily when generating the
 project and task graphs. The most common use case for this is building those projects _before_
@@ -48,7 +49,7 @@ dependsOn:
 
 ## `language`<VersionLabel version="0.3" />
 
-> `ProjectLanguage`
+<HeadingApiLink to="/api/types/interface/ProjectConfig#language" />
 
 The primary programming language the project is written in. Supports the following values:
 
@@ -71,7 +72,7 @@ language: 'javascript'
 
 ## `project`
 
-> `ProjectMetadataConfig`
+<HeadingApiLink to="/api/types/interface/ProjectConfig#project" />
 
 The `project` setting defines metadata about the project itself. Although this setting is optional,
 when defined, all fields within it _must_ be defined as well.
@@ -91,41 +92,41 @@ organize all projects. Feel free to build your own tooling around these settings
 
 ### `channel`
 
-> `string`
+<HeadingApiLink to="/api/types/interface/ProjectMetadataConfig#channel" />
 
 The Slack, Discord, Teams, IRC, etc channel name (with leading #) in which to discuss the project.
 
 ### `description`
 
-> `string`
+<HeadingApiLink to="/api/types/interface/ProjectMetadataConfig#description" />
 
 A description of what the project does and aims to achieve. Be as descriptive as possible, as this
 is the kind of information search engines would index on.
 
 ### `maintainers`
 
-> `string[]`
+<HeadingApiLink to="/api/types/interface/ProjectMetadataConfig#maintainers" />
 
 A list of people/developers that maintain the project, review code changes, and can provide support.
 Can be a name, email, LDAP name, GitHub username, etc, the choice is yours.
 
 ### `name`
 
-> `string`
+<HeadingApiLink to="/api/types/interface/ProjectMetadataConfig#name" />
 
 A human readable name of the project. This is _different_ from the unique project name configured in
 [`projects`](./workspace#projects).
 
 ### `owner`
 
-> `string`
+<HeadingApiLink to="/api/types/interface/ProjectMetadataConfig#owner" />
 
 The team or organization that owns the project. Can be a title, LDAP name, GitHub team, etc. We
 suggest _not_ listing people/developers as the owner, use [maintainers](#maintainers) instead.
 
 ## `type`
 
-> `ProjectType`
+<HeadingApiLink to="/api/types/interface/ProjectMetadataConfig#type" />
 
 The type of project. Supports the following values:
 
@@ -142,7 +143,7 @@ type: 'application'
 
 ## `fileGroups`
 
-> `Record<string, string[]>`
+<HeadingApiLink to="/api/types/interface/ProjectConfig#fileGroups" />
 
 Defines [file groups](../concepts/file-group) to be used by local tasks. By default, this setting
 _is not required_ for the following reasons:
@@ -179,7 +180,7 @@ fileGroups:
 
 ## `tasks`
 
-> `Record<string, TaskConfig>`
+<HeadingApiLink to="/api/types/interface/ProjectConfig#tasks" />
 
 Tasks are actions that are ran within the context of a [project](../concepts/project), and commonly
 wrap an npm binary or system command. This setting requires a map, where the key is a unique name
@@ -199,7 +200,7 @@ tasks:
 
 ### `command`<RequiredLabel />
 
-> `string | string[]`
+<HeadingApiLink to="/api/types/interface/TaskConfig#command" />
 
 The `command` field is the command line to run for the task, including the command name (must be
 first) and any optional [arguments](#args). This field is required when _not_ inheriting a global
@@ -243,7 +244,7 @@ For interoperability reasons, the following command names have special handling.
 
 ### `args`
 
-> `string | string[]`
+<HeadingApiLink to="/api/types/interface/TaskConfig#args" />
 
 The `args` field is a collection of _additional_ arguments to pass to the command line when
 executing the task. This field exists purely to provide arguments for
@@ -284,7 +285,7 @@ tasks:
 
 ### `deps`
 
-> `Target[]`
+<HeadingApiLink to="/api/types/interface/TaskConfig#deps" />
 
 The `deps` field is a list of other tasks (known as [targets](../concepts/target)), either within
 this project or found in another project, that will be executed _before_ this task. It achieves this
@@ -301,7 +302,7 @@ tasks:
 
 ### `env`
 
-> `Record<string, string>`
+<HeadingApiLink to="/api/types/interface/TaskConfig#env" />
 
 The `env` field is map of strings that are passed as environment variables when running the command.
 Variables defined here will take precedence over those loaded with [`envFile`](#envfile).
@@ -316,7 +317,7 @@ tasks:
 
 ### `inputs`<VersionLabel updated version="0.9" />
 
-> `string[]`
+<HeadingApiLink to="/api/types/interface/TaskConfig#inputs" />
 
 The `inputs` field is a list of sources that calculate whether to execute this task based on the
 environment and files that have been touched since the last time the task has been ran. If _not_
@@ -352,7 +353,7 @@ always run and bypass the cache.
 
 ### `local`<VersionLabel version="0.11" />
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/TaskConfig#local" />
 
 Marks the task as local only. This should primarily be enabled for long-running or never-ending
 tasks, like development servers and watch mode. Defaults to `true` if the task name is "dev",
@@ -373,7 +374,7 @@ tasks:
 
 ### `outputs`
 
-> `string[]`
+<HeadingApiLink to="/api/types/interface/TaskConfig#outputs" />
 
 The `outputs` field is a list of files and folders that are _created_ as a result of executing this
 task, excluding internal cache files that are created from the underlying command (for example,
@@ -395,7 +396,7 @@ tasks:
 
 ### `options`
 
-> `TaskOptionsConfig`
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig" />
 
 The `options` field is an object of configurable options that can be used to modify the task and its
 execution. The following fields can be provided, with merge related fields supporting all
@@ -412,7 +413,7 @@ tasks:
 
 #### `cache`<VersionLabel version="0.9" />
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#cache" />
 
 Whether to cache the task's execution result using our [smart hashing](../concepts/cache#hashing)
 system. If disabled, _will not_ create a cache hash, and _will not_ persist a task's
@@ -431,7 +432,7 @@ tasks:
 
 #### `envFile`<VersionLabel version="0.11" />
 
-> `boolean | string`
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#envFile" />
 
 A boolean or path to a project relative file (also know as dotenv file) that defines a collection of
 [environment variables](#env) for the current task. Variables will be loaded on project creation,
@@ -450,42 +451,42 @@ tasks:
 
 #### `mergeArgs`
 
-> `TaskMergeStrategy`
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#mergeArgs" />
 
 The [strategy](../concepts/task#merge-strategies) to use when merging the [`args`](#args) list with
 an inherited task. Defaults to "append".
 
 #### `mergeDeps`
 
-> `TaskMergeStrategy`
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#mergeDeps" />
 
 The [strategy](../concepts/task#merge-strategies) to use when merging the [`deps`](#deps) list with
 an inherited task. Defaults to "append".
 
 #### `mergeEnv`
 
-> `TaskMergeStrategy`
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#mergeEnv" />
 
 The [strategy](../concepts/task#merge-strategies) to use when merging the [`env`](#env) map with an
 inherited task. Defaults to "append".
 
 #### `mergeInputs`
 
-> `TaskMergeStrategy`
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#mergeInputs" />
 
 The [strategy](../concepts/task#merge-strategies) to use when merging the [`inputs`](#inputs) list
 with an inherited task. Defaults to "append".
 
 #### `mergeOutputs`
 
-> `TaskMergeStrategy`
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#mergeOutputs" />
 
 The [strategy](../concepts/task#merge-strategies) to use when merging the [`outputs`](#outputs) list
 with an inherited task. Defaults to "append".
 
 #### `outputStyle`<VersionLabel version="0.10" />
 
-> `TaskOutputStyle`
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#outputStyle" />
 
 Controls how stdout/stderr is displayed when the task is ran as a _transitive target_. By default,
 this setting is not defined and defers to the action runner, but can be overridden with one of the
@@ -510,7 +511,7 @@ tasks:
 
 #### `retryCount`
 
-> `number`
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#retryCount" />
 
 The number of attempts the task will retry execution before returning a failure. This is especially
 useful for flaky tasks. Defaults to `0`.
@@ -525,7 +526,7 @@ tasks:
 
 #### `runDepsInParallel`<VersionLabel version="0.10" />
 
-> boolean
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#runDepsInParallel" />
 
 Whether to run the task's [`deps`](#deps) in parallel or serial (in order). Defaults to `true`.
 
@@ -542,7 +543,7 @@ tasks:
 
 #### `runInCI`
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#runInCI" />
 
 Whether to run the task automatically in a CI (continuous integration) environment when affected by
 touched files, typically through the [`moon ci`](../commands/ci) command. Defaults to `true` unless
@@ -559,7 +560,7 @@ tasks:
 
 #### `runFromWorkspaceRoot`
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#runFromWorkspaceRoot" />
 
 Whether to use the workspace root as the working directory when executing a task. Defaults to
 `false` and runs from the task's project root.
@@ -573,6 +574,8 @@ tasks:
 ```
 
 ### `type`
+
+<HeadingApiLink to="/api/types/interface/TaskConfig#type" />
 
 The `type` field defines the type of command to run, where to locate its executable, and which tool
 to execute it with. By default will set to a value based on the project's [`language`](#language).
@@ -599,11 +602,11 @@ Dictates how a project interacts with settings defined at the workspace-level.
 
 ### `inheritedTasks`
 
+<HeadingApiLink to="/api/types/interface/ProjectWorkspaceConfig#inheritedTasks" />
+
 Provides a layer of control when inheriting tasks from [`.moon/project.yml`](./global-project).
 
 #### `exclude`
-
-> `string[]`
 
 The optional `exclude` setting permits a project to exclude specific tasks from being inherited. It
 accepts a list of strings, where each string is the name of a global task to exclude.
@@ -618,8 +621,6 @@ workspace:
 > Exclusion is applied after inclusion and before renaming.
 
 #### `include`
-
-> `string[]`
 
 The optional `include` setting permits a project to _only_ include specific inherited tasks (works
 like an allow/white list). It accepts a list of strings, where each string is the name of a global
@@ -643,8 +644,6 @@ workspace:
 
 #### `rename`
 
-> `Record<string, string>`
-
 The optional `rename` setting permits a project to rename the inherited task within the current
 project. It accepts a map of strings, where the key is the original name (found in the global
 project config), and the value is the new name to use.
@@ -664,14 +663,12 @@ workspace:
 
 ### `node`<VersionLabel version="0.16" />
 
-> `ProjectWorkspaceNodeConfig`
+<HeadingApiLink to="/api/types/interface/ProjectWorkspaceConfig#node" />
 
 Configures Node.js for this project and overrides the workspace-level [`node`](./workspace#node)
 setting. Currently, only the Node.js version can be overridden per-project, not the package manager.
 
 #### `version`
-
-> `string`
 
 Defines the explicit Node.js version to use when _running tasks_ for this project.
 
@@ -683,7 +680,7 @@ workspace:
 
 ### `typescript`<VersionLabel version="0.12" />
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/ProjectWorkspaceConfig#typescript" />
 
 Enables or disables [TypeScript support](./workspace#typescript) for this project. Currently
 controls project reference syncing and `tsconfig.json` creation. Defaults to `true`.

--- a/website/docs/config/template.mdx
+++ b/website/docs/config/template.mdx
@@ -3,6 +3,7 @@ title: template.yml
 toc_max_heading_level: 6
 ---
 
+import HeadingApiLink from '@site/src/components/Docs/HeadingApiLink';
 import RequiredLabel from '@site/src/components/Docs/RequiredLabel';
 import VersionLabel from '@site/src/components/Docs/VersionLabel';
 
@@ -13,7 +14,7 @@ The `template.yml` file configures metadata and variables for a template,
 
 ## `title`<RequiredLabel />
 
-> `string`
+<HeadingApiLink to="/api/types/interface/TemplateConfig#title" />
 
 A human readable title that will be displayed during the [`moon generate`](../commands/generate)
 process.
@@ -24,7 +25,7 @@ title: 'npm package'
 
 ## `description`<RequiredLabel />
 
-> `string`
+<HeadingApiLink to="/api/types/interface/TemplateConfig#description" />
 
 A description of why the template exists, what its purpose is, and any other relevant information.
 
@@ -36,7 +37,7 @@ description: |
 
 ## `variables`
 
-> `Record<string, TemplateVariableConfig>`
+<HeadingApiLink to="/api/types/interface/TemplateConfig#variables" />
 
 A mapping of variables that will be interpolated into all template files and file system paths when
 [rendering with Tera](https://tera.netlify.app/docs/#variables). The map key is the variable name
@@ -54,7 +55,7 @@ variables:
 
 ### `default`<RequiredLabel />
 
-> `T`
+<HeadingApiLink to="/api/types/interface/TemplateVariableConfig#default" />
 
 The default value of the variable. When `--defaults` is passed to
 [`moon generate`](../commands/generate) or [`prompt`](#prompt) is not defined, the default value
@@ -62,14 +63,12 @@ will be used, otherwise the user will be prompted to enter a custom value.
 
 ### `prompt`<RequiredLabel text="Required for enums" />
 
-> `string`
+<HeadingApiLink to="/api/types/interface/TemplateVariableConfig#prompt" />
 
 When defined, will prompt the user with a message in the terminal to input a custom value, otherwise
 [`default`](#default) will be used.
 
 ### `type`<RequiredLabel />
-
-> `boolean | enum | number | string`
 
 The type of value for the variable. Accepts `boolean`, `string`, `number`, or `enum`. Floats _are
 not supported_, use strings instead.
@@ -79,6 +78,8 @@ not supported_, use strings instead.
 Your basic primitives.
 
 ### `required`
+
+<HeadingApiLink to="/api/types/interface/TemplateVariableConfig#required" />
 
 Marks the variable as required during _prompting only_. For strings, will error for empty values
 (`''`). For numbers, will error for zero's (`0`).
@@ -107,14 +108,14 @@ variables:
 
 ### `multiple`
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/TemplateEnumVariableConfig#multiple" />
 
 Allows multiple values to be chosen during prompting. In the template, an array or strings will be
 rendered, otherwise when not-multiple, a single string will be.
 
 ### `values`<RequiredLabel />
 
-> `string[]`
+<HeadingApiLink to="/api/types/interface/TemplateEnumVariableConfig#values" />
 
 List of explicit values to choose from.
 
@@ -126,7 +127,7 @@ information.
 
 ### `force`
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/TemplateFrontmatterConfig#force" />
 
 When enabled, will always overwrite a file of the same name at the destination path, and will bypass
 any prompting in the terminal.
@@ -141,7 +142,7 @@ Some template content!
 
 ### `to`
 
-> `string`
+<HeadingApiLink to="/api/types/interface/TemplateFrontmatterConfig#to" />
 
 Defines a custom file path, relative from the destination root, in which to create the file. This
 will override the file path within the template folder, and allow for conditional rendering and
@@ -161,7 +162,7 @@ export function {{ component_name }}() {
 
 ### `skip`
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/TemplateFrontmatterConfig#skip" />
 
 When enabled, the template file will be skipped while writing to the destination path. This setting
 can be used to conditionally render a file.

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -5,6 +5,7 @@ toc_max_heading_level: 6
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import HeadingApiLink from '@site/src/components/Docs/HeadingApiLink';
 import RequiredLabel from '@site/src/components/Docs/RequiredLabel';
 import VersionLabel from '@site/src/components/Docs/VersionLabel';
 
@@ -13,7 +14,7 @@ the workspace development environment.
 
 ## `extends`<VersionLabel version="0.4" />
 
-> `string`
+<HeadingApiLink to="/api/types/interface/WorkspaceConfig#extends" />
 
 Defines an external `.moon/workspace.yml` to extend and inherit settings from. Perfect for
 reusability and sharing configuration across repositories and projects. When defined, this setting
@@ -33,7 +34,7 @@ _does not merge_!
 
 ## `projects`<RequiredLabel />
 
-> `Record<string, string> | string[]`
+<HeadingApiLink to="/api/types/interface/WorkspaceConfig#projects" />
 
 Defines the location of all [projects](../concepts/project) within the workspace. Supports either a
 manual map of projects (default), _or_ a list of globs in which to automatically locate projects.
@@ -90,7 +91,7 @@ projects:
 
 ## `node`
 
-> `NodeConfig`
+<HeadingApiLink to="/api/types/interface/WorkspaceConfig#node" />
 
 Defines the Node.js version and package manager to install within the toolchain, as moon _does not_
 use a Node.js binary found on the local machine. Managing the Node.js version within the toolchain
@@ -99,7 +100,7 @@ machine).
 
 ### `version`
 
-> `string`
+<HeadingApiLink to="/api/types/interface/NodeConfig#version" />
 
 Defines the explicit Node.js version to use. We require an explicit and semantic major, minor, and
 patch version, to ensure the same environment is used across every machine. Ranges are _not_
@@ -114,7 +115,7 @@ node:
 
 ### `packageManager`
 
-> `npm | pnpm | yarn`
+<HeadingApiLink to="/api/types/interface/NodeConfig#packageManager" />
 
 Defines which package manager to utilize within the workspace. Supports `npm` (default), `pnpm`, or
 `yarn`.
@@ -126,7 +127,7 @@ node:
 
 ### `npm`, `pnpm`, `yarn`
 
-> `PackageManagerConfig`
+<HeadingApiLink to="/api/types/interface/NodePackageManagerConfig" />
 
 Optional fields for defining package manager specific configuration. The chosen setting is dependent
 on the value of [`node.packageManager`](#packagemanager). If these settings _are not defined_, the
@@ -134,7 +135,7 @@ latest version of the active package manager will be used (when applicable).
 
 #### `version`
 
-> `string`
+<HeadingApiLink to="/api/types/interface/NodePackageManagerConfig#version" />
 
 The `version` setting defines the explicit package manager version to use. We require an explicit
 major, minor, and patch version, to ensure the same environment is used across every machine.
@@ -151,9 +152,11 @@ node:
 
 ### `yarn`
 
+<HeadingApiLink to="/api/types/interface/NodeConfig#yarn" />
+
 #### `plugins`
 
-> `string[]`
+<HeadingApiLink to="/api/types/interface/YarnConfig#plugins" />
 
 A list of plugins that will automatically be imported using `yarn plugin import` (Yarn 2+ only). For
 performance reasons, plugins will only be imported when the Yarn version changes.
@@ -170,7 +173,7 @@ node:
 
 ### `addEnginesConstraint`
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/NodeConfig#addEnginesConstraint" />
 
 Injects the currently configured [Node.js version](#version) as an `engines` constraint to the root
 `package.json` field. Defaults to `true`.
@@ -195,7 +198,7 @@ ensure other Node.js processes outside of our toolchain are utilizing the same v
 
 ### `aliasPackageNames`<VersionLabel version="0.10" />
 
-> `NodeProjectAliasFormat`
+<HeadingApiLink to="/api/types/interface/NodeConfig#aliasPackageNames" />
 
 When enabled, will assign [aliases](../concepts/project#aliases) to configured [projects](#projects)
 based on the `name` field in the project's `package.json`. Aliases can be used as a substitute for
@@ -217,7 +220,7 @@ node:
 
 ### `dedupeOnLockfileChange`
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/NodeConfig#dedupeOnLockfileChange" />
 
 Will dedupe dependencies after they have been installed, added, removing, or changed in any way, in
 an effort to keep the workspace tree as clean and lean as possible. Defaults to `true`.
@@ -229,7 +232,7 @@ node:
 
 ### `dependencyVersionFormat`<VersionLabel version="0.9" />
 
-> `NodeVersionFormat`
+<HeadingApiLink to="/api/types/interface/NodeConfig#dependencyVersionFormat" />
 
 When [syncing project dependencies](#syncprojectworkspacedependencies), customize the format that
 will be used for the dependency version range. The following formats are supported (but use the one
@@ -258,7 +261,7 @@ node:
 
 ### `inferTasksFromScripts`<VersionLabel version="0.8" />
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/NodeConfig#inferTasksFromScripts" />
 
 Will infer and automatically create [tasks](../concepts/task) from `package.json` scripts. Defaults
 to `false`.
@@ -290,7 +293,7 @@ this feature, especially in regards to `runInCI`, as it may be inaccurate!
 
 ### `syncProjectWorkspaceDependencies`
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/NodeConfig#syncProjectWorkspaceDependencies" />
 
 Will sync a project's [`dependsOn`](./project#dependson) setting as normal dependencies within the
 project's `package.json`. If a dependent project does not have a `package.json`, or if a dependency
@@ -326,7 +329,7 @@ can be customized with [`node.dependencyVersionFormat`](#dependencyversionformat
 
 ### `syncVersionManagerConfig`
 
-> `(none) | nodenv | nvm`
+<HeadingApiLink to="/api/types/interface/NodeConfig#syncVersionManagerConfig" />
 
 Will sync the currently configured [Node.js version](#version) to a 3rd-party version manager's
 config/rc file. Supports "nodenv" (syncs to `.node-version`), "nvm" (syncs to `.nvmrc`), or none
@@ -342,14 +345,14 @@ the same version, which is a very common practice when managing dependencies.
 
 ## `typescript`<VersionLabel updated version="0.12" />
 
-> `TypeScriptConfig`
+<HeadingApiLink to="/api/types/interface/WorkspaceConfig#typescript" />
 
 Dictates how moon interacts with and utilizes TypeScript within the workspace. This field is
 optional and is undefined by default. Define it to enable TypeScript support.
 
 ### `createMissingConfig`<VersionLabel version="0.6" />
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/TypeScriptConfig#createMissingConfig" />
 
 When [syncing project references](#syncprojectreferences) and a depended on project _does not_ have
 a `tsconfig.json`, automatically create one. Defaults to `true`.
@@ -361,7 +364,7 @@ typescript:
 
 ### `projectConfigFileName`
 
-> `string`
+<HeadingApiLink to="/api/types/interface/TypeScriptConfig#projectConfigFileName" />
 
 Defines the file name of the `tsconfig.json` found in the project root. We utilize this setting when
 syncing project references between projects. Defaults to `tsconfig.json`.
@@ -373,7 +376,7 @@ typescript:
 
 ### `rootConfigFileName`
 
-> `string`
+<HeadingApiLink to="/api/types/interface/TypeScriptConfig#rootConfigFileName" />
 
 Defines the file name of the `tsconfig.json` found in the workspace root. We utilize this setting
 when syncing projects as references. Defaults to `tsconfig.json`.
@@ -385,7 +388,7 @@ typescript:
 
 ### `rootOptionsConfigFileName`<VersionLabel version="0.6" />
 
-> `string`
+<HeadingApiLink to="/api/types/interface/TypeScriptConfig#rootOptionsConfigFileName" />
 
 Defines the file name of the config file found in the workspace root that houses shared compiler
 options. Defaults to `tsconfig.options.json`. This setting is used in the following scenarios:
@@ -399,7 +402,7 @@ typescript:
 
 ### `syncProjectReferences`
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/TypeScriptConfig#syncProjectReferences" />
 
 Will sync a project's [`dependsOn`](./project#dependson) setting as project references within that
 project's `tsconfig.json`, and the workspace root `tsconfig.json`. Defaults to `true` when the
@@ -435,13 +438,13 @@ Would result in the following `references` within both `tsconfig.json`s.
 
 ## `generator`<VersionLabel version="0.14" />
 
-> `GeneratorConfig`
+<HeadingApiLink to="/api/types/interface/WorkspaceConfig#generator" />
 
 Configures aspects of the template generator.
 
 ### `templates`
 
-> `string[]`
+<HeadingApiLink to="/api/types/interface/GeneratorConfig#templates" />
 
 A list of file system paths where templates can be located, relative from the workspace root.
 Defaults to `./templates`.
@@ -455,11 +458,13 @@ generator:
 
 ## `hasher`<VersionLabel version="0.13" />
 
-> `HasherConfig`
+<HeadingApiLink to="/api/types/interface/WorkspaceConfig#hasher" />
 
 Configures aspects of smart hashing layer.
 
 ### `optimization`
+
+<HeadingApiLink to="/api/types/interface/HasherConfig#optimization" />
 
 Determines the optimization level to utilize when hashing content before running targets.
 
@@ -475,13 +480,13 @@ hasher:
 
 ## `runner`<VersionLabel updated version="0.13" />
 
-> `RunnerConfig`
+<HeadingApiLink to="/api/types/interface/WorkspaceConfig#runner" />
 
 Configures aspects of the action runner.
 
 ### `cacheLifetime`<VersionLabel version="0.11" />
 
-> `string`
+<HeadingApiLink to="/api/types/interface/RunnerConfig#cacheLifetime" />
 
 The maximum lifetime of cached artifacts before they're marked as stale and automatically removed by
 the action runner. Defaults to "7 days". This field requires an integer and a timeframe unit that
@@ -494,7 +499,7 @@ runner:
 
 ### `implicitInputs`<VersionLabel version="0.9" />
 
-> `string[]`
+<HeadingApiLink to="/api/types/interface/RunnerConfig#implicitInputs" />
 
 Defines task [`inputs`](./project#inputs) that are implicit inherited by _all_ tasks within the
 workspace. This is extremely useful for the "changes to these files should always trigger a task"
@@ -518,7 +523,7 @@ runner:
 
 ### `inheritColorsForPipedTasks`<VersionLabel version="0.3" />
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/RunnerConfig#inheritColorsForPipedTasks" />
 
 Force colors to be inherited from the current terminal for all tasks that are ran as a child process
 and their output is piped to the action runner. Defaults to `true`.
@@ -531,7 +536,7 @@ runner:
 
 ### `logRunningCommand`<VersionLabel version="0.4" />
 
-> `boolean`
+<HeadingApiLink to="/api/types/interface/RunnerConfig#logRunningCommand" />
 
 When enabled, will log the task's command, resolved arguments, and working directory when a target
 is ran. Defaults to `false`.
@@ -543,7 +548,7 @@ runner:
 
 ## `vcs`
 
-> `VcsConfig`
+<HeadingApiLink to="/api/types/interface/WorkspaceConfig#vcs" />
 
 Configures the version control system to utilize within the workspace (and repository). A VCS is
 required for determining touched (added, modified, etc) files, calculating file hashes, computing
@@ -551,7 +556,7 @@ affected files, and much more.
 
 ### `manager`
 
-> `git | svn`
+<HeadingApiLink to="/api/types/interface/VcsConfig#manager" />
 
 Defines the VCS tool/binary that is being used for managing the repository. Accepts "git" (default)
 or "svn" (experimental).
@@ -562,6 +567,8 @@ vcs:
 ```
 
 ### `defaultBranch`
+
+<HeadingApiLink to="/api/types/interface/VcsConfig#defaultBranch" />
 
 Defines the default upstream branch (master/main/trunk) in the repository for comparing differences
 against. For git, this is typically "master" (default) or "main", and must include the remote prefix

--- a/website/src/components/Docs/HeadingApiLink.tsx
+++ b/website/src/components/Docs/HeadingApiLink.tsx
@@ -8,12 +8,7 @@ export interface HeadingApiLinkProps {
 
 export default function HeadingApiLink({ to }: HeadingApiLinkProps) {
 	return (
-		<a
-			href={to}
-			target="_blank"
-			className="float-right inline-block"
-			style={{ marginTop: '-3.5em' }}
-		>
+		<a href={to} target="_blank" className="float-right inline-block" style={{ marginTop: '-3em' }}>
 			<Icon icon={faCode} />
 		</a>
 	);

--- a/website/src/components/Docs/HeadingApiLink.tsx
+++ b/website/src/components/Docs/HeadingApiLink.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { faCode } from '@fortawesome/pro-regular-svg-icons';
+import Icon from '../../ui/iconography/Icon';
+
+export interface HeadingApiLinkProps {
+	to: string;
+}
+
+export default function HeadingApiLink({ to }: HeadingApiLinkProps) {
+	return (
+		<a
+			href={to}
+			target="_blank"
+			className="float-right inline-block"
+			style={{ marginTop: '-3.5em' }}
+		>
+			<Icon icon={faCode} />
+		</a>
+	);
+}


### PR DESCRIPTION
Instead of displaying the setting "type" as a blockquote, this will link to the actual API docs. This is 100x better and actually cleans up the visuals of these config pages.