### PR TITLE
build: Enable LTO.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,5 +3,6 @@
 
 [profile.release]
 codegen-units = 1
+lto = true
 panic = "abort"
 strip = "debuginfo"

--- a/.github/workflows/rust-stub.yml
+++ b/.github/workflows/rust-stub.yml
@@ -3,6 +3,7 @@ name: Rust
 on:
   pull_request:
     paths-ignore:
+      - .cargo/config.toml
       - .github/workflows/rust.yml
       - crates/**
       - tests/**

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
       - master
   pull_request:
     paths:
+      - .cargo/config.toml
       - .github/workflows/rust.yml
       - crates/**
       - tests/**


### PR DESCRIPTION
This enables link-time optimization, which should increase runtime performance. I have no way of benchmarking/verifying this at this time though.

It however does increase release build times by roughly 1 min, which isn't bad.

```
lto=false, non-cpu
cargo build --release  1424.32s user 85.85s system 618% cpu 4:04.21 total
cargo build --release  1345.28s user 70.56s system 721% cpu 3:16.37 total 
= 13.5mb

lto=true, non-cpu
cargo build --release  1252.25s user 71.29s system 457% cpu 4:49.60 total
cargo build --release  1233.79s user 68.33s system 455% cpu 4:46.13 total
= 12.1mb

--- 

RUSTFLAGS="-C target-cpu=native" 

lto=false, cpu
cargo build --release  1406.34s user 73.71s system 662% cpu 3:43.44 total
cargo build --release  1409.73s user 76.49s system 652% cpu 3:47.62 total
= 13.6mb

lto=true, cpu
cargo build --release  1328.17s user 75.95s system 424% cpu 5:30.63 total
cargo build --release  1301.23s user 76.17s system 432% cpu 5:18.44 total
= 12.2mb
```

I've also opted _against_ `-C target-cpu=native`, as I cannot guarantee this will work on all downstream consumer machines.