### PR TITLE
breaking: Use dashes when cleaning IDs.

### DIFF
--- a/crates/generator/tests/generator_test.rs
+++ b/crates/generator/tests/generator_test.rs
@@ -67,19 +67,19 @@ mod create_template {
             .unwrap();
 
         assert!(dir
-            .join("templates/sometemPlatE-withRandom-Values123_")
+            .join("templates/so-me-temPlatE--with-Ran-dom-Valu-es-123_")
             .exists());
         assert!(dir
-            .join("templates/sometemPlatE-withRandom-Values123_/template.yml")
+            .join("templates/so-me-temPlatE--with-Ran-dom-Valu-es-123_/template.yml")
             .exists());
 
         assert_eq!(
             template.name,
-            "sometemPlatE-withRandom-Values123_".to_owned()
+            "so-me-temPlatE--with-Ran-dom-Valu-es-123_".to_owned()
         );
         assert_eq!(
             template.root,
-            dir.join("templates/sometemPlatE-withRandom-Values123_")
+            dir.join("templates/so-me-temPlatE--with-Ran-dom-Valu-es-123_")
         );
     }
 }

--- a/crates/utils/src/regex.rs
+++ b/crates/utils/src/regex.rs
@@ -40,7 +40,7 @@ pub fn create_regex(value: &str) -> Result<Regex, MoonError> {
 }
 
 pub fn clean_id(id: &str) -> String {
-    ID_CLEAN.replace_all(id, "").to_string()
+    ID_CLEAN.replace_all(id, "-").to_string()
 }
 
 pub fn matches_id(id: &str) -> bool {
@@ -57,4 +57,23 @@ pub fn matches_token_func(token: &str) -> bool {
 
 pub fn matches_token_var(token: &str) -> bool {
     TOKEN_VAR_PATTERN.is_match(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod clean_ids {
+        use super::*;
+
+        #[test]
+        fn doesnt_clean_supported_chars() {
+            assert_eq!(clean_id("foo-bar_baz/123"), "foo-bar_baz/123");
+        }
+
+        #[test]
+        fn replaces_unsupported_chars() {
+            assert_eq!(clean_id("foo bar.baz$123"), "foo-bar-baz-123");
+        }
+    }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+#### 💥 Breaking
+
+- Refactored project and task name/id cleaning. Previously, unsupported characters were simply
+  removed. Instead, we now replace them with dashes for better readability.
+
 #### ⚙️ Internal
 
 - Integrated [mimalloc](https://github.com/microsoft/mimalloc). This reduces memory cost and


### PR DESCRIPTION
This has much better readability for common cases.