### PR TITLE
new: Add `@moonrepo/report` package.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,9 +14,9 @@ jobs:
           cache: yarn
       - run: yarn install --immutable
       - run: yarn version check
-      - run: node scripts/version/checkBumpForRustChanges.mjs
+      - run: node ./scripts/version/checkBumpForRustChanges.mjs
       # This just tests package building, which release uses
-      - run: yarn run build
+      - run: bash ./scripts/release/buildPackages.sh
   clibin:
     name: CLI binary check
     runs-on: ubuntu-latest

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
       - name: Build packages
-        run: yarn run build
+        run: bash ./scripts/release/buildPackages.sh
       - name: Publish npm packages
         run: bash ./scripts/release/publishPackages.sh
         shell: bash

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,27 @@
+name: Release npm
+on:
+  workflow_dispatch:
+jobs:
+  publish-npm:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Publish npm packages
+    runs-on: ubuntu-latest
+    env:
+      NPM_CHANNEL: latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          check-latest: true
+          node-version: 16
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build packages
+        run: yarn run build
+      - name: Publish npm packages
+        run: bash ./scripts/release/publishPackages.sh
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
       - name: Build packages
-        run: yarn run build
+        run: bash ./scripts/release/buildPackages.sh
       - name: Publish npm packages
         run: bash ./scripts/release/publishPackages.sh
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,14 +176,6 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
-      - uses: actions/cache@v3
-        name: Cache node modules
-        with:
-          path: |
-            ~/.yarn
-            .yarn/install-state.gz
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-yarn-
       - name: Setup toolchain
         if: ${{ matrix.setup }}
         run: ${{ matrix.setup }}
@@ -226,14 +218,6 @@ jobs:
           cache: yarn
           check-latest: true
           node-version: 16
-      - uses: actions/cache@v3
-        name: Cache node modules
-        with:
-          path: |
-            ~/.yarn
-            .yarn/install-state.gz
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --immutable
       - uses: actions/download-artifact@v2
@@ -272,14 +256,6 @@ jobs:
           cache: yarn
           check-latest: true
           node-version: 16
-      - uses: actions/cache@v3
-        name: Cache node modules
-        with:
-          path: |
-            ~/.yarn
-            .yarn/install-state.gz
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --immutable
       - name: Build packages

--- a/.moon/project.yml
+++ b/.moon/project.yml
@@ -11,13 +11,15 @@ fileGroups:
 
 tasks:
   build:
-    command: 'packemon build --addFiles --addExports --declaration'
+    command:
+      'packemon build --addFiles --addExports --declaration --declarationConfig tsconfig.build.json'
     env:
       NODE_ENV: 'production'
     inputs:
       - '@globs(sources)'
       - 'package.json'
       - 'tsconfig.json'
+      - 'tsconfig.build.json'
       - '/tsconfig.options.json'
     outputs:
       - 'cjs'
@@ -90,5 +92,3 @@ tasks:
       - '@globs(tests)'
       - 'tsconfig.json'
       - '/tsconfig.options.json'
-    outputs:
-      - 'dts'

--- a/.moon/project.yml
+++ b/.moon/project.yml
@@ -57,8 +57,6 @@ tasks:
       - '--no-error-on-unmatched-pattern'
       - '--report-unused-disable-directives'
       - '.'
-    deps:
-      - '^:build'
     inputs:
       - '@globs(sources)'
       - '@globs(tests)'
@@ -85,8 +83,6 @@ tasks:
 
   typecheck:
     command: 'tsc --build --verbose'
-    deps:
-      - '^:build'
     inputs:
       - '@globs(sources)'
       - '@globs(tests)'

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -21,6 +21,7 @@ node:
   inferTasksFromScripts: false
 
 typescript:
+  routeOutDirToCache: true
   syncProjectReferences: true
 
 generator:

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -30,6 +30,8 @@ generator:
     - './tests/fixtures/generator/templates'
 
 runner:
+  implicitDeps:
+    - '^:build'
   logRunningCommand: true
 
 vcs:

--- a/.yarn/versions/1303c893.yml
+++ b/.yarn/versions/1303c893.yml
@@ -1,7 +1,8 @@
 releases:
-  "@moonrepo/report": patch
-  "@moonrepo/runtime": patch
-  "@moonrepo/types": patch
+  '@moonrepo/report': patch
+  '@moonrepo/runtime': patch
+  '@moonrepo/types': patch
 
 declined:
+  - '@moonrepo/cli'
   - website

--- a/.yarn/versions/1303c893.yml
+++ b/.yarn/versions/1303c893.yml
@@ -1,0 +1,7 @@
+releases:
+  "@moonrepo/report": patch
+  "@moonrepo/runtime": patch
+  "@moonrepo/types": patch
+
+declined:
+  - website

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	presets: ['moon'],
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@moonrepo/cli": "workspace:*",
     "@types/node": "^17.0.45",
+    "babel-preset-moon": "^1.0.2",
     "eslint": "^8.24.0",
     "eslint-config-moon": "^1.0.2",
     "execa": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "packageManager": "yarn@3.2.3",
   "scripts": {
-    "build": "bash ./scripts/release/buildPackages.sh",
     "docs": "cargo run -- run website:start",
     "moon": "target/debug/moon --log trace",
     "type": "target/debug/moon --log trace run :typecheck",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "yarn@3.2.3",
   "scripts": {
-    "build": "NODE_ENV=production packemon pack --addEngines --addExports --declaration",
+    "build": "bash ./scripts/release/buildPackages.sh",
     "docs": "cargo run -- run website:start",
     "moon": "target/debug/moon --log trace",
     "type": "target/debug/moon --log trace run :typecheck",

--- a/packages/cli/postinstall.js
+++ b/packages/cli/postinstall.js
@@ -6,7 +6,8 @@ const path = require('path');
 
 const isMoonLocal =
 	fs.existsSync(path.join(__dirname, '../../.moon')) &&
-	fs.existsSync(path.join(__dirname, '../../crates'));
+	fs.existsSync(path.join(__dirname, '../../crates')) &&
+	!process.env.CI;
 
 const isLinux = process.platform === 'linux';
 const isMacos = process.platform === 'darwin';

--- a/packages/cli/postinstall.js
+++ b/packages/cli/postinstall.js
@@ -6,8 +6,7 @@ const path = require('path');
 
 const isMoonLocal =
 	fs.existsSync(path.join(__dirname, '../../.moon')) &&
-	fs.existsSync(path.join(__dirname, '../../crates')) &&
-	!process.env.CI;
+	fs.existsSync(path.join(__dirname, '../../crates'));
 
 const isLinux = process.platform === 'linux';
 const isMacos = process.platform === 'darwin';

--- a/packages/report/.eslintrc.js
+++ b/packages/report/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+	rules: {
+		'no-magic-numbers': 'off',
+	},
+};

--- a/packages/report/LICENSE
+++ b/packages/report/LICENSE
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) 2021 moonrepo LLC, Miles Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/report/README.md
+++ b/packages/report/README.md
@@ -1,0 +1,7 @@
+# @moonrepo/report
+
+![build status](https://img.shields.io/github/workflow/status/moonrepo/moon/Moon)
+![npm version](https://img.shields.io/npm/v/@moonrepo/report)
+![npm license](https://img.shields.io/npm/l/@moonrepo/report)
+
+Utilities for working with moon run reports.

--- a/packages/report/moon.yml
+++ b/packages/report/moon.yml
@@ -1,0 +1,2 @@
+language: typescript
+type: library

--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonrepo/report",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "type": "commonjs",
   "description": "Utilities working with moon run reports.",
   "keywords": [

--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -28,6 +28,9 @@
     "platform": "node",
     "bundle": true
   },
+  "dependencies": {
+    "@moonrepo/types": "workspace:^"
+  },
   "engines": {
     "node": ">=14.15.0",
     "npm": ">=6.14.0"
@@ -41,8 +44,5 @@
         "require": "./cjs/index.cjs"
       }
     }
-  },
-  "dependencies": {
-    "@moonrepo/types": "workspace:^"
   }
 }

