### PR TITLE
new: Add `typescript.routeOutDirToCache` setting.

### DIFF
--- a/crates/cli/tests/run_node_test.rs
+++ b/crates/cli/tests/run_node_test.rs
@@ -1105,6 +1105,38 @@ mod typescript {
             read_to_string(fixture.path().join("syncs-deps-refs/tsconfig.json")).unwrap()
         );
     }
+
+    #[test]
+    fn routes_out_dir_to_cache() {
+        let fixture = create_sandbox_with_git("typescript");
+
+        append_workspace_config(fixture.path(), "  routeOutDirToCache: true");
+
+        create_moon_command(fixture.path())
+            .arg("run")
+            .arg("out-dir-routing:test")
+            .assert();
+
+        assert_snapshot!(
+            read_to_string(fixture.path().join("out-dir-routing/tsconfig.json")).unwrap()
+        );
+    }
+
+    #[test]
+    fn doesnt_route_out_dir_to_cache() {
+        let fixture = create_sandbox_with_git("typescript");
+
+        append_workspace_config(fixture.path(), "  routeOutDirToCache: false");
+
+        create_moon_command(fixture.path())
+            .arg("run")
+            .arg("out-dir-routing:test")
+            .assert();
+
+        assert_snapshot!(
+            read_to_string(fixture.path().join("out-dir-routing/tsconfig.json")).unwrap()
+        );
+    }
 }
 
 mod workspace_overrides {

--- a/crates/cli/tests/snapshots/run_node_test__typescript__doesnt_route_out_dir_to_cache.snap
+++ b/crates/cli/tests/snapshots/run_node_test__typescript__doesnt_route_out_dir_to_cache.snap
@@ -1,0 +1,11 @@
+---
+source: crates/cli/tests/run_node_test.rs
+assertion_line: 1136
+expression: "read_to_string(fixture.path().join(\"out-dir-routing/tsconfig.json\")).unwrap()"
+---
+{
+  "compilerOptions": {
+    "outDir": "./dts"
+  }
+}
+

--- a/crates/cli/tests/snapshots/run_node_test__typescript__routes_out_dir_to_cache.snap
+++ b/crates/cli/tests/snapshots/run_node_test__typescript__routes_out_dir_to_cache.snap
@@ -1,0 +1,11 @@
+---
+source: crates/cli/tests/run_node_test.rs
+assertion_line: 1120
+expression: "read_to_string(fixture.path().join(\"out-dir-routing/tsconfig.json\")).unwrap()"
+---
+{
+  "compilerOptions": {
+    "outDir": "../.moon/cache/types/out-dir-routing"
+  }
+}
+

--- a/crates/config/src/workspace/typescript.rs
+++ b/crates/config/src/workspace/typescript.rs
@@ -15,6 +15,8 @@ pub struct TypeScriptConfig {
 
     pub root_options_config_file_name: String,
 
+    pub route_out_dir_to_cache: bool,
+
     pub sync_project_references: bool,
 }
 
@@ -25,6 +27,7 @@ impl Default for TypeScriptConfig {
             project_config_file_name: String::from("tsconfig.json"),
             root_config_file_name: String::from("tsconfig.json"),
             root_options_config_file_name: String::from("tsconfig.options.json"),
+            route_out_dir_to_cache: false,
             sync_project_references: true,
         }
     }

--- a/crates/vcs/src/git.rs
+++ b/crates/vcs/src/git.rs
@@ -483,7 +483,7 @@ mod test {
                     ),
                     (
                         "shared-workspace.yml".to_owned(),
-                        "ccf25b65e53f642ea63003c79f70d3aa4ad86957".to_owned()
+                        "6b639b54b13a9847d4cdf610c8589f0ea6966aeb".to_owned()
                     )
                 ])
             );

--- a/tests/fixtures/shared-workspace.yml
+++ b/tests/fixtures/shared-workspace.yml
@@ -2,4 +2,9 @@ node:
   version: '16.0.0'
   dedupeOnLockfileChange: false
 
+typescript:
+  createMissingConfig: false
+  routeOutDirToCache: false
+  syncProjectReferences: false
+
 projects: {}

--- a/tests/fixtures/typescript/.moon/workspace.yml
+++ b/tests/fixtures/typescript/.moon/workspace.yml
@@ -4,4 +4,6 @@ projects:
   - '*'
 
 typescript:
+  createMissingConfig: true
   syncProjectReferences: true
+  routeOutDirToCache: false

--- a/tests/fixtures/typescript/out-dir-routing/package.json
+++ b/tests/fixtures/typescript/out-dir-routing/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-typescript-syncs-deps-refs",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/typescript/out-dir-routing/tsconfig.json
+++ b/tests/fixtures/typescript/out-dir-routing/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "outDir": "./dts"
+  }
+}

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -400,6 +400,32 @@ typescript:
   rootOptionsConfigFileName: 'tsconfig.base.json'
 ```
 
+### `routeOutDirToCache`
+
+<HeadingApiLink to="/api/types/interface/TypeScriptConfig#routeOutDirToCache" />
+
+Updates the `outDir` compiler option in each project's [`tsconfig.json`](#projectConfigFileName) to
+route to moon's cache folder. This is useful when using project references and wanting to keep all
+the compiled `.d.ts` files _out_ of the project folder.
+
+```yaml title=".moon/workspace.yml" {2}
+typescript:
+  routeOutDirToCache: true
+```
+
+As a demonstration, if we had an npm package located at "packages/components", the `outDir` compiler
+option will be re-routed to the following when syncing.
+
+```json title="<project>/tsconfig.json"
+{
+  // ...
+  "compilerOptions": {
+    // ...
+    "outDir": "../../.moon/cache/types/packages/components"
+  }
+}
+```
+
 ### `syncProjectReferences`
 
 <HeadingApiLink to="/api/types/interface/TypeScriptConfig#syncProjectReferences" />

--- a/website/static/schemas/workspace.json
+++ b/website/static/schemas/workspace.json
@@ -325,6 +325,10 @@
           "default": "tsconfig.options.json",
           "type": "string"
         },
+        "routeOutDirToCache": {
+          "default": false,
+          "type": "boolean"
+        },
         "syncProjectReferences": {
           "default": true,
           "type": "boolean"


### PR DESCRIPTION
This adds a new setting `typescript.routeOutDirToCache`, which will update the `outDir` of all `tsconfig.json`s to point to the `.moon/cache/types` directory. I've found this to be extremely useful when working in large project reference monorepos.