### PR TITLE
fix: Handle unsuccessful requests when downloading tools.

### DIFF
--- a/crates/toolchain/src/errors.rs
+++ b/crates/toolchain/src/errors.rs
@@ -5,6 +5,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ToolchainError {
+    #[error("Failed to download tool from <url>{0}</url> <muted>({1})</muted>")]
+    DownloadFailed(String, String),
+
     #[error("Internet connection required, unable to download and install tools.")]
     InternetConnectionRequired,
 

--- a/crates/toolchain/src/helpers.rs
+++ b/crates/toolchain/src/helpers.rs
@@ -85,6 +85,14 @@ pub async fn download_file_from_url(url: &str, dest: &Path) -> Result<(), Toolch
 
     // Fetch the file from the HTTP source
     let response = reqwest::get(url).await?;
+    let status = response.status();
+
+    if !status.is_success() {
+        return Err(ToolchainError::DownloadFailed(
+            url.to_owned(),
+            status.to_string(),
+        ));
+    }
 
     // Write the bytes to our local file
     let mut contents = io::Cursor::new(response.bytes().await?);

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where `moon init` would generate a config with invalid settings.
+- Fixed an issue where downloading a tool would fail, but moon would still continue.
+
 ## 0.16.0
 
 #### 🚀 Updates


### PR DESCRIPTION
This was an oversight on my part. I assumed that reqwest would throw errors for non-200s, but that's not the case. This fixes that and handles this failure case explicitly.