### PR TITLE
fix: Rework `init` config templates to use correct values.

### DIFF
--- a/.yarn/versions/e1f8405e.yml
+++ b/.yarn/versions/e1f8405e.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/init_test.rs
 assertion_line: 267
 expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -32,16 +33,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -57,18 +59,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,

--- a/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_globs_from_workspaces_expanded.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/init_test.rs
 assertion_line: 297
 expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -32,16 +33,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -57,18 +59,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/init_test.rs
 assertion_line: 207
 expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -32,16 +33,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -57,18 +59,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,

--- a/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_projects_from_workspaces_expanded.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/init_test.rs
 assertion_line: 237
 expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -32,16 +33,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -57,18 +59,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,

--- a/crates/cli/tests/snapshots/init_test__node__infers_version_from_nodenv.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_version_from_nodenv.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/init_test.rs
 assertion_line: 177
 expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -31,16 +32,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -56,18 +58,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,

--- a/crates/cli/tests/snapshots/init_test__node__infers_version_from_nvm.snap
+++ b/crates/cli/tests/snapshots/init_test__node__infers_version_from_nvm.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/init_test.rs
 assertion_line: 159
 expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -31,16 +32,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -56,18 +58,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/init_test.rs
 assertion_line: 318
 expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -31,16 +32,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -56,18 +58,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm_from_package.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_npm_from_package.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/init_test.rs
 assertion_line: 340
 expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -35,16 +36,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -60,18 +62,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/init_test.rs
 assertion_line: 358
 expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -35,16 +36,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -60,18 +62,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm_from_package.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_pnpm_from_package.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/init_test.rs
 assertion_line: 380
 expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -35,16 +36,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -60,18 +62,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/init_test.rs
 assertion_line: 398
 expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -35,16 +36,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -60,18 +62,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,

--- a/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn_from_package.snap
+++ b/crates/cli/tests/snapshots/init_test__node__package_manager__infers_yarn_from_package.snap
@@ -3,6 +3,7 @@ source: crates/cli/tests/init_test.rs
 assertion_line: 420
 expression: "fs::read_to_string(workspace_config).unwrap()"
 ---
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -35,16 +36,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -60,18 +62,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,

--- a/crates/config/templates/global_project.yml
+++ b/crates/config/templates/global_project.yml
@@ -1,3 +1,4 @@
+# https://moonrepo.dev/docs/config/global-project
 $schema: 'https://moonrepo.dev/schemas/global-project.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.

--- a/crates/config/templates/project.yml
+++ b/crates/config/templates/project.yml
@@ -1,10 +1,10 @@
+# https://moonrepo.dev/docs/config/project
 $schema: 'https://moonrepo.dev/schemas/project.json'
 
 # The type of project. Accepts "library" (default), "application", or "tool".
 type: 'library'
 
 # Primary programming language the project is written in.
-# Accepts "javascript" or "typescript" (default).
 language: 'typescript'
 
 # This setting defines metadata about the project itself. Although this
@@ -28,7 +28,7 @@ project:
   # and can provide support. Can be a name, email, LDAP/GitHub username, etc.
   maintainers: ['user.name']
 
-# A list of other projects that this project depends on. Each value
+# An explicit list of other projects that this project depends on. Each value
 # must be a unique project ID, and NOT a file path or project name.
 #
 # When `node.syncProjectWorkspaceDependencies` and `typescript.syncProjectReferences`

--- a/crates/config/templates/template.yml
+++ b/crates/config/templates/template.yml
@@ -1,3 +1,4 @@
+# https://moonrepo.dev/docs/config/template
 $schema: 'https://moonrepo.dev/schemas/template.json'
 
 # REQUIRED: Name of the template in a human readable format.

--- a/crates/config/templates/workspace.yml
+++ b/crates/config/templates/workspace.yml
@@ -1,3 +1,4 @@
+# https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
@@ -38,16 +39,17 @@ node:
   addEnginesConstraint: true
 
   # Use the `package.json` name as an alias for the respective moon project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
-  aliasPackageNames: false
+  # aliasPackageNames: 'name-and-scope'
 
   # Dedupe dependencies after the lockfile has changed.
   dedupeOnLockfileChange: true
 
+  # Version format to use when syncing dependencies within the project's `package.json`.
+  # dependencyVersionFormat: 'workspace'
+
   # Infer and automatically create moon tasks from `package.json` scripts, per project.
-  # Do note that this requires eager loading all `package.json`s in the repo.
   # BEWARE: Tasks and scripts are not 1:1 in functionality, so please refer to the documentation.
-  inferTasksFromScripts: false
+  # inferTasksFromScripts: false
 
   # Sync a project's `dependsOn` as dependencies within the project's `package.json`.
   syncProjectWorkspaceDependencies: true
@@ -69,18 +71,24 @@ typescript:
   createMissingConfig: true
 
   # Name of `tsconfig.json` file in the project root.
-  projectConfigFileName: 'tsconfig.json'
+  # projectConfigFileName: 'tsconfig.json'
 
   # Name of `tsconfig.json` file in the workspace root.
-  rootConfigFileName: 'tsconfig.json'
+  # rootConfigFileName: 'tsconfig.json'
 
   # Name of the config file in the workspace root that defines shared compiler options
   # for all project reference based config files.
-  rootOptionsConfigFileName: 'tsconfig.options.json'
+  # rootOptionsConfigFileName: 'tsconfig.options.json'
+
+  # Update the project's `tsconfig.json` to route the `outDir` to moon's cache.
+  # routeOutDirToCache: true
 
   # Sync a project's `dependsOn` as TypeScript project references within the
   # project's `tsconfig.json` and the workspace root `tsconfig.json`.
   syncProjectReferences: true
+
+  # Sync a project's project references as `paths` aliases.
+  # syncProjectReferencesToPaths: true
 
 # Configures the version control system to utilize within the workspace. A VCS
 # is required for determining touched (added, modified, etc) files, calculating file hashes,


### PR DESCRIPTION
The `node.aliasPackageNames` setting was using an incorrect value.