### PR TITLE
new: Support shorthand "self" target scopes.

### DIFF
--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -16,7 +16,10 @@ use validator::{Validate, ValidationError};
 
 fn validate_deps(list: &[String]) -> Result<(), ValidationError> {
     for (index, item) in list.iter().enumerate() {
-        validate_target(format!("deps[{}]", index), item)?;
+        // When no target scope, it's assumed to be a self scope
+        if item.contains(':') {
+            validate_target(format!("deps[{}]", index), item)?;
+        }
     }
 
     Ok(())

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -1,7 +1,9 @@
 use crate::project::local_config::{ProjectConfig, ProjectLanguage};
 use crate::project::task_options::TaskOptionsConfig;
 use crate::types::{FilePath, InputValue, TargetID};
-use crate::validators::{skip_if_default, validate_child_or_root_path, validate_target};
+use crate::validators::{
+    skip_if_default, validate_child_or_root_path, validate_id, validate_target,
+};
 use moon_utils::process::split_args;
 use moon_utils::process::ArgsParseError;
 use moon_utils::regex::{ENV_VAR, NODE_COMMAND, UNIX_SYSTEM_COMMAND, WINDOWS_SYSTEM_COMMAND};
@@ -16,9 +18,13 @@ use validator::{Validate, ValidationError};
 
 fn validate_deps(list: &[String]) -> Result<(), ValidationError> {
     for (index, item) in list.iter().enumerate() {
+        let key = format!("deps[{}]", index);
+
         // When no target scope, it's assumed to be a self scope
         if item.contains(':') {
-            validate_target(format!("deps[{}]", index), item)?;
+            validate_target(key, item)?;
+        } else {
+            validate_id(key, item)?;
         }
     }
 

--- a/crates/config/src/workspace/runner.rs
+++ b/crates/config/src/workspace/runner.rs
@@ -1,4 +1,7 @@
-use crate::{errors::create_validation_error, validators::validate_target};
+use crate::{
+    errors::create_validation_error,
+    validators::{validate_id, validate_target},
+};
 use moon_utils::{string_vec, time};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -6,9 +9,13 @@ use validator::{Validate, ValidationError};
 
 fn validate_deps(list: &[String]) -> Result<(), ValidationError> {
     for (index, item) in list.iter().enumerate() {
+        let key = format!("implicitDeps[{}]", index);
+
         // When no target scope, it's assumed to be a self scope
         if item.contains(':') {
-            validate_target(format!("implicitDeps[{}]", index), item)?;
+            validate_target(key, item)?;
+        } else {
+            validate_id(key, item)?;
         }
     }
 

--- a/crates/config/src/workspace/runner.rs
+++ b/crates/config/src/workspace/runner.rs
@@ -1,8 +1,19 @@
-use crate::errors::create_validation_error;
+use crate::{errors::create_validation_error, validators::validate_target};
 use moon_utils::{string_vec, time};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationError};
+
+fn validate_deps(list: &[String]) -> Result<(), ValidationError> {
+    for (index, item) in list.iter().enumerate() {
+        // When no target scope, it's assumed to be a self scope
+        if item.contains(':') {
+            validate_target(format!("implicitDeps[{}]", index), item)?;
+        }
+    }
+
+    Ok(())
+}
 
 fn validate_cache_lifetime(value: &str) -> Result<(), ValidationError> {
     if let Err(e) = time::parse_duration(value) {
@@ -23,6 +34,7 @@ pub struct RunnerConfig {
     #[validate(custom = "validate_cache_lifetime")]
     pub cache_lifetime: String,
 
+    #[validate(custom = "validate_deps")]
     pub implicit_deps: Vec<String>,
 
     pub implicit_inputs: Vec<String>,

--- a/crates/project-graph/src/graph.rs
+++ b/crates/project-graph/src/graph.rs
@@ -357,7 +357,7 @@ impl ProjectGraph {
                 // Inferred tasks should not override explicit tasks
                 #[allow(clippy::map_entry)]
                 if !project.tasks.contains_key(&task_id) {
-                    let task = Task::from_config(Target::format(id, &task_id)?, &task_config)?;
+                    let task = Task::from_config(Target::new(id, &task_id)?, &task_config)?;
 
                     project.tasks.insert(task_id, task);
                 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -206,7 +206,7 @@ fn create_tasks_from_config(
 
         tasks.insert(
             task_name.to_owned(),
-            Task::from_config(Target::format(project_id, task_name)?, task_config)?,
+            Task::from_config(Target::new(project_id, task_name)?, task_config)?,
         );
     }
 
@@ -225,7 +225,7 @@ fn create_tasks_from_config(
             // Insert a new task
             tasks.insert(
                 task_id.clone(),
-                Task::from_config(Target::format(project_id, task_id)?, task_config)?,
+                Task::from_config(Target::new(project_id, task_id)?, task_config)?,
             );
         }
     }

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -294,7 +294,11 @@ mod tasks {
         let mut task =
             create_expanded_task_internal(workspace_root, &project_root, Some(config)).unwrap();
 
+        let mut parts = target.split(':');
+        parts.next();
+
         task.log_target = format!("moon:project:{}", target);
+        task.id = parts.next().unwrap().to_string();
         task.target = target;
 
         Ok(task)
@@ -1484,10 +1488,11 @@ mod workspace {
             let mut task =
                 create_expanded_task(&workspace_root, &workspace_root.join("rename-merge"), None)
                     .unwrap();
+            task.id = "foo".to_owned();
             task.target = "id:foo".to_owned();
             task.command = "a".to_owned();
             task.args.push("renamed-and-merge-foo".to_owned());
-            task.log_target = String::from("moon:project:id:foo");
+            task.log_target = "moon:project:id:foo".to_owned();
 
             assert_eq!(*project.get_task("foo").unwrap(), task);
 

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -314,7 +314,7 @@ mod tasks {
         );
 
         let mut task = Task::from_config(
-            Target::format("id", "standard").unwrap(),
+            Target::new("id", "standard").unwrap(),
             &mock_task_config("cmd"),
         )
         .unwrap();
@@ -355,28 +355,28 @@ mod tasks {
         );
 
         let mut build = Task::from_config(
-            Target::format("id", "build").unwrap(),
+            Target::new("id", "build").unwrap(),
             &mock_task_config("webpack"),
         )
         .unwrap();
         build.platform = PlatformType::Node;
 
         let mut std = Task::from_config(
-            Target::format("id", "standard").unwrap(),
+            Target::new("id", "standard").unwrap(),
             &mock_task_config("cmd"),
         )
         .unwrap();
         std.platform = PlatformType::System;
 
         let mut test = Task::from_config(
-            Target::format("id", "test").unwrap(),
+            Target::new("id", "test").unwrap(),
             &mock_task_config("jest"),
         )
         .unwrap();
         test.platform = PlatformType::Node;
 
         let mut lint = Task::from_config(
-            Target::format("id", "lint").unwrap(),
+            Target::new("id", "lint").unwrap(),
             &mock_task_config("eslint"),
         )
         .unwrap();
@@ -444,25 +444,25 @@ mod tasks {
             .unwrap();
 
         let mut build = Task::from_config(
-            Target::format("id", "build").unwrap(),
+            Target::new("id", "build").unwrap(),
             &mock_task_config("webpack"),
         )
         .unwrap();
 
         let mut std = Task::from_config(
-            Target::format("id", "standard").unwrap(),
+            Target::new("id", "standard").unwrap(),
             &mock_task_config("cmd"),
         )
         .unwrap();
 
         let mut test = Task::from_config(
-            Target::format("id", "test").unwrap(),
+            Target::new("id", "test").unwrap(),
             &mock_task_config("jest"),
         )
         .unwrap();
 
         let mut lint = Task::from_config(
-            Target::format("id", "lint").unwrap(),
+            Target::new("id", "lint").unwrap(),
             &mock_task_config("eslint"),
         )
         .unwrap();
@@ -500,7 +500,7 @@ mod tasks {
             .unwrap();
 
         let mut build = Task::from_config(
-            Target::format("id", "build").unwrap(),
+            Target::new("id", "build").unwrap(),
             &mock_task_config("webpack"),
         )
         .unwrap();
@@ -531,25 +531,25 @@ mod tasks {
             .unwrap();
 
         let mut build = Task::from_config(
-            Target::format("id", "build").unwrap(),
+            Target::new("id", "build").unwrap(),
             &mock_task_config("webpack"),
         )
         .unwrap();
 
         let mut std = Task::from_config(
-            Target::format("id", "standard").unwrap(),
+            Target::new("id", "standard").unwrap(),
             &mock_task_config("cmd"),
         )
         .unwrap();
 
         let mut test = Task::from_config(
-            Target::format("id", "test").unwrap(),
+            Target::new("id", "test").unwrap(),
             &mock_task_config("jest"),
         )
         .unwrap();
 
         let mut lint = Task::from_config(
-            Target::format("id", "lint").unwrap(),
+            Target::new("id", "lint").unwrap(),
             &mock_task_config("eslint"),
         )
         .unwrap();

--- a/crates/runner/src/dep_graph.rs
+++ b/crates/runner/src/dep_graph.rs
@@ -191,7 +191,7 @@ impl DepGraph {
                 }
             }
             // ~:task
-            TargetProjectScope::Own => {
+            TargetProjectScope::OwnSelf => {
                 target.fail_with(TargetError::NoProjectSelfInRunContext)?;
             }
         };

--- a/crates/task/src/target.rs
+++ b/crates/task/src/target.rs
@@ -9,7 +9,7 @@ pub enum TargetProjectScope {
     All,           // :task
     Deps,          // ^:task
     Id(ProjectID), // project:task
-    Own,           // ~:task
+    OwnSelf,       // ~:task
 }
 
 // impl fmt::Display for TargetProjectScope {
@@ -59,6 +59,15 @@ impl Target {
         })
     }
 
+    pub fn new_self(task_id: &str) -> Result<Target, TargetError> {
+        Ok(Target {
+            id: Target::format("~", task_id)?,
+            project: TargetProjectScope::OwnSelf,
+            project_id: None,
+            task_id: task_id.to_owned(),
+        })
+    }
+
     pub fn format(project_id: &str, task_id: &str) -> Result<TargetID, TargetError> {
         Ok(format!("{}:{}", project_id, task_id))
     }
@@ -79,7 +88,7 @@ impl Target {
             Some(value) => match value.as_str() {
                 "" => TargetProjectScope::All,
                 "^" => TargetProjectScope::Deps,
-                "~" => TargetProjectScope::Own,
+                "~" => TargetProjectScope::OwnSelf,
                 id => {
                     project_id = Some(id.to_owned());
                     TargetProjectScope::Id(id.to_owned())
@@ -229,7 +238,7 @@ mod tests {
             Target::parse("~:build").unwrap(),
             Target {
                 id: String::from("~:build"),
-                project: TargetProjectScope::Own,
+                project: TargetProjectScope::OwnSelf,
                 project_id: None,
                 task_id: "build".to_owned(),
                 // task: TargetTask::Id("build".to_owned())

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -410,7 +410,11 @@ impl Task {
         };
 
         for dep in &self.deps {
-            let target = Target::parse(dep)?;
+            let target = if dep.contains(':') {
+                Target::parse(dep)?
+            } else {
+                Target::new_self(dep)?
+            };
 
             match &target.project {
                 // ^:task
@@ -420,7 +424,7 @@ impl Task {
                     }
                 }
                 // ~:task
-                TargetProjectScope::Own => {
+                TargetProjectScope::OwnSelf => {
                     push_dep(Target::format(owner_id, &target.task_id)?);
                 }
                 // project:task

--- a/crates/task/src/test.rs
+++ b/crates/task/src/test.rs
@@ -71,7 +71,7 @@ pub fn create_file_groups() -> HashMap<String, FileGroup> {
 
 pub fn create_initial_task(config: Option<TaskConfig>) -> Task {
     Task::from_config(
-        Target::format("project", "task").unwrap(),
+        Target::new("project", "task").unwrap(),
         &config.unwrap_or_default(),
     )
     .unwrap()

--- a/crates/task/tests/task_test.rs
+++ b/crates/task/tests/task_test.rs
@@ -1,6 +1,6 @@
 use moon_config::{TaskCommandArgs, TaskConfig, TaskOptionEnvFile, TaskOptionsConfig};
 use moon_task::test::create_expanded_task;
-use moon_task::{Task, TaskOptions};
+use moon_task::{Target, Task, TaskOptions};
 use moon_utils::test::{create_sandbox, get_fixtures_dir};
 use moon_utils::{glob, string_vec};
 use std::collections::{HashMap, HashSet};
@@ -30,7 +30,8 @@ mod from_config {
 
     #[test]
     fn sets_defaults() {
-        let task = Task::from_config("foo:test".to_owned(), &TaskConfig::default()).unwrap();
+        let task =
+            Task::from_config(Target::new("foo", "test").unwrap(), &TaskConfig::default()).unwrap();
 
         assert_eq!(task.inputs, string_vec!["**/*"]);
         assert_eq!(task.log_target, "moon:project:foo:test");
@@ -57,7 +58,7 @@ mod from_config {
     #[test]
     fn changes_options_if_local() {
         let task = Task::from_config(
-            "foo:test".to_owned(),
+            Target::new("foo", "test").unwrap(),
             &TaskConfig {
                 local: true,
                 ..TaskConfig::default()
@@ -79,7 +80,7 @@ mod from_config {
     #[test]
     fn determines_local_from_command() {
         let task = Task::from_config(
-            "foo:test".to_owned(),
+            Target::new("foo", "test").unwrap(),
             &TaskConfig {
                 command: Some(TaskCommandArgs::String("dev".to_owned())),
                 ..TaskConfig::default()
@@ -101,7 +102,7 @@ mod from_config {
     #[test]
     fn can_override_local_output_style() {
         let task = Task::from_config(
-            "foo:test".to_owned(),
+            Target::new("foo", "test").unwrap(),
             &TaskConfig {
                 local: true,
                 options: TaskOptionsConfig {
@@ -127,7 +128,7 @@ mod from_config {
     #[test]
     fn converts_env_file_enum() {
         let task = Task::from_config(
-            "foo:test".to_owned(),
+            Target::new("foo", "test").unwrap(),
             &TaskConfig {
                 options: TaskOptionsConfig {
                     env_file: Some(TaskOptionEnvFile::Enabled(true)),
@@ -150,7 +151,7 @@ mod from_config {
     #[test]
     fn handles_command_string() {
         let task = Task::from_config(
-            "foo:test".to_owned(),
+            Target::new("foo", "test").unwrap(),
             &TaskConfig {
                 command: Some(TaskCommandArgs::String("foo --bar".to_owned())),
                 args: Some(TaskCommandArgs::Sequence(string_vec!["--baz"])),
@@ -166,7 +167,7 @@ mod from_config {
     #[test]
     fn handles_command_list() {
         let task = Task::from_config(
-            "foo:test".to_owned(),
+            Target::new("foo", "test").unwrap(),
             &TaskConfig {
                 command: Some(TaskCommandArgs::Sequence(string_vec!["foo", "--bar"])),
                 args: Some(TaskCommandArgs::String("--baz".to_owned())),

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,11 @@
 
 #### 🚀 Updates
 
+##### Tasks
+
+- When defining `deps` within the current project, the `~:` prefix is now optional. For example,
+  `~:build` can now be written as simply `build`.
+
 ##### Generator
 
 - Enum variables can now declare an object form for `values`, so that a custom label can be provided

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -33,6 +33,7 @@ export interface Task {
 	command: string;
 	deps: string[];
 	env: Record<string, string>;
+	id: string;
 	inputs: string[];
 	inputGlobs: string[];
 	inputPaths: string[];

--- a/tests/fixtures/task-deps/self-no-prefix/moon.yml
+++ b/tests/fixtures/task-deps/self-no-prefix/moon.yml
@@ -1,0 +1,11 @@
+tasks:
+  clean:
+    command: rm
+    args: -rf
+  build:
+    command: tsc
+  lint:
+    command: eslint
+    deps:
+      - clean
+      - build

--- a/website/docs/concepts/target.mdx
+++ b/website/docs/concepts/target.mdx
@@ -46,10 +46,9 @@ $ moon run :lint
 
 > Only available when configuring a task.
 
-When you want to include a reference for each project in your
-[`dependsOn`](../config/project#dependson) list, you can utilize the `^` scope. This will be
-expanded to _all_ depended on projects. If you do not want all projects, then you'll need to
-explicitly define them.
+When you want to include a reference for each project [that's depended on](./project#dependencies),
+you can utilize the `^` scope. This will be expanded to _all_ depended on projects. If you do not
+want all projects, then you'll need to explicitly define them.
 
 ```yaml title="moon.yml"
 dependsOn:
@@ -76,10 +75,10 @@ tasks:
 
 > Only available when configuring a task.
 
-When referring to another task within the current project, you can utilize the `~` scope, which will
-be expanded to the current project's name. This is useful for situations where the name is unknown,
-for example, when configuring [`.moon/project.yml`](../config/global-project). Or if you just want a
-shortcut!
+When referring to another task within the current project, you can utilize the `~` scope, or emit
+the `~:` prefix altogether, which will be expanded to the current project's name. This is useful for
+situations where the name is unknown, for example, when configuring
+[`.moon/project.yml`](../config/global-project). Or if you just want a shortcut!
 
 ```yaml title=".moon/project.yml"
 # Configured as
@@ -88,6 +87,8 @@ tasks:
 		command: 'eslint'
 		deps:
 			- '~:typecheck'
+			# OR
+			- 'typecheck'
 	typecheck:
 		command: 'tsc'
 

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -298,6 +298,8 @@ tasks:
     deps:
       - 'apiClients:build'
       - 'designSystem:build'
+      # A task within the current project
+      - 'codegen'
 ```
 
 ### `env`


### PR DESCRIPTION
Instead of writing `~:build`, you can simply write `build`. This defaults to the "self" scope.

I've also added the `id` field to tasks, since it's required downstream by tools.