--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@moonrepo/report",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "description": "Utilities working with moon run reports.",
+  "keywords": [
+    "moon",
+    "repo",
+    "report",
+    "utils"
+  ],
+  "author": "Miles Johnson",
+  "license": "MIT",
+  "main": "./cjs/index.cjs",
+  "types": "./dts/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/moonrepo/moon",
+    "directory": "packages/report"
+  },
+  "files": [
+    "cjs/**/*.{cjs,mjs,map}",
+    "dts/**/*.d.ts",
+    "src/**/*.{ts,tsx,json}"
+  ],
+  "packemon": {
+    "format": "cjs",
+    "platform": "node",
+    "bundle": true
+  },
+  "engines": {
+    "node": ">=14.15.0",
+    "npm": ">=6.14.0"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dts/index.d.ts",
+      "node": {
+        "import": "./cjs/index-wrapper.mjs",
+        "require": "./cjs/index.cjs"
+      }
+    }
+  },
+  "dependencies": {
+    "@moonrepo/types": "workspace:^"
+  }
+}

--- a/packages/report/src/action.ts
+++ b/packages/report/src/action.ts
@@ -1,0 +1,47 @@
+import { Action, ActionStatus } from '@moonrepo/types';
+import { getDurationInMillis } from './time';
+
+export function getIconForStatus(status: ActionStatus): string {
+	switch (status) {
+		case 'cached':
+			return '🟪';
+		// case 'cached-remote':
+		// 	return '🟦';
+		case 'failed':
+		case 'failed-and-abort':
+			return '🟥';
+		case 'invalid':
+			return '🟨';
+		case 'passed':
+			return '🟩';
+		default:
+			return '⬛️';
+	}
+}
+
+export function hasFailed(status: ActionStatus): boolean {
+	return status === 'failed' || status === 'failed-and-abort';
+}
+
+export function hasPassed(status: ActionStatus): boolean {
+	return status === 'passed' || status === 'cached';
+}
+
+export function isFlaky(action: Action): boolean {
+	if (!action.attempts || action.attempts.length === 0) {
+		return false;
+	}
+
+	return hasPassed(action.status) && action.attempts.some((attempt) => hasFailed(attempt.status));
+}
+
+export function isSlow(action: Action, slowThreshold: number): boolean {
+	if (!action.duration) {
+		return false;
+	}
+
+	const millis = getDurationInMillis(action.duration);
+	const threshold = slowThreshold * 1000; // In seconds
+
+	return millis > threshold;
+}

--- a/packages/report/src/action.ts
+++ b/packages/report/src/action.ts
@@ -2,6 +2,8 @@ import { Action, ActionStatus } from '@moonrepo/types';
 import { getDurationInMillis } from './time';
 
 export function getIconForStatus(status: ActionStatus): string {
+	// Use exhaustive checks!
+	// eslint-disable-next-line default-case
 	switch (status) {
 		case 'cached':
 			return '🟪';
@@ -14,9 +16,12 @@ export function getIconForStatus(status: ActionStatus): string {
 			return '🟨';
 		case 'passed':
 			return '🟩';
-		default:
+		case 'running':
+		case 'skipped':
 			return '⬛️';
 	}
+
+	return '⬜️';
 }
 
 export function hasFailed(status: ActionStatus): boolean {
@@ -28,6 +33,11 @@ export function hasPassed(status: ActionStatus): boolean {
 }
 
 export function isFlaky(action: Action): boolean {
+	if (action.flaky) {
+		return true;
+	}
+
+	// The flaky field above didn't always exist!
 	if (!action.attempts || action.attempts.length === 0) {
 		return false;
 	}

--- a/packages/report/src/index.ts
+++ b/packages/report/src/index.ts
@@ -1,0 +1,3 @@
+export * from './action';
+export * from './report';
+export * from './time';

--- a/packages/report/src/report.ts
+++ b/packages/report/src/report.ts
@@ -24,7 +24,7 @@ export function sortReport(report: RunReport, sortBy: string, sortDir: string) {
 			}
 
 			default: {
-				return 0;
+				throw new Error(`Unknown sort by "${sortBy}".`);
 			}
 		}
 	});

--- a/packages/report/src/report.ts
+++ b/packages/report/src/report.ts
@@ -1,0 +1,65 @@
+import { Duration, RunReport } from '@moonrepo/types';
+import { getIconForStatus, isFlaky, isSlow } from './action';
+import { formatDuration } from './time';
+
+export function sortReport(report: RunReport, sortBy: string, sortDir: string) {
+	const isAsc = sortDir === 'asc';
+
+	report.actions.sort((a, d) => {
+		switch (sortBy) {
+			case 'time': {
+				const at: Duration = a.duration ?? { nanos: 0, secs: 0 };
+				const dt: Duration = d.duration ?? { nanos: 0, secs: 0 };
+				const am = at.secs * 1000 + at.nanos / 1_000_000;
+				const dm = dt.secs * 1000 + dt.nanos / 1_000_000;
+
+				return isAsc ? am - dm : dm - am;
+			}
+
+			case 'label': {
+				const al = a.label ?? '';
+				const dl = d.label ?? '';
+
+				return isAsc ? al.localeCompare(dl) : dl.localeCompare(al);
+			}
+
+			default: {
+				return 0;
+			}
+		}
+	});
+}
+
+export interface PreparedAction {
+	comments: string[];
+	duration: Duration | null;
+	icon: string;
+	label: string;
+	time: string;
+}
+
+export function prepareReportActions(report: RunReport, slowThreshold: number): PreparedAction[] {
+	return report.actions.map((action) => {
+		const comments: string[] = [];
+
+		if (isFlaky(action)) {
+			comments.push('**FLAKY**');
+		}
+
+		if (action.attempts && action.attempts.length > 1) {
+			comments.push(`${action.attempts.length} attempts`);
+		}
+
+		if (isSlow(action, slowThreshold)) {
+			comments.push('**SLOW**');
+		}
+
+		return {
+			comments,
+			duration: action.duration,
+			icon: getIconForStatus(action.status),
+			label: action.label ?? '<unknown>',
+			time: formatDuration(action.duration),
+		};
+	});
+}

