### PR TITLE
new: Add `--report` support to `moon check`.

### DIFF
--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -290,6 +290,9 @@ pub enum Commands {
     Check {
         #[arg(help = "List of project IDs to explicitly check")]
         ids: Vec<ProjectID>,
+
+        #[arg(long, help = "Generate a run report for the current actions")]
+        report: bool,
     },
 
     // moon ci

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -3,7 +3,15 @@ use crate::helpers::load_workspace;
 use moon_project::Project;
 use std::env;
 
-pub async fn check(project_ids: &Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Default)]
+pub struct CheckOptions {
+    pub report: bool,
+}
+
+pub async fn check(
+    project_ids: &Vec<String>,
+    options: CheckOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
     let workspace = load_workspace().await?;
     let mut projects: Vec<Project> = vec![];
 
@@ -28,7 +36,15 @@ pub async fn check(project_ids: &Vec<String>) -> Result<(), Box<dyn std::error::
     }
 
     // Run targets using our run command
-    run(&targets, RunOptions::default(), Some(workspace)).await?;
+    run(
+        &targets,
+        RunOptions {
+            report: options.report,
+            ..RunOptions::default()
+        },
+        Some(workspace),
+    )
+    .await?;
 
     Ok(())
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -5,7 +5,7 @@ mod helpers;
 pub mod queries;
 
 use crate::commands::bin::bin;
-use crate::commands::check::check;
+use crate::commands::check::{check, CheckOptions};
 use crate::commands::ci::{ci, CiOptions};
 use crate::commands::clean::{clean, CleanOptions};
 use crate::commands::dep_graph::dep_graph;
@@ -80,7 +80,7 @@ pub async fn run_cli() {
             })
             .await
         }
-        Commands::Check { ids } => check(ids).await,
+        Commands::Check { ids, report } => check(ids, CheckOptions { report: *report }).await,
         Commands::Clean { lifetime } => {
             clean(CleanOptions {
                 cache_liftime: lifetime.to_owned(),

--- a/crates/cli/tests/check_test.rs
+++ b/crates/cli/tests/check_test.rs
@@ -55,3 +55,32 @@ fn runs_tasks_from_multiple_project() {
     assert!(predicate::str::contains("noop:noopWithDeps").eval(&output));
     assert!(predicate::str::contains("depsA:dependencyOrder").eval(&output)); // dep of noop
 }
+
+mod reports {
+    use super::*;
+
+    #[test]
+    fn doesnt_create_a_report_by_default() {
+        let fixture = create_sandbox_with_git("cases");
+
+        create_moon_command(fixture.path())
+            .arg("check")
+            .arg("base")
+            .assert();
+
+        assert!(!fixture.path().join(".moon/cache/runReport.json").exists());
+    }
+
+    #[test]
+    fn creates_report_when_option_passed() {
+        let fixture = create_sandbox_with_git("cases");
+
+        create_moon_command(fixture.path())
+            .arg("check")
+            .arg("base")
+            .arg("--report")
+            .assert();
+
+        assert!(fixture.path().join(".moon/cache/runReport.json").exists());
+    }
+}

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - All YAML configuration files can now use
   [aliases and anchors](https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/)!
+- The `moon check` command can now use the `--report` option.
 
 ##### Tasks
 

--- a/website/blog/2022-10-21_v0.17.mdx
+++ b/website/blog/2022-10-21_v0.17.mdx
@@ -135,6 +135,7 @@ full list of changes.
 - Template enum variables can now define objects for their
   [`values`](../docs/config/template#values).
 - Task `deps` can now omit the `~:` prefix for tasks within the current project.
+- The `moon check` command can now use the `--report` option.
 
 ## What's next?
 

--- a/website/docs/commands/check.mdx
+++ b/website/docs/commands/check.mdx
@@ -26,3 +26,8 @@ $ moon check client server
 
 - `[...names]` - List of project names or aliases to explicitly check, as defined in
   [`projects`](../config/workspace#projects).
+
+### Options
+
+- `--report` - Generate a report of the ran actions. Report is written to
+  `.moon/cache/runReport.json`.


### PR DESCRIPTION
Want this for the VS Code extension!