### PR TITLE
new: Add `runner.implicitDeps` setting.

### DIFF
--- a/crates/config/src/workspace/runner.rs
+++ b/crates/config/src/workspace/runner.rs
@@ -23,6 +23,8 @@ pub struct RunnerConfig {
     #[validate(custom = "validate_cache_lifetime")]
     pub cache_lifetime: String,
 
+    pub implicit_deps: Vec<String>,
+
     pub implicit_inputs: Vec<String>,
 
     pub inherit_colors_for_piped_tasks: bool,
@@ -34,6 +36,7 @@ impl Default for RunnerConfig {
     fn default() -> Self {
         RunnerConfig {
             cache_lifetime: "7 days".to_owned(),
+            implicit_deps: vec![],
             implicit_inputs: string_vec![
                 // When a project changes
                 "package.json",

--- a/crates/project-graph/src/graph.rs
+++ b/crates/project-graph/src/graph.rs
@@ -367,6 +367,7 @@ impl ProjectGraph {
         // Expand all tasks for the project (this must happen last)
         project.expand_tasks(
             &self.workspace_root,
+            &self.workspace_config.runner.implicit_deps,
             &self.workspace_config.runner.implicit_inputs,
         )?;
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -357,6 +357,7 @@ impl Project {
     pub fn expand_tasks(
         &mut self,
         workspace_root: &Path,
+        implicit_deps: &[String],
         implicit_inputs: &[String],
     ) -> Result<(), ProjectError> {
         let resolver_data =
@@ -368,7 +369,8 @@ impl Project {
                 task.platform = TaskConfig::detect_platform(&self.config, &task.command);
             }
 
-            // Inherit implicit inputs before resolving
+            // Inherit implicits before resolving
+            task.deps.extend(implicit_deps.iter().cloned());
             task.inputs.extend(implicit_inputs.iter().cloned());
 
             // Resolve in order!

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -30,6 +30,8 @@
   can be toggled with the `runner.logRunningCommand` setting.
 - The dedupe command will now be displayed when running if the `node.dedupeOnLockfileChange` setting
   is enabled.
+- Added a new `runner.implicitDeps` setting to `.moon/workspace.yml`, that will add task `deps` to
+  _all_ tasks.
 
 #### 📚 Docs
 

--- a/packages/types/src/workspace-config.ts
+++ b/packages/types/src/workspace-config.ts
@@ -42,6 +42,7 @@ export interface NodeConfig {
 
 export interface RunnerConfig {
 	cacheLifetime: string;
+	implicitDeps: string[];
 	implicitInputs: string[];
 	inheritColorsForPipedTasks: boolean;
 	logRunningCommand: boolean;

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -565,9 +565,9 @@ runner:
 
 <HeadingApiLink to="/api/types/interface/RunnerConfig#implicitDeps" />
 
-Defines task [`deps`](./project#deps) that are implicit inherited by _all_ tasks within the
+Defines task [`deps`](./project#deps) that are implicitly inherited by _all_ tasks within the
 workspace. This is extremely useful for pre-building projects that are used extensively throughout
-the repo, or always building dependencies. Defaults to an empty list.
+the repo, or always building project dependencies. Defaults to an empty list.
 
 ```yaml title=".moon/workspace.yml" {2-5}
 runner:
@@ -579,7 +579,7 @@ runner:
 
 <HeadingApiLink to="/api/types/interface/RunnerConfig#implicitInputs" />
 
-Defines task [`inputs`](./project#inputs) that are implicit inherited by _all_ tasks within the
+Defines task [`inputs`](./project#inputs) that are implicitly inherited by _all_ tasks within the
 workspace. This is extremely useful for the "changes to these files should always trigger a task"
 scenario.
 

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -561,6 +561,20 @@ runner:
   cacheLifetime: '24 hours'
 ```
 
+### `implicitDeps`<VersionLabel version="0.16" />
+
+<HeadingApiLink to="/api/types/interface/RunnerConfig#implicitDeps" />
+
+Defines task [`deps`](./project#deps) that are implicit inherited by _all_ tasks within the
+workspace. This is extremely useful for pre-building projects that are used extensively throughout
+the repo, or always building dependencies. Defaults to an empty list.
+
+```yaml title=".moon/workspace.yml" {2-5}
+runner:
+  implicitDeps:
+    - '^:build'
+```
+
 ### `implicitInputs`<VersionLabel version="0.9" />
 
 <HeadingApiLink to="/api/types/interface/RunnerConfig#implicitInputs" />

--- a/website/src/components/ComparisonTable.tsx
+++ b/website/src/components/ComparisonTable.tsx
@@ -55,6 +55,12 @@ const workspaceRows: Comparison[] = [
 		},
 	},
 	{
+		feature: 'Supports dependencies inherited by all tasks',
+		support: {
+			moon: [SUPPORTED, 'via `implicitDeps`'],
+		},
+	},
+	{
 		feature: 'Supports inputs inherited by all tasks',
 		support: {
 			moon: [SUPPORTED, 'via `implicitInputs`'],

--- a/website/static/schemas/workspace.json
+++ b/website/static/schemas/workspace.json
@@ -55,6 +55,7 @@
     "runner": {
       "default": {
         "cacheLifetime": "7 days",
+        "implicitDeps": [],
         "implicitInputs": [
           "package.json",
           "/.moon/project.yml",
@@ -284,6 +285,13 @@
         "cacheLifetime": {
           "default": "7 days",
           "type": "string"
+        },
+        "implicitDeps": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "implicitInputs": {
           "default": [


### PR DESCRIPTION
This provides a way for task dependencies to be defined globally.