--- a/packages/report/src/report.ts
+++ b/packages/report/src/report.ts
@@ -1,17 +1,15 @@
 import { Duration, RunReport } from '@moonrepo/types';
 import { getIconForStatus, isFlaky, isSlow } from './action';
-import { formatDuration } from './time';
+import { formatDuration, getDurationInMillis } from './time';
 
-export function sortReport(report: RunReport, sortBy: string, sortDir: string) {
+export function sortReport(report: RunReport, sortBy: 'label' | 'time', sortDir: 'asc' | 'desc') {
 	const isAsc = sortDir === 'asc';
 
 	report.actions.sort((a, d) => {
 		switch (sortBy) {
 			case 'time': {
-				const at: Duration = a.duration ?? { nanos: 0, secs: 0 };
-				const dt: Duration = d.duration ?? { nanos: 0, secs: 0 };
-				const am = at.secs * 1000 + at.nanos / 1_000_000;
-				const dm = dt.secs * 1000 + dt.nanos / 1_000_000;
+				const am = getDurationInMillis(a.duration ?? { nanos: 0, secs: 0 });
+				const dm = getDurationInMillis(d.duration ?? { nanos: 0, secs: 0 });
 
 				return isAsc ? am - dm : dm - am;
 			}

--- a/packages/report/src/time.ts
+++ b/packages/report/src/time.ts
@@ -1,0 +1,66 @@
+import { Duration } from '@moonrepo/types';
+
+export function getDurationInMillis(duration: Duration): number {
+	return duration.secs * 1000 + duration.nanos / 1_000_000;
+}
+
+export function formatTime(mins: number, secs: number, millis: number): string {
+	if (mins === 0 && secs === 0 && millis === 0) {
+		return '0s';
+	}
+
+	const format = (val: number) => {
+		let v = val.toFixed(1);
+
+		if (v.endsWith('.0')) {
+			v = v.slice(0, -2);
+		}
+
+		return v;
+	};
+
+	// When minutes, only show mins + secs
+	if (mins > 0) {
+		let value = `${mins}m`;
+
+		if (secs > 0) {
+			value += ` ${secs}s`;
+		}
+
+		return value;
+	}
+
+	// When seconds, only show secs + first milli digit
+	if (secs > 0) {
+		return `${format((secs * 1000 + millis) / 1000)}s`;
+	}
+
+	// When millis, show as is
+	if (millis > 0) {
+		return `${format(millis)}ms`;
+	}
+
+	// How did we get here?
+	return '0s';
+}
+
+export function formatDuration(duration: Duration | null): string {
+	if (!duration) {
+		return '--';
+	}
+
+	if (duration.secs === 0 && duration.nanos === 0) {
+		return '0s';
+	}
+
+	let mins = 0;
+	let { secs } = duration;
+	const millis = duration.nanos / 1_000_000;
+
+	while (secs >= 60) {
+		mins += 1;
+		secs -= 60;
+	}
+
+	return formatTime(mins, secs, millis);
+}

--- a/packages/report/tests/action.test.ts
+++ b/packages/report/tests/action.test.ts
@@ -1,0 +1,59 @@
+import { Action } from '@moonrepo/types';
+import { isFlaky, isSlow } from '../src';
+
+const action: Action = {
+	attempts: null,
+	createdAt: '2022-09-12T22:50:12.932311Z',
+	duration: {
+		secs: 34,
+		nanos: 431_185_666,
+	},
+	error: null,
+	flaky: false,
+	label: 'RunTarget(app:build)',
+	nodeIndex: 8,
+	status: 'passed',
+};
+
+describe('isFlaky()', () => {
+	it('returns false if no attempts', () => {
+		expect(isFlaky({ ...action })).toBe(false);
+		expect(isFlaky({ ...action, attempts: [] })).toBe(false);
+	});
+
+	it('returns true if status is passed but an attempt failed', () => {
+		expect(
+			isFlaky({
+				...action,
+				attempts: [
+					{
+						duration: null,
+						finishedAt: null,
+						index: 1,
+						startedAt: '',
+						status: 'failed',
+					},
+				],
+				status: 'passed',
+			}),
+		).toBe(true);
+	});
+
+	it('returns true if flaky field is true', () => {
+		expect(isFlaky({ ...action, flaky: true })).toBe(true);
+	});
+});
+
+describe('isSlow()', () => {
+	it('returns false for no duration', () => {
+		expect(isSlow({ ...action, duration: null }, 1)).toBe(false);
+	});
+
+	it('returns false if below threshold', () => {
+		expect(isSlow({ ...action, duration: { secs: 1, nanos: 0 } }, 2)).toBe(false);
+	});
+
+	it('returns true if above threshold', () => {
+		expect(isSlow({ ...action, duration: { secs: 3, nanos: 0 } }, 2)).toBe(true);
+	});
+});

--- a/packages/report/tests/report.test.ts
+++ b/packages/report/tests/report.test.ts
@@ -1,0 +1,176 @@
+import { RunReport } from '@moonrepo/types';
+import { prepareReportActions, sortReport } from '../src';
+
+function mockReport(): RunReport {
+	return {
+		actions: [
+			{
+				attempts: null,
+				createdAt: '2022-09-12T22:50:12.621680Z',
+				duration: {
+					secs: 0,
+					nanos: 0,
+				},
+				error: null,
+				flaky: false,
+				label: 'RunTarget(types:build)',
+				nodeIndex: 5,
+				status: 'cached',
+			},
+			{
+				attempts: null,
+				createdAt: '2022-09-12T22:50:12.932177Z',
+				duration: {
+					secs: 1922,
+					nanos: 380_231_540,
+				},
+				error: null,
+				flaky: true,
+				label: 'RunTarget(runtime:typecheck)',
+				nodeIndex: 4,
+				status: 'passed',
+			},
+			{
+				attempts: null,
+				createdAt: '2022-09-12T22:50:12.932228Z',
+				duration: {
+					secs: 64,
+					nanos: 571_634_134,
+				},
+				error: null,
+				flaky: false,
+				label: 'RunTarget(types:typecheck)',
+				nodeIndex: 6,
+				status: 'passed',
+			},
+			{
+				attempts: null,
+				createdAt: '2022-09-12T22:50:12.932311Z',
+				duration: {
+					secs: 34,
+					nanos: 431_185_666,
+				},
+				error: null,
+				flaky: false,
+				label: 'RunTarget(website:typecheck)',
+				nodeIndex: 8,
+				status: 'passed',
+			},
+		],
+		context: {
+			passthroughArgs: [],
+			primaryTargets: [],
+			profile: null,
+			touchedFiles: [],
+		},
+		duration: {
+			secs: 0,
+			nanos: 371_006_844,
+		},
+		estimatedSavings: {
+			secs: 0,
+			nanos: 990_820_168,
+		},
+		projectedDuration: {
+			secs: 1,
+			nanos: 361_827_012,
+		},
+	};
+}
+
+describe('sortReport()', () => {
+	it('sorts by time asc', () => {
+		const report = mockReport();
+		sortReport(report, 'time', 'asc');
+
+		expect(report.actions.map((a) => a.label)).toEqual([
+			'RunTarget(types:build)',
+			'RunTarget(website:typecheck)',
+			'RunTarget(types:typecheck)',
+			'RunTarget(runtime:typecheck)',
+		]);
+	});
+
+	it('sorts by time desc', () => {
+		const report = mockReport();
+		sortReport(report, 'time', 'desc');
+
+		expect(report.actions.map((a) => a.label)).toEqual([
+			'RunTarget(runtime:typecheck)',
+			'RunTarget(types:typecheck)',
+			'RunTarget(website:typecheck)',
+			'RunTarget(types:build)',
+		]);
+	});
+
+	it('sorts by label asc', () => {
+		const report = mockReport();
+		sortReport(report, 'label', 'asc');
+
+		expect(report.actions.map((a) => a.label)).toEqual([
+			'RunTarget(runtime:typecheck)',
+			'RunTarget(types:build)',
+			'RunTarget(types:typecheck)',
+			'RunTarget(website:typecheck)',
+		]);
+	});
+
+	it('sorts by label desc', () => {
+		const report = mockReport();
+		sortReport(report, 'label', 'desc');
+
+		expect(report.actions.map((a) => a.label)).toEqual([
+			'RunTarget(website:typecheck)',
+			'RunTarget(types:typecheck)',
+			'RunTarget(types:build)',
+			'RunTarget(runtime:typecheck)',
+		]);
+	});
+});
+
+describe('prepareReportActions()', () => {
+	it('returns actions prepared', () => {
+		expect(prepareReportActions(mockReport(), 60)).toEqual([
+			{
+				comments: [],
+				duration: {
+					nanos: 0,
+					secs: 0,
+				},
+				icon: '🟪',
+				label: 'RunTarget(types:build)',
+				time: '0s',
+			},
+			{
+				comments: ['**FLAKY**', '**SLOW**'],
+				duration: {
+					nanos: 380_231_540,
+					secs: 1922,
+				},
+				icon: '🟩',
+				label: 'RunTarget(runtime:typecheck)',
+				time: '32m 2s',
+			},
+			{
+				comments: ['**SLOW**'],
+				duration: {
+					nanos: 571_634_134,
+					secs: 64,
+				},
+				icon: '🟩',
+				label: 'RunTarget(types:typecheck)',
+				time: '1m 4s',
+			},
+			{
+				comments: [],
+				duration: {
+					nanos: 431_185_666,
+					secs: 34,
+				},
+				icon: '🟩',
+				label: 'RunTarget(website:typecheck)',
+				time: '34.4s',
+			},
+		]);
+	});
+});

--- a/packages/report/tests/time.test.ts
+++ b/packages/report/tests/time.test.ts
@@ -1,0 +1,55 @@
+import { formatDuration, formatTime } from '../src';
+
+describe('formatTime()', () => {
+	it('handles all zeros', () => {
+		expect(formatTime(0, 0, 0)).toBe('0s');
+	});
+
+	it('handles minutes', () => {
+		expect(formatTime(5, 0, 555)).toBe('5m');
+	});
+
+	it('handles minutes with seconds', () => {
+		expect(formatTime(5, 12, 555)).toBe('5m 12s');
+	});
+
+	it('handles seconds', () => {
+		expect(formatTime(0, 59, 0)).toBe('59s');
+	});
+
+	it('handles seconds with millis', () => {
+		expect(formatTime(0, 23, 250)).toBe('23.3s');
+		expect(formatTime(0, 59, 900)).toBe('59.9s');
+	});
+
+	it('handles millis', () => {
+		expect(formatTime(0, 0, 125)).toBe('125ms');
+		expect(formatTime(0, 0, 895)).toBe('895ms');
+	});
+});
+
+describe('formatDuration()', () => {
+	it('returns nothing for missing duration', () => {
+		expect(formatDuration(null)).toBe('--');
+	});
+
+	it('handles zeros', () => {
+		expect(formatDuration({ secs: 0, nanos: 0 })).toBe('0s');
+	});
+
+	it('handles millis', () => {
+		expect(formatDuration({ secs: 0, nanos: 2500 * 1_000_000 })).toBe('2500ms');
+	});
+
+	it('handles seconds', () => {
+		expect(formatDuration({ secs: 12, nanos: 0 })).toBe('12s');
+	});
+
+	it('handles seconds with millis', () => {
+		expect(formatDuration({ secs: 15, nanos: 2500 * 1_000_000 })).toBe('17.5s');
+	});
+
+	it('handles minutes', () => {
+		expect(formatDuration({ secs: 85, nanos: 32_500 * 1_000_000 })).toBe('1m 25s');
+	});
+});

--- a/packages/report/tsconfig.build.json
+++ b/packages/report/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dts",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/report/tsconfig.json
+++ b/packages/report/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.options.json",
+  "compilerOptions": {
+    "outDir": "dts",
+    "rootDir": "src"
+  },
+  "exclude": [
+    "dts"
+  ],
+  "include": [
+    "src/**/*",
+    "tests/**/*",
+    "types/**/*"
+  ]
+}

--- a/packages/report/tsconfig.json
+++ b/packages/report/tsconfig.json
@@ -1,15 +1,16 @@
 {
   "extends": "../../tsconfig.options.json",
   "compilerOptions": {
-    "outDir": "dts",
-    "rootDir": "src"
+    "outDir": "../../.moon/cache/types/packages/report",
+    "rootDir": "."
   },
-  "exclude": [
-    "dts"
-  ],
   "include": [
-    "src/**/*",
-    "tests/**/*",
-    "types/**/*"
+    ".eslintrc.js",
+    "src/**/*"
+  ],
+  "references": [
+    {
+      "path": "../types"
+    }
   ]
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@boost/common": "^4.0.0",
-    "@moonrepo/types": "^0.0.4"
+    "@moonrepo/types": "workspace:^"
   },
   "engines": {
     "node": ">=14.15.0",

--- a/packages/runtime/tsconfig.build.json
+++ b/packages/runtime/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dts",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -1,16 +1,11 @@
 {
   "extends": "../../tsconfig.options.json",
   "compilerOptions": {
-    "outDir": "dts",
-    "rootDir": "src"
+    "outDir": "../../.moon/cache/types/packages/runtime",
+    "rootDir": "."
   },
-  "exclude": [
-    "dts"
-  ],
   "include": [
-    "src/**/*",
-    "tests/**/*",
-    "types/**/*"
+    "src/**/*"
   ],
   "references": [
     {

--- a/packages/types/tsconfig.build.json
+++ b/packages/types/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dts",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,15 +1,10 @@
 {
   "extends": "../../tsconfig.options.json",
   "compilerOptions": {
-    "outDir": "dts",
-    "rootDir": "src"
+    "outDir": "../../.moon/cache/types/packages/types",
+    "rootDir": "."
   },
-  "exclude": [
-    "dts"
-  ],
   "include": [
-    "src/**/*",
-    "tests/**/*",
-    "types/**/*"
+    "src/**/*"
   ]
 }

--- a/scripts/release/buildPackages.sh
+++ b/scripts/release/buildPackages.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Build all packages with moon itself, so that the order is resolved correctly
+npx --package @moonrepo/cli@latest -- moon run :build

--- a/scripts/release/buildPackages.sh
+++ b/scripts/release/buildPackages.sh
@@ -4,17 +4,7 @@
 cd scripts
 
 # Build all packages with moon itself, so that the order is resolved correctly
-# npm install @moonrepo/cli@latest
-# ./node_modules/@moonrepo/cli/moon run :build
 npm install -g pnpm
 pnpm --package @moonrepo/cli@latest dlx moon run :build
 
-# # When not in CI, use npx
-# if [[ -z "${CI}" ]]; then
-# 	npx --package @moonrepo/cli@latest -- moon run :build
-
-# # npx doesn't work in CI, so install directly
-# else
-# 	yarn add --dev @moonrepo/cli@latest
-# 	./node_modules/@moonrepo/cli/moon run :build
-# fi
+# Note: yarn/npm/npx did not work here, but pnpm does!

--- a/scripts/release/buildPackages.sh
+++ b/scripts/release/buildPackages.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 # Build all packages with moon itself, so that the order is resolved correctly
+yarn dlx --package @moonrepo/cli@latest moon run :build
 
-
-# When not in CI, use npx
+# # When not in CI, use npx
 # if [[ -z "${CI}" ]]; then
-	npx --package @moonrepo/cli@latest -- moon run :build
+# 	npx --package @moonrepo/cli@latest -- moon run :build
 
-# npx doesn't work in CI, so install directly
+# # npx doesn't work in CI, so install directly
 # else
 # 	yarn add --dev @moonrepo/cli@latest
 # 	./node_modules/@moonrepo/cli/moon run :build

--- a/scripts/release/buildPackages.sh
+++ b/scripts/release/buildPackages.sh
@@ -4,10 +4,10 @@
 cd scripts
 
 # Build all packages with moon itself, so that the order is resolved correctly
-npm install @moonrepo/cli@latest
-./node_modules/@moonrepo/cli/moon run :build
-
-# npx --package @moonrepo/cli@latest -- moon run :build
+# npm install @moonrepo/cli@latest
+# ./node_modules/@moonrepo/cli/moon run :build
+npm install -g pnpm
+pnpm --package @moonrepo/cli@latest dlx moon run :build
 
 # # When not in CI, use npx
 # if [[ -z "${CI}" ]]; then

--- a/scripts/release/buildPackages.sh
+++ b/scripts/release/buildPackages.sh
@@ -4,7 +4,10 @@
 cd scripts
 
 # Build all packages with moon itself, so that the order is resolved correctly
-npx --package @moonrepo/cli@latest -- moon run :build
+npm install @moonrepo/cli@latest
+./node_modules/@moonrepo/cli/moon run :build
+
+# npx --package @moonrepo/cli@latest -- moon run :build
 
 # # When not in CI, use npx
 # if [[ -z "${CI}" ]]; then

--- a/scripts/release/buildPackages.sh
+++ b/scripts/release/buildPackages.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
 
 # Build all packages with moon itself, so that the order is resolved correctly
-npx --package @moonrepo/cli@latest -- moon run :build
+
+
+# When not in CI, use npx
+if [[ -z "${CI}" ]]; then
+	npx --package @moonrepo/cli@latest -- moon run :build
+
+# npx doesn't work in CI, so install directly
+else
+	yarn add --dev @moonrepo/cli@latest
+	./node_modules/@moonrepo/cli/moon run :build
+fi

--- a/scripts/release/buildPackages.sh
+++ b/scripts/release/buildPackages.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+# Change the working directory so that we avoid the CLI postinstall checks!
+cd scripts
+
 # Build all packages with moon itself, so that the order is resolved correctly
-yarn dlx --package @moonrepo/cli@latest moon run :build
+npx --package @moonrepo/cli@latest -- moon run :build
 
 # # When not in CI, use npx
 # if [[ -z "${CI}" ]]; then

--- a/scripts/release/buildPackages.sh
+++ b/scripts/release/buildPackages.sh
@@ -4,11 +4,11 @@
 
 
 # When not in CI, use npx
-if [[ -z "${CI}" ]]; then
+# if [[ -z "${CI}" ]]; then
 	npx --package @moonrepo/cli@latest -- moon run :build
 
 # npx doesn't work in CI, so install directly
-else
-	yarn add --dev @moonrepo/cli@latest
-	./node_modules/@moonrepo/cli/moon run :build
-fi
+# else
+# 	yarn add --dev @moonrepo/cli@latest
+# 	./node_modules/@moonrepo/cli/moon run :build
+# fi

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -8,6 +8,7 @@
     "extraFileExtensions": [".mjs"]
   },
   "include": [
+    "packages/*/.eslintrc.js",
     "packages/*/src/**/*",
     "packages/*/tests/**/*",
     "packages/*/types/**/*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
       "path": "packages/cli"
     },
     {
+      "path": "packages/report"
+    },
+    {
       "path": "packages/runtime"
     },
     {

--- a/tsconfig.options.json
+++ b/tsconfig.options.json
@@ -1,3 +1,6 @@
 {
-  "extends": "tsconfig-moon/tsconfig.projects.json"
+  "extends": "tsconfig-moon/tsconfig.projects.json",
+  "compilerOptions": {
+    "incremental": true
+  }
 }

--- a/website/blog/2022-10-06_v0.16.mdx
+++ b/website/blog/2022-10-06_v0.16.mdx
@@ -130,7 +130,7 @@ full list of changes.
   [syntax highlighting](../docs/guides/codegen#file-extensions).
 - We now display more commands and information when running tasks.
 - Declare implicit task dependencies with a new
-  [`runner.implicitDeps`](../docs/config/workspace.mdx#implicitdeps) setting.
+  [`runner.implicitDeps`](../docs/config/workspace#implicitdeps) setting.
 
 ## What's next?
 

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -6,7 +6,8 @@
     "src/**/*"
   ],
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "outDir": "../.moon/cache/types/website"
   },
   "references": [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,10 +190,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.17.7, @babel/compat-data@npm:^7.18.8, @babel/compat-data@npm:^7.19.3":
-  version: 7.19.3
-  resolution: "@babel/compat-data@npm:7.19.3"
-  checksum: e6014cdb31f3e893a1bde6dd3ae05c8f946778318fa337b18b546ace6f9c9f7a5033fd9447070ebc8e820fa9fc7e0a30d4e354989e091900305a876b44346c8f
+"@babel/compat-data@npm:^7.17.7, @babel/compat-data@npm:^7.19.3, @babel/compat-data@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/compat-data@npm:7.19.4"
+  checksum: 757fdaeb6756c2d323ff56f60fb8e670292108cda6abf762a56c0d40910ecc4d2c7e283dbdfbcee6bc28c74ad659144352609e1cb49d31e101ab13ea5ce90072
   languageName: node
   linkType: hard
 
@@ -244,14 +244,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.12.5, @babel/generator@npm:^7.18.7, @babel/generator@npm:^7.19.3, @babel/generator@npm:^7.7.2":
-  version: 7.19.3
-  resolution: "@babel/generator@npm:7.19.3"
+"@babel/generator@npm:^7.12.5, @babel/generator@npm:^7.18.7, @babel/generator@npm:^7.19.3, @babel/generator@npm:^7.19.4, @babel/generator@npm:^7.7.2":
+  version: 7.19.5
+  resolution: "@babel/generator@npm:7.19.5"
   dependencies:
-    "@babel/types": ^7.19.3
+    "@babel/types": ^7.19.4
     "@jridgewell/gen-mapping": ^0.3.2
     jsesc: ^2.5.1
-  checksum: b1585e398f6c37f442a2fdac964a326b348fbc8fb99a6aaf4f72bbe993adb0ca792bc0a9c65e59930b2a2e55eb5aa3aab360ceb678d3d40692eb0cda2b7b6aa6
+  checksum: a66eafc540f80fc36c1b009b28bde1d12aff85e7916e7f5adf49c5a8866fecee4906b3c3c6db315d2723ea54e4e5ddfb2913fe6ab424f51dbccf753000930eaf
   languageName: node
   linkType: hard
 
@@ -448,16 +448,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-replace-supers@npm:^7.18.6, @babel/helper-replace-supers@npm:^7.18.9":
-  version: 7.18.9
-  resolution: "@babel/helper-replace-supers@npm:7.18.9"
+"@babel/helper-replace-supers@npm:^7.18.6, @babel/helper-replace-supers@npm:^7.18.9, @babel/helper-replace-supers@npm:^7.19.1":
+  version: 7.19.1
+  resolution: "@babel/helper-replace-supers@npm:7.19.1"
   dependencies:
     "@babel/helper-environment-visitor": ^7.18.9
     "@babel/helper-member-expression-to-functions": ^7.18.9
     "@babel/helper-optimise-call-expression": ^7.18.6
-    "@babel/traverse": ^7.18.9
-    "@babel/types": ^7.18.9
-  checksum: 2de8b29cc4bfa4e241da2de16abd5571709f6eb394206dc16e3a7816976d1691635dd4bc930881e9d798f44b48a5f1849dc7f51a62946f3e8270452be1ec5352
+    "@babel/traverse": ^7.19.1
+    "@babel/types": ^7.19.0
+  checksum: a0e4bf79ebe7d2bb5947169e47a0b4439c73fb0ec57d446cf3ea81b736721129ec373c3f94d2ebd2716b26dd65f8e6c083dac898170d42905e7ba815a2f52c25
   languageName: node
   linkType: hard
 
@@ -488,10 +488,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-string-parser@npm:^7.18.10":
-  version: 7.18.10
-  resolution: "@babel/helper-string-parser@npm:7.18.10"
-  checksum: d554a4393365b624916b5c00a4cc21c990c6617e7f3fe30be7d9731f107f12c33229a7a3db9d829bfa110d2eb9f04790745d421640e3bd245bb412dc0ea123c1
+"@babel/helper-string-parser@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/helper-string-parser@npm:7.19.4"
+  checksum: b2f8a3920b30dfac81ec282ac4ad9598ea170648f8254b10f475abe6d944808fb006aab325d3eb5a8ad3bea8dfa888cfa6ef471050dae5748497c110ec060943
   languageName: node
   linkType: hard
 
@@ -543,12 +543,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.7, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.18.10, @babel/parser@npm:^7.18.8, @babel/parser@npm:^7.19.3":
-  version: 7.19.3
-  resolution: "@babel/parser@npm:7.19.3"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.7, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.18.10, @babel/parser@npm:^7.18.8, @babel/parser@npm:^7.19.3, @babel/parser@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/parser@npm:7.19.4"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 854f1390328a8cea5d95ed2a8655a8976cdb41e72393845df0f86088dc777817a5e015a1a61739d312accccf1a22358fb70707a013d25596251cceba2c8985ee
+  checksum: 5ef97da97915085ff3b9c562b04fb6316074ece52d20de95f44c47b46abf87fd754cbcae769a69570a84652b736afe5bb2cb7dc117aa7ad6d81ab40eed0c613b
   languageName: node
   linkType: hard
 
@@ -615,18 +615,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-decorators@npm:^7.19.0":
-  version: 7.19.0
-  resolution: "@babel/plugin-proposal-decorators@npm:7.19.0"
+"@babel/plugin-proposal-decorators@npm:^7.19.0, @babel/plugin-proposal-decorators@npm:^7.19.1":
+  version: 7.19.3
+  resolution: "@babel/plugin-proposal-decorators@npm:7.19.3"
   dependencies:
     "@babel/helper-create-class-features-plugin": ^7.19.0
     "@babel/helper-plugin-utils": ^7.19.0
-    "@babel/helper-replace-supers": ^7.18.9
+    "@babel/helper-replace-supers": ^7.19.1
     "@babel/helper-split-export-declaration": ^7.18.6
     "@babel/plugin-syntax-decorators": ^7.19.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 0ea38430e6525b3d231c06f9383815aa3a3984505e21d3ef4818001b58815ae4cd4331a8b0cd514b83ff4f6c0aa3f4352b7c73fd5c4bd692eae3d02b4321cc51
+  checksum: d5ff9b963907e960968733a736e329d5c6fd9fe3432379cb8f34858ada9163e92d0c393603602c70126ee6b61f2fff274284b3da9f43e7f3b9f00dbc7052b747
   languageName: node
   linkType: hard
 
@@ -639,6 +639,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 96b1c8a8ad8171d39e9ab106be33bde37ae09b22fb2c449afee9a5edf3c537933d79d963dcdc2694d10677cb96da739cdf1b53454e6a5deab9801f28a818bb2f
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-export-default-from@npm:^7.18.10":
+  version: 7.18.10
+  resolution: "@babel/plugin-proposal-export-default-from@npm:7.18.10"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.9
+    "@babel/plugin-syntax-export-default-from": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 2a12387e095ccd02a1560e5dd40812a83befe581d319685ae2a95f0650a4500381c1d9c710e6e29b34a1b053f9632ee2d3827b937e1cc5c9d2555280da22df53
   languageName: node
   linkType: hard
 
@@ -715,18 +727,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-object-rest-spread@npm:^7.18.9":
-  version: 7.18.9
-  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.18.9"
+"@babel/plugin-proposal-object-rest-spread@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.19.4"
   dependencies:
-    "@babel/compat-data": ^7.18.8
-    "@babel/helper-compilation-targets": ^7.18.9
-    "@babel/helper-plugin-utils": ^7.18.9
+    "@babel/compat-data": ^7.19.4
+    "@babel/helper-compilation-targets": ^7.19.3
+    "@babel/helper-plugin-utils": ^7.19.0
     "@babel/plugin-syntax-object-rest-spread": ^7.8.3
     "@babel/plugin-transform-parameters": ^7.18.8
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 66b9bae741d46edf1c96776d26dfe5d335981e57164ec2450583e3d20dfaa08a5137ffebb897e443913207789f9816bfec4ae845f38762c0196a60949eaffdba
+  checksum: 90a2a59da305e6c8c83831e16079193df33d727a77a90972e286af2c8c0295fddb91b0978b88f16f63080d08a82b08ce3ee82a88b0488b3c51decc73c1d35786
   languageName: node
   linkType: hard
 
@@ -856,6 +868,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: ce307af83cf433d4ec42932329fad25fa73138ab39c7436882ea28742e1c0066626d224e0ad2988724c82644e41601cef607b36194f695cb78a1fcdc959637bd
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-export-default-from@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-syntax-export-default-from@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 4258156553d825abb2ebac920eae6837087b485eb8e0011e05ad1e57004a03441335325feb18185ffbfa0c33a340673e7ab79549080ff2beb4607f88936fedf2
   languageName: node
   linkType: hard
 
@@ -1070,14 +1093,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-block-scoping@npm:^7.18.9":
-  version: 7.18.9
-  resolution: "@babel/plugin-transform-block-scoping@npm:7.18.9"
+"@babel/plugin-transform-block-scoping@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.19.4"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.18.9
+    "@babel/helper-plugin-utils": ^7.19.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: f8064ea431eb7aa349dc5b6be87a650f912b48cd65afde917e8644f6f840d7f9d2ce4795f2aa3955aa5b23a73d4ad38abd03386ae109b4b8702b746c6d35bda3
+  checksum: 86353ccbb57b4a0513ac2b1209271858f9c3f2c56b15a6225ff5f1c97ffb1c48f8984046a718a9835ecdae100cbe80ed0b9ca15a5554e33386671b56a8cd887c
   languageName: node
   linkType: hard
 
@@ -1111,14 +1134,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-destructuring@npm:^7.18.13":
-  version: 7.18.13
-  resolution: "@babel/plugin-transform-destructuring@npm:7.18.13"
+"@babel/plugin-transform-destructuring@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/plugin-transform-destructuring@npm:7.19.4"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.18.9
+    "@babel/helper-plugin-utils": ^7.19.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 83e44ec93a4cfbf69376db8836d00ec803820081bf0f8b6cea73a9b3cd320b8285768d5b385744af4a27edda4b6502245c52d3ed026ea61356faf57bfe78effb
+  checksum: 0ca40f6abf7273dafefb7a1cc11fef2b9ab3edbd23188cdcff8cd5e30783b89d64e7813e44aae9efab417b90972ae80971bf6c4130eeeb112bcfb44100c72657
   languageName: node
   linkType: hard
 
@@ -1517,11 +1540,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:^7.18.2, @babel/preset-env@npm:^7.18.6, @babel/preset-env@npm:^7.19.0":
-  version: 7.19.3
-  resolution: "@babel/preset-env@npm:7.19.3"
+"@babel/preset-env@npm:^7.18.2, @babel/preset-env@npm:^7.18.6, @babel/preset-env@npm:^7.19.0, @babel/preset-env@npm:^7.19.1":
+  version: 7.19.4
+  resolution: "@babel/preset-env@npm:7.19.4"
   dependencies:
-    "@babel/compat-data": ^7.19.3
+    "@babel/compat-data": ^7.19.4
     "@babel/helper-compilation-targets": ^7.19.3
     "@babel/helper-plugin-utils": ^7.19.0
     "@babel/helper-validator-option": ^7.18.6
@@ -1536,7 +1559,7 @@ __metadata:
     "@babel/plugin-proposal-logical-assignment-operators": ^7.18.9
     "@babel/plugin-proposal-nullish-coalescing-operator": ^7.18.6
     "@babel/plugin-proposal-numeric-separator": ^7.18.6
-    "@babel/plugin-proposal-object-rest-spread": ^7.18.9
+    "@babel/plugin-proposal-object-rest-spread": ^7.19.4
     "@babel/plugin-proposal-optional-catch-binding": ^7.18.6
     "@babel/plugin-proposal-optional-chaining": ^7.18.9
     "@babel/plugin-proposal-private-methods": ^7.18.6
@@ -1560,10 +1583,10 @@ __metadata:
     "@babel/plugin-transform-arrow-functions": ^7.18.6
     "@babel/plugin-transform-async-to-generator": ^7.18.6
     "@babel/plugin-transform-block-scoped-functions": ^7.18.6
-    "@babel/plugin-transform-block-scoping": ^7.18.9
+    "@babel/plugin-transform-block-scoping": ^7.19.4
     "@babel/plugin-transform-classes": ^7.19.0
     "@babel/plugin-transform-computed-properties": ^7.18.9
-    "@babel/plugin-transform-destructuring": ^7.18.13
+    "@babel/plugin-transform-destructuring": ^7.19.4
     "@babel/plugin-transform-dotall-regex": ^7.18.6
     "@babel/plugin-transform-duplicate-keys": ^7.18.9
     "@babel/plugin-transform-exponentiation-operator": ^7.18.6
@@ -1590,7 +1613,7 @@ __metadata:
     "@babel/plugin-transform-unicode-escapes": ^7.18.10
     "@babel/plugin-transform-unicode-regex": ^7.18.6
     "@babel/preset-modules": ^0.1.5
-    "@babel/types": ^7.19.3
+    "@babel/types": ^7.19.4
     babel-plugin-polyfill-corejs2: ^0.3.3
     babel-plugin-polyfill-corejs3: ^0.6.0
     babel-plugin-polyfill-regenerator: ^0.4.1
@@ -1598,7 +1621,7 @@ __metadata:
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: f967cf48fa54f4b87cfd6dcad0d8c6249379af55c657f7519d2e3538ebb5e3f73b465677d88a6730e569f45150a2966e14b43bd1134d434a12ca351c14381871
+  checksum: f12af25281f3c5e7df60fa1e79ad481ddd7f6a111d4c0fabcffdabf0eaed3a01b4f8c647ae5445ed1f58df70f52083ffd283e8919ade7afa73801a49c733d22c
   languageName: node
   linkType: hard
 
@@ -1689,32 +1712,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.12.9, @babel/traverse@npm:^7.18.11, @babel/traverse@npm:^7.18.8, @babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.19.0, @babel/traverse@npm:^7.19.3, @babel/traverse@npm:^7.7.2":
-  version: 7.19.3
-  resolution: "@babel/traverse@npm:7.19.3"
+"@babel/traverse@npm:^7.12.9, @babel/traverse@npm:^7.18.11, @babel/traverse@npm:^7.18.8, @babel/traverse@npm:^7.19.0, @babel/traverse@npm:^7.19.1, @babel/traverse@npm:^7.19.3, @babel/traverse@npm:^7.7.2":
+  version: 7.19.4
+  resolution: "@babel/traverse@npm:7.19.4"
   dependencies:
     "@babel/code-frame": ^7.18.6
-    "@babel/generator": ^7.19.3
+    "@babel/generator": ^7.19.4
     "@babel/helper-environment-visitor": ^7.18.9
     "@babel/helper-function-name": ^7.19.0
     "@babel/helper-hoist-variables": ^7.18.6
     "@babel/helper-split-export-declaration": ^7.18.6
-    "@babel/parser": ^7.19.3
-    "@babel/types": ^7.19.3
+    "@babel/parser": ^7.19.4
+    "@babel/types": ^7.19.4
     debug: ^4.1.0
     globals: ^11.1.0
-  checksum: ef16c98fca7f2c347febd06737c13230ea103d619a0d6c142445bc8eff6359d2fce026f27dece02b4838f614cda8a9330bc4a576ccc6cd0ce21844d1d0205769
+  checksum: 8ae1ac3dace181620cd0e3078aec99604a48302fb873193a171e37a7cc4f8909ed496f286bf08c6473f9692db36423e2601eb9c771493d19f6a5fd1a56745af5
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.7, @babel/types@npm:^7.16.0, @babel/types@npm:^7.18.10, @babel/types@npm:^7.18.4, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.19.0, @babel/types@npm:^7.19.3, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
-  version: 7.19.3
-  resolution: "@babel/types@npm:7.19.3"
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.7, @babel/types@npm:^7.16.0, @babel/types@npm:^7.18.10, @babel/types@npm:^7.18.4, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.19.0, @babel/types@npm:^7.19.3, @babel/types@npm:^7.19.4, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
+  version: 7.19.4
+  resolution: "@babel/types@npm:7.19.4"
   dependencies:
-    "@babel/helper-string-parser": ^7.18.10
+    "@babel/helper-string-parser": ^7.19.4
     "@babel/helper-validator-identifier": ^7.19.1
     to-fast-properties: ^2.0.0
-  checksum: 34a5b3db3b99a1a80ec2a784c2bb0e48769a38f1526dc377a5753a3ac5e5704663c405a393117ecc7a9df9da07b01625be7c4c3fee43ae46aba23b0c40928d77
+  checksum: 4032f6407093f80dd4f4764be676f7527d2a5c0381586967cd79683cf8af01cdc16745a381b9cef045f702f0c9b0dffd880d84ee55dad59ba01bd23d5d52a8e0
   languageName: node
   linkType: hard
 
@@ -3017,6 +3040,14 @@ __metadata:
   checksum: 330098b771183bedb8467d359a7bf109ef1f74fbfc4b6864981cddcd19105c6a7116329390b6cea536f3741b31f15c8ad7dca813de66683ddf7763acdbf462fd
   languageName: node
   linkType: hard
+
+"@moonrepo/report@workspace:packages/report":
+  version: 0.0.0-use.local
+  resolution: "@moonrepo/report@workspace:packages/report"
+  dependencies:
+    "@moonrepo/types": "workspace:^"
+  languageName: unknown
+  linkType: soft
 
 "@moonrepo/runtime@workspace:^, @moonrepo/runtime@workspace:packages/runtime":
   version: 0.0.0-use.local
@@ -5008,9 +5039,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-jsx-dom-expressions@npm:^0.34.5":
-  version: 0.34.7
-  resolution: "babel-plugin-jsx-dom-expressions@npm:0.34.7"
+"babel-plugin-jsx-dom-expressions@npm:^0.34.11":
+  version: 0.34.13
+  resolution: "babel-plugin-jsx-dom-expressions@npm:0.34.13"
   dependencies:
     "@babel/helper-module-imports": 7.16.0
     "@babel/plugin-syntax-jsx": ^7.16.5
@@ -5018,7 +5049,7 @@ __metadata:
     html-entities: 2.3.2
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 21c6b8dc523ed6c958dd7c2fcaefed689b458524c57f97d5d588276de692d5e39bbe8ef68036fb689d7807ecec71bd75bc6c2847d95d1e3db9ac2d8d9869f04e
+  checksum: 3c3d5ec1edacdf8d2550d5812948157f4fe50b8e06da3e679465a7101240993d5711794b1e97cbf8fcde81b74a5a900e5d3d3e14d4d9dafdb6d1f775c35de990
   languageName: node
   linkType: hard
 
@@ -5092,14 +5123,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-preset-solid@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "babel-preset-solid@npm:1.5.4"
+"babel-preset-moon@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "babel-preset-moon@npm:1.0.2"
   dependencies:
-    babel-plugin-jsx-dom-expressions: ^0.34.5
+    "@babel/plugin-proposal-class-properties": ^7.18.6
+    "@babel/plugin-proposal-decorators": ^7.19.1
+    "@babel/plugin-proposal-export-default-from": ^7.18.10
+    "@babel/plugin-proposal-export-namespace-from": ^7.18.9
+    "@babel/plugin-proposal-private-methods": ^7.18.6
+    "@babel/preset-env": ^7.19.1
+    "@babel/preset-react": ^7.18.6
+    "@babel/preset-typescript": ^7.18.6
+    babel-plugin-conditional-invariant: ^2.0.2
+    babel-plugin-env-constants: ^2.0.2
+    babel-preset-solid: ^1.5.6
+  peerDependencies:
+    "@babel/core": ">=7.0.0"
+  checksum: 341eed70905109b4a34620a9ba39d000829db06ffda75cd24e87e97ee089f915917b0d41399c65fd72ea8a1659860108ad2d79745adba53dd9d4ad43e659f3d4
+  languageName: node
+  linkType: hard
+
+"babel-preset-solid@npm:^1.5.4, babel-preset-solid@npm:^1.5.6":
+  version: 1.5.7
+  resolution: "babel-preset-solid@npm:1.5.7"
+  dependencies:
+    babel-plugin-jsx-dom-expressions: ^0.34.11
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 7aec177faa2b67b28128d2ef5cf793f43ce826ebb4c2b34b571e41f4f3a01d942ae558dc58a6c608a2fcd34e4ffd08186c4c558dacc222d14b8f61adcc0189fa
+  checksum: 7d3ddf572ff95337686e7cdbbe375830d5fb69c777fbebd6040a8c34e395234ac4a765172ce47e56e2b923282bd3648302262bdfbbee039943768056783f24d4
   languageName: node
   linkType: hard
 
@@ -10909,6 +10961,7 @@ __metadata:
   dependencies:
     "@moonrepo/cli": "workspace:*"
     "@types/node": ^17.0.45
+    babel-preset-moon: ^1.0.2
     eslint: ^8.24.0
     eslint-config-moon: ^1.0.2
     execa: ^6.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3054,11 +3054,11 @@ __metadata:
   resolution: "@moonrepo/runtime@workspace:packages/runtime"
   dependencies:
     "@boost/common": ^4.0.0
-    "@moonrepo/types": ^0.0.4
+    "@moonrepo/types": "workspace:^"
   languageName: unknown
   linkType: soft
 
-"@moonrepo/types@^0.0.4, @moonrepo/types@workspace:^, @moonrepo/types@workspace:packages/types":
+"@moonrepo/types@workspace:^, @moonrepo/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@moonrepo/types@workspace:packages/types"
   languageName: unknown


### PR DESCRIPTION
This extracts all the run report utils from https://github.com/moonrepo/run-report-action so that we can use them in other packages, like the vscode extension.