### PR TITLE
breaking: Rename task `type` to `platform`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1866,6 +1866,7 @@ dependencies = [
  "moon_logger",
  "moon_utils",
  "serde",
+ "strum",
  "thiserror",
 ]
 

--- a/crates/cli/tests/snapshots/migrate_test__from_package_json__converts_scripts-2.snap
+++ b/crates/cli/tests/snapshots/migrate_test__from_package_json__converts_scripts-2.snap
@@ -9,7 +9,7 @@ tasks:
     command:
     - eslint
     - .
-    type: node
+    platform: node
   lint-fix:
     command:
     - moon
@@ -17,5 +17,5 @@ tasks:
     - common:lint
     - --
     - --fix
-    type: node
+    platform: node
 

--- a/crates/cli/tests/snapshots/migrate_test__from_package_json__links_depends_on-2.snap
+++ b/crates/cli/tests/snapshots/migrate_test__from_package_json__links_depends_on-2.snap
@@ -15,8 +15,8 @@ tasks:
     - ./lib
     outputs:
     - lib
-    type: node
+    platform: node
   test:
     command: jest
-    type: node
+    platform: node
 

--- a/crates/config/src/project/task.rs
+++ b/crates/config/src/project/task.rs
@@ -105,8 +105,7 @@ pub struct TaskConfig {
     pub options: TaskOptionsConfig,
 
     #[serde(skip_serializing_if = "skip_if_default")]
-    #[serde(rename = "type")]
-    pub type_of: PlatformType,
+    pub platform: PlatformType,
 }
 
 impl TaskConfig {

--- a/crates/config/templates/global_project.yml
+++ b/crates/config/templates/global_project.yml
@@ -68,6 +68,6 @@ tasks:
     # To output files to the workspace root, prefix the path with a "/".
     outputs: []
 
-    # The type of command to run, and where to locate it.
-    # Accepts "node" (default) or "system".
-    type: 'node'
+    # The platform to run the command on, and where to locate it.
+    # Accepts "node" or "system". Defaults based on project `language`.
+    platform: 'node'

--- a/crates/config/tests/tasks_test.rs
+++ b/crates/config/tests/tasks_test.rs
@@ -539,10 +539,10 @@ outputs:
     }
 }
 
-mod type_of {
+mod platform {
     #[test]
     #[should_panic(
-        expected = "unknown variant: found `whatisthis`, expected `one of `node`, `system`, `unknown`` for key \"default.type\""
+        expected = "unknown variant: found `whatisthis`, expected `one of `node`, `system`, `unknown`` for key \"default.platform\""
     )]
     fn invalid_type() {
         figment::Jail::expect_with(|jail| {
@@ -550,7 +550,7 @@ mod type_of {
                 super::CONFIG_FILENAME,
                 r#"
 command: foo
-type: whatisthis
+platform: whatisthis
 "#,
             )?;
 

--- a/crates/platform-node/src/task.rs
+++ b/crates/platform-node/src/task.rs
@@ -170,7 +170,7 @@ pub fn create_task(
     }
 
     if is_wrapping {
-        task_config.type_of = PlatformType::Node;
+        task_config.platform = PlatformType::Node;
         task_config.command = Some(TaskCommandArgs::Sequence(string_vec![
             "moon",
             "node",
@@ -190,7 +190,7 @@ pub fn create_task(
             args.insert(0, "noop".to_owned());
         }
 
-        task_config.type_of = detect_platform_type(&args[0]);
+        task_config.platform = detect_platform_type(&args[0]);
         task_config.command = Some(if args.len() == 1 {
             TaskCommandArgs::String(args.remove(0))
         } else {

--- a/crates/platform-node/tests/task_test.rs
+++ b/crates/platform-node/tests/task_test.rs
@@ -168,7 +168,7 @@ mod create_task {
                         "bash",
                         "scripts/setup.sh"
                     ])),
-                    type_of: PlatformType::System,
+                    platform: PlatformType::System,
                     ..TaskConfig::default()
                 }
             )
@@ -191,7 +191,7 @@ mod create_task {
                         "bash",
                         "scripts/setup.sh"
                     ])),
-                    type_of: PlatformType::System,
+                    platform: PlatformType::System,
                     ..TaskConfig::default()
                 }
             )
@@ -214,7 +214,7 @@ mod create_task {
                         "node",
                         "scripts/test.js"
                     ])),
-                    type_of: PlatformType::Node,
+                    platform: PlatformType::Node,
                     ..TaskConfig::default()
                 }
             )
@@ -237,7 +237,7 @@ mod create_task {
                     task,
                     TaskConfig {
                         command: Some(TaskCommandArgs::Sequence(string_vec!["node", candidate])),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                         ..TaskConfig::default()
                     }
                 )
@@ -263,7 +263,7 @@ mod create_task {
                 TaskConfig {
                     command: Some(TaskCommandArgs::Sequence(string_vec!["yarn", "install"])),
                     env: Some(HashMap::from([("KEY".to_owned(), "VALUE".to_owned())])),
-                    type_of: PlatformType::Node,
+                    platform: PlatformType::Node,
                     ..TaskConfig::default()
                 }
             )
@@ -287,7 +287,7 @@ mod create_task {
                         ("KEY1".to_owned(), "VAL1".to_owned()),
                         ("KEY2".to_owned(), "VAL2".to_owned())
                     ])),
-                    type_of: PlatformType::Node,
+                    platform: PlatformType::Node,
                     ..TaskConfig::default()
                 }
             )
@@ -311,7 +311,7 @@ mod create_task {
                         ("KEY1".to_owned(), "VAL1".to_owned()),
                         ("KEY2".to_owned(), "VAL2".to_owned())
                     ])),
-                    type_of: PlatformType::Node,
+                    platform: PlatformType::Node,
                     ..TaskConfig::default()
                 }
             )
@@ -335,7 +335,7 @@ mod create_task {
                         "NODE_OPTIONS".to_owned(),
                         "-f -b".to_owned()
                     )])),
-                    type_of: PlatformType::Node,
+                    platform: PlatformType::Node,
                     ..TaskConfig::default()
                 }
             )
@@ -383,7 +383,7 @@ mod create_task {
                             candidate.1
                         ])),
                         outputs: Some(string_vec![candidate.2]),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                         ..TaskConfig::default()
                     }
                 )
@@ -461,7 +461,7 @@ mod infer_tasks_from_scripts {
                             "build:app"
                         ])),
                         outputs: Some(string_vec!["dist"]),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                         ..TaskConfig::default()
                     }
                 ),
@@ -475,7 +475,7 @@ mod infer_tasks_from_scripts {
                             "dev"
                         ])),
                         local: true,
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                         ..TaskConfig::default()
                     }
                 ),
@@ -488,7 +488,7 @@ mod infer_tasks_from_scripts {
                             "run-script",
                             "test"
                         ])),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                         ..TaskConfig::default()
                     }
                 ),
@@ -501,7 +501,7 @@ mod infer_tasks_from_scripts {
                             "run-script",
                             "lint"
                         ])),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                         ..TaskConfig::default()
                     }
                 ),
@@ -514,7 +514,7 @@ mod infer_tasks_from_scripts {
                             "run-script",
                             "typecheck"
                         ])),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                         ..TaskConfig::default()
                     }
                 ),
@@ -601,7 +601,7 @@ mod create_tasks_from_scripts {
                     "test".to_owned(),
                     TaskConfig {
                         command: Some(TaskCommandArgs::Sequence(string_vec!["jest", "."])),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                         ..TaskConfig::default()
                     }
                 ),
@@ -611,7 +611,7 @@ mod create_tasks_from_scripts {
                         command: Some(TaskCommandArgs::Sequence(string_vec![
                             "eslint", "src/**/*", "."
                         ])),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                         ..TaskConfig::default()
                     }
                 ),
@@ -619,7 +619,7 @@ mod create_tasks_from_scripts {
                     "typecheck".to_owned(),
                     TaskConfig {
                         command: Some(TaskCommandArgs::Sequence(string_vec!["tsc", "--build"])),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                         ..TaskConfig::default()
                     }
                 ),
@@ -656,7 +656,7 @@ mod create_tasks_from_scripts {
                                 "do",
                                 "something"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -665,7 +665,7 @@ mod create_tasks_from_scripts {
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["do", "another"])),
                             deps: Some(string_vec!["~:test"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -674,7 +674,7 @@ mod create_tasks_from_scripts {
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["jest", "."])),
                             deps: Some(string_vec!["~:pretest"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -706,7 +706,7 @@ mod create_tasks_from_scripts {
                                 "do",
                                 "something"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -715,7 +715,7 @@ mod create_tasks_from_scripts {
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["do", "another"])),
                             deps: Some(string_vec!["~:pretest-dep1"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -724,7 +724,7 @@ mod create_tasks_from_scripts {
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["jest", "."])),
                             deps: Some(string_vec!["~:pretest"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     )
@@ -756,7 +756,7 @@ mod create_tasks_from_scripts {
                                 "do",
                                 "something"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -765,7 +765,7 @@ mod create_tasks_from_scripts {
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["do", "another"])),
                             deps: Some(string_vec!["~:posttest-dep1", "~:test"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -773,7 +773,7 @@ mod create_tasks_from_scripts {
                         "test".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["jest", "."])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -804,7 +804,7 @@ mod create_tasks_from_scripts {
                             command: Some(TaskCommandArgs::Sequence(string_vec![
                                 "webpack", "build"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -813,7 +813,7 @@ mod create_tasks_from_scripts {
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["npm", "publish"])),
                             deps: Some(string_vec!["~:prerelease"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -846,7 +846,7 @@ mod create_tasks_from_scripts {
                     "lint".to_owned(),
                     TaskConfig {
                         command: Some(TaskCommandArgs::Sequence(string_vec!["eslint", "."])),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                         ..TaskConfig::default()
                     }
                 )])
@@ -886,7 +886,7 @@ mod create_tasks_from_scripts {
                                 command: Some(TaskCommandArgs::Sequence(string_vec![
                                     "eslint", "."
                                 ])),
-                                type_of: PlatformType::Node,
+                                platform: PlatformType::Node,
                                 ..TaskConfig::default()
                             }
                         ),
@@ -898,7 +898,7 @@ mod create_tasks_from_scripts {
                                     "run",
                                     "project:lint"
                                 ])),
-                                type_of: PlatformType::Node,
+                                platform: PlatformType::Node,
                                 ..TaskConfig::default()
                             }
                         ),
@@ -939,7 +939,7 @@ mod create_tasks_from_scripts {
                                 command: Some(TaskCommandArgs::Sequence(string_vec![
                                     "eslint", "."
                                 ])),
-                                type_of: PlatformType::Node,
+                                platform: PlatformType::Node,
                                 ..TaskConfig::default()
                             }
                         ),
@@ -953,7 +953,7 @@ mod create_tasks_from_scripts {
                                     "--",
                                     "--fix"
                                 ])),
-                                type_of: PlatformType::Node,
+                                platform: PlatformType::Node,
                                 ..TaskConfig::default()
                             }
                         ),
@@ -996,7 +996,7 @@ mod create_tasks_from_scripts {
                             command: Some(TaskCommandArgs::Sequence(string_vec![
                                 "webpack", "build"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1014,7 +1014,7 @@ mod create_tasks_from_scripts {
                                 "NODE_ENV".to_owned(),
                                 "development".to_owned()
                             )])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1030,7 +1030,7 @@ mod create_tasks_from_scripts {
                                 "NODE_ENV".to_owned(),
                                 "production".to_owned()
                             )])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1049,7 +1049,7 @@ mod create_tasks_from_scripts {
                                 "NODE_ENV".to_owned(),
                                 "staging".to_owned()
                             )])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1103,7 +1103,7 @@ mod create_tasks_from_scripts {
                         "build".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["babel", "."])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1111,7 +1111,7 @@ mod create_tasks_from_scripts {
                         "lint".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["eslint", "."])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1119,7 +1119,7 @@ mod create_tasks_from_scripts {
                         "test".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["jest", "."])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     )
@@ -1188,7 +1188,7 @@ mod create_tasks_from_scripts {
                                 "make",
                                 "bootstrap"
                             ])),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1196,7 +1196,7 @@ mod create_tasks_from_scripts {
                         "build".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["make", "build"])),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1207,7 +1207,7 @@ mod create_tasks_from_scripts {
                                 "make",
                                 "build-no-bundle"
                             ])),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1215,7 +1215,7 @@ mod create_tasks_from_scripts {
                         "fix".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["make", "fix"])),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1223,7 +1223,7 @@ mod create_tasks_from_scripts {
                         "lint".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["make", "lint"])),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1231,7 +1231,7 @@ mod create_tasks_from_scripts {
                         "test".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::Sequence(string_vec!["make", "test"])),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1242,7 +1242,7 @@ mod create_tasks_from_scripts {
                                 "node",
                                 "test/esm/index.js"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1253,7 +1253,7 @@ mod create_tasks_from_scripts {
                                 "node",
                                 "test/runtime-integration/bundlers.cjs"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1264,7 +1264,7 @@ mod create_tasks_from_scripts {
                                 "node",
                                 "test/runtime-integration/generate-absolute-runtime.cjs"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1275,7 +1275,7 @@ mod create_tasks_from_scripts {
                                 "node",
                                 "test/runtime-integration/node.cjs"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1326,7 +1326,7 @@ mod create_tasks_from_scripts {
                                 "--",
                                 "build"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1338,7 +1338,7 @@ mod create_tasks_from_scripts {
                                 "run",
                                 "project:type",
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1351,7 +1351,7 @@ mod create_tasks_from_scripts {
                                 "project:test",
                             ])),
                             deps: Some(string_vec!["~:check-dep1"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1364,7 +1364,7 @@ mod create_tasks_from_scripts {
                                 "project:lint",
                             ])),
                             deps: Some(string_vec!["~:check-dep2"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1378,7 +1378,7 @@ mod create_tasks_from_scripts {
                                 "--",
                                 "clean"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1388,7 +1388,7 @@ mod create_tasks_from_scripts {
                             command: Some(TaskCommandArgs::Sequence(string_vec![
                                 "yarn", "install"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1401,7 +1401,7 @@ mod create_tasks_from_scripts {
                                 "yarn.lock"
                             ])),
                             deps: Some(string_vec!["~:commit-dep1"]),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1415,7 +1415,7 @@ mod create_tasks_from_scripts {
                                 "--",
                                 "--coverage"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1423,7 +1423,7 @@ mod create_tasks_from_scripts {
                         "create-config".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::String("create-config".to_owned())),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1431,7 +1431,7 @@ mod create_tasks_from_scripts {
                         "format".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::String("prettier".to_owned())),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1439,7 +1439,7 @@ mod create_tasks_from_scripts {
                         "lint".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::String("eslint".to_owned())),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1460,7 +1460,7 @@ mod create_tasks_from_scripts {
                                 "NODE_ENV".to_owned(),
                                 "production".to_owned()
                             )])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1471,7 +1471,7 @@ mod create_tasks_from_scripts {
                                 "node",
                                 "./packages/packemon/cjs/bin.cjs"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1483,7 +1483,7 @@ mod create_tasks_from_scripts {
                                 "run",
                                 "project:clean"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1496,7 +1496,7 @@ mod create_tasks_from_scripts {
                                 "project:setup"
                             ])),
                             deps: Some(string_vec!["~:prerelease-dep1"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1509,7 +1509,7 @@ mod create_tasks_from_scripts {
                                 "project:packup"
                             ])),
                             deps: Some(string_vec!["~:prerelease-dep2"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1522,7 +1522,7 @@ mod create_tasks_from_scripts {
                                 "project:check"
                             ])),
                             deps: Some(string_vec!["~:prerelease-dep3"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1534,7 +1534,7 @@ mod create_tasks_from_scripts {
                                 "lerna-release"
                             ])),
                             deps: Some(string_vec!["~:prerelease"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1552,7 +1552,7 @@ mod create_tasks_from_scripts {
                                 "packemon",
                                 "build"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1560,7 +1560,7 @@ mod create_tasks_from_scripts {
                         "test".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::String("jest".to_owned())),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1571,7 +1571,7 @@ mod create_tasks_from_scripts {
                                 "typescript",
                                 "--build"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1585,7 +1585,7 @@ mod create_tasks_from_scripts {
                                 "--",
                                 "validate"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1644,7 +1644,7 @@ mod create_tasks_from_scripts {
                             command: Some(TaskCommandArgs::Sequence(string_vec![
                                 "run-p", "lint:*"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1652,7 +1652,7 @@ mod create_tasks_from_scripts {
                         "lint-actionlint".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::String("node-actionlint".to_owned())),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1663,7 +1663,7 @@ mod create_tasks_from_scripts {
                                 "node",
                                 "./scripts/lint-changelog.mjs"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1674,7 +1674,7 @@ mod create_tasks_from_scripts {
                                 "node",
                                 "./scripts/check-deps.mjs"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1692,7 +1692,7 @@ mod create_tasks_from_scripts {
                                 "EFF_NO_LINK_RULES".to_owned(),
                                 "true".to_owned()
                             )])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1702,7 +1702,7 @@ mod create_tasks_from_scripts {
                             command: Some(TaskCommandArgs::Sequence(string_vec![
                                 "prettier", ".", "!test*", "--check"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1716,7 +1716,7 @@ mod create_tasks_from_scripts {
                                 "--dot",
                                 "--gitignore"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1724,7 +1724,7 @@ mod create_tasks_from_scripts {
                         "lint-typecheck".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::String("tsc".to_owned())),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1738,7 +1738,7 @@ mod create_tasks_from_scripts {
                                 "--",
                                 "--fix"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1752,7 +1752,7 @@ mod create_tasks_from_scripts {
                                 "--",
                                 "--write"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1763,7 +1763,7 @@ mod create_tasks_from_scripts {
                                 "node",
                                 "./scripts/build/build.mjs"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1774,7 +1774,7 @@ mod create_tasks_from_scripts {
                                 "node",
                                 "./scripts/build-website.mjs"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1791,7 +1791,7 @@ mod create_tasks_from_scripts {
                                 "NODE_ENV".to_owned(),
                                 "production".to_owned()
                             )])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1805,7 +1805,7 @@ mod create_tasks_from_scripts {
                                 "--",
                                 "--debug-benchmark"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1823,7 +1823,7 @@ mod create_tasks_from_scripts {
                                 "NODE_ENV".to_owned(),
                                 "production".to_owned()
                             )])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1835,7 +1835,7 @@ mod create_tasks_from_scripts {
                                 "run",
                                 "project:build"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1847,7 +1847,7 @@ mod create_tasks_from_scripts {
                                 "run",
                                 "project:build"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1855,7 +1855,7 @@ mod create_tasks_from_scripts {
                         "test".to_owned(),
                         TaskConfig {
                             command: Some(TaskCommandArgs::String("jest".to_owned())),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1870,7 +1870,7 @@ mod create_tasks_from_scripts {
                                 "INSTALL_PACKAGE".to_owned(),
                                 "1".to_owned()
                             )])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1885,7 +1885,7 @@ mod create_tasks_from_scripts {
                                 "NODE_ENV".to_owned(),
                                 "production".to_owned()
                             )])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1900,7 +1900,7 @@ mod create_tasks_from_scripts {
                                 "--config=./scripts/bundle-eslint-config.cjs",
                                 "dist/**/*.{js,mjs}"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1915,7 +1915,7 @@ mod create_tasks_from_scripts {
                                 ("TEST_STANDALONE".to_owned(), "1".to_owned()),
                                 ("NODE_ENV".to_owned(), "production".to_owned())
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1926,7 +1926,7 @@ mod create_tasks_from_scripts {
                                 "jest",
                                 "tests/integration"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),
@@ -1937,7 +1937,7 @@ mod create_tasks_from_scripts {
                                 "node",
                                 "./scripts/vendors/bundle-vendors.mjs"
                             ])),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         }
                     ),

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -596,7 +596,7 @@ mod tasks {
                         inputs: Some(string_vec!["a.*"]),
                         outputs: Some(string_vec!["a.ts"]),
                         options: stub_global_task_options_config(),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                     },
                 )]),
                 ..GlobalProjectConfig::default()
@@ -619,7 +619,7 @@ mod tasks {
                             inputs: Some(string_vec!["b.*"]),
                             outputs: Some(string_vec!["b.ts"]),
                             options: mock_local_task_options_config(TaskMergeStrategy::Replace),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                         }
                     )]),
                     ..ProjectConfig::default()
@@ -640,7 +640,7 @@ mod tasks {
                             inputs: Some(string_vec!["b.*"]),
                             outputs: Some(string_vec!["b.ts"]),
                             options: mock_merged_task_options_config(TaskMergeStrategy::Replace),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                         },
                         &workspace_root,
                         project_source
@@ -672,7 +672,7 @@ mod tasks {
                         inputs: Some(string_vec!["a.*"]),
                         outputs: Some(string_vec!["a.ts"]),
                         options: stub_global_task_options_config(),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                     },
                 )]),
                 ..GlobalProjectConfig::default()
@@ -695,7 +695,7 @@ mod tasks {
                             inputs: Some(string_vec!["b.*"]),
                             outputs: Some(string_vec!["b.ts"]),
                             options: mock_local_task_options_config(TaskMergeStrategy::Append),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                         }
                     )]),
                     ..ProjectConfig::default()
@@ -719,7 +719,7 @@ mod tasks {
                             local: false,
                             outputs: Some(string_vec!["a.ts", "b.ts"]),
                             options: mock_merged_task_options_config(TaskMergeStrategy::Append),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                         },
                         &workspace_root,
                         project_source
@@ -751,7 +751,7 @@ mod tasks {
                         local: false,
                         outputs: Some(string_vec!["a.ts"]),
                         options: stub_global_task_options_config(),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                     },
                 )]),
                 ..GlobalProjectConfig::default()
@@ -774,7 +774,7 @@ mod tasks {
                             local: false,
                             outputs: Some(string_vec!["b.ts"]),
                             options: mock_local_task_options_config(TaskMergeStrategy::Prepend),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                         }
                     )]),
                     ..ProjectConfig::default()
@@ -798,7 +798,7 @@ mod tasks {
                             local: false,
                             outputs: Some(string_vec!["b.ts", "a.ts"]),
                             options: mock_merged_task_options_config(TaskMergeStrategy::Prepend),
-                            type_of: PlatformType::System,
+                            platform: PlatformType::System,
                         },
                         &workspace_root,
                         project_source
@@ -830,7 +830,7 @@ mod tasks {
                         local: false,
                         outputs: Some(string_vec!["a.ts"]),
                         options: stub_global_task_options_config(),
-                        type_of: PlatformType::Node,
+                        platform: PlatformType::Node,
                     },
                 )]),
                 ..GlobalProjectConfig::default()
@@ -860,7 +860,7 @@ mod tasks {
                     run_from_workspace_root: None,
                     ..TaskOptionsConfig::default()
                 },
-                type_of: PlatformType::Unknown,
+                platform: PlatformType::Unknown,
             },
             &workspace_root,
             project_source,
@@ -897,7 +897,7 @@ mod tasks {
                                 run_in_ci: None,
                                 run_from_workspace_root: None,
                             },
-                            type_of: PlatformType::Unknown,
+                            platform: PlatformType::Unknown,
                         }
                     )]),
                     ..ProjectConfig::default()
@@ -1269,7 +1269,7 @@ mod tasks {
                         TaskConfig {
                             command: Some(TaskCommandArgs::String("test".to_owned())),
                             deps: Some(string_vec!["~:test"]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         },
                     )]),
@@ -1314,7 +1314,7 @@ mod tasks {
                         TaskConfig {
                             command: Some(TaskCommandArgs::String("test".to_owned())),
                             inputs: Some(string_vec!["local.ts",]),
-                            type_of: PlatformType::Node,
+                            platform: PlatformType::Node,
                             ..TaskConfig::default()
                         },
                     )]),

--- a/crates/project/tests/project_test.rs
+++ b/crates/project/tests/project_test.rs
@@ -1328,7 +1328,7 @@ mod tasks {
                     &workspace_root,
                     &[],
                     &[
-                        "/.moon/$taskType-$projectType.yml".to_owned(),
+                        "/.moon/$taskPlatform-$projectType.yml".to_owned(),
                         "*.yml".to_owned(),
                     ],
                 )

--- a/crates/task/Cargo.toml
+++ b/crates/task/Cargo.toml
@@ -11,4 +11,5 @@ moon_utils = { path = "../utils" }
 common-path = "1.0.0"
 dotenvy = "0.15.6"
 serde = { workspace = true }
+strum = { version = "0.24.1", features = ["derive"] }
 thiserror = { workspace = true }

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -12,13 +12,19 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
+use strum::Display;
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Display, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum TaskType {
+    #[strum(serialize = "build")]
     Build,
+
+    #[strum(serialize = "run")]
     Run,
+
     #[default]
+    #[strum(serialize = "test")]
     Test,
 }
 

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -240,7 +240,7 @@ impl Task {
             },
             outputs: cloned_config.outputs.unwrap_or_default(),
             output_paths: HashSet::new(),
-            platform: cloned_config.type_of,
+            platform: cloned_config.platform,
             target: target.id.clone(),
             type_of: TaskType::Test,
         };
@@ -284,7 +284,7 @@ impl Task {
         }
 
         if !matches!(self.platform, PlatformType::Unknown) {
-            config.type_of = self.platform.clone();
+            config.platform = self.platform.clone();
         }
 
         config
@@ -581,7 +581,7 @@ impl Task {
 
         // Merge options first incase the merge strategy has changed
         self.options.merge(&config.options);
-        self.platform = config.type_of.clone();
+        self.platform = config.platform.clone();
 
         // Then merge the actual task fields
         if let Some(cmd) = command {

--- a/crates/task/src/token.rs
+++ b/crates/task/src/token.rs
@@ -277,7 +277,7 @@ impl<'a> TokenResolver<'a> {
             "projectType" => project_config.type_of.to_string(),
             "target" => task.target.clone(),
             "task" => task_id,
-            "taskType" => task.platform.to_string(),
+            "taskPlatform" => task.platform.to_string(),
             "workspaceRoot" => path::to_string(workspace_root)?,
             _ => {
                 warn!(

--- a/crates/task/src/token.rs
+++ b/crates/task/src/token.rs
@@ -278,6 +278,7 @@ impl<'a> TokenResolver<'a> {
             "target" => task.target.clone(),
             "task" => task_id,
             "taskPlatform" => task.platform.to_string(),
+            "taskType" => task.type_of.to_string(),
             "workspaceRoot" => path::to_string(workspace_root)?,
             _ => {
                 warn!(

--- a/crates/task/tests/token_test.rs
+++ b/crates/task/tests/token_test.rs
@@ -516,7 +516,7 @@ mod args {
 
         assert_eq!(resolver.resolve_var("$task", &task).unwrap(), "task");
 
-        assert_eq!(resolver.resolve_var("$taskType", &task).unwrap(), "node");
+        assert_eq!(resolver.resolve_var("$taskPlatform", &task).unwrap(), "node");
 
         assert_eq!(
             resolver.resolve_var("$workspaceRoot", &task).unwrap(),
@@ -526,7 +526,7 @@ mod args {
         // Multiple vars
         assert_eq!(
             resolver
-                .resolve_vars("$language-$taskType-project", &task)
+                .resolve_vars("$language-$taskPlatform-project", &task)
                 .unwrap(),
             "javascript-node-project"
         );

--- a/crates/task/tests/token_test.rs
+++ b/crates/task/tests/token_test.rs
@@ -516,7 +516,12 @@ mod args {
 
         assert_eq!(resolver.resolve_var("$task", &task).unwrap(), "task");
 
-        assert_eq!(resolver.resolve_var("$taskPlatform", &task).unwrap(), "node");
+        assert_eq!(
+            resolver.resolve_var("$taskPlatform", &task).unwrap(),
+            "node"
+        );
+
+        assert_eq!(resolver.resolve_var("$taskType", &task).unwrap(), "test");
 
         assert_eq!(
             resolver.resolve_var("$workspaceRoot", &task).unwrap(),

--- a/crates/utils/src/regex.rs
+++ b/crates/utils/src/regex.rs
@@ -22,7 +22,7 @@ lazy_static! {
 
     pub static ref TOKEN_FUNC_PATTERN: Regex = Regex::new(&format!("^@([a-z]+)\\({}\\)$", *TOKEN_GROUP)).unwrap();
     pub static ref TOKEN_FUNC_ANYWHERE_PATTERN: Regex = Regex::new(&format!("@([a-z]+)\\({}\\)", *TOKEN_GROUP)).unwrap();
-    pub static ref TOKEN_VAR_PATTERN: Regex = Regex::new("\\$(language|projectRoot|projectSource|projectType|project|target|taskType|task|workspaceRoot)").unwrap();
+    pub static ref TOKEN_VAR_PATTERN: Regex = Regex::new("\\$(language|projectRoot|projectSource|projectType|project|target|taskPlatform|task|workspaceRoot)").unwrap();
 
     // Task commands (these are not exhaustive)
     pub static ref NODE_COMMAND: regex::Regex =

--- a/crates/utils/src/regex.rs
+++ b/crates/utils/src/regex.rs
@@ -22,7 +22,7 @@ lazy_static! {
 
     pub static ref TOKEN_FUNC_PATTERN: Regex = Regex::new(&format!("^@([a-z]+)\\({}\\)$", *TOKEN_GROUP)).unwrap();
     pub static ref TOKEN_FUNC_ANYWHERE_PATTERN: Regex = Regex::new(&format!("@([a-z]+)\\({}\\)", *TOKEN_GROUP)).unwrap();
-    pub static ref TOKEN_VAR_PATTERN: Regex = Regex::new("\\$(language|projectRoot|projectSource|projectType|project|target|taskPlatform|task|workspaceRoot)").unwrap();
+    pub static ref TOKEN_VAR_PATTERN: Regex = Regex::new("\\$(language|projectRoot|projectSource|projectType|project|target|taskPlatform|taskType|task|workspaceRoot)").unwrap();
 
     // Task commands (these are not exhaustive)
     pub static ref NODE_COMMAND: regex::Regex =

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Refactored project and task name/id cleaning. Previously, unsupported characters were simply
   removed. Instead, we now replace them with dashes for better readability.
+- The task `type` in `moon.yml` and `.moon/project.yml` has been renamed to `platform`.
+- The `$taskType` token has been renamed to `$taskPlatform`.
 
 #### 🚀 Updates
 

--- a/packages/types/src/project-config.ts
+++ b/packages/types/src/project-config.ts
@@ -37,7 +37,7 @@ export interface TaskConfig {
 	local: boolean;
 	outputs: string[] | null;
 	options: TaskOptionsConfig;
-	type: Platform;
+	platform: Platform;
 }
 
 export type ProjectLanguage = 'bash' | 'batch' | 'javascript' | 'typescript' | 'unknown';

--- a/tests/fixtures/cases/base/moon.yml
+++ b/tests/fixtures/cases/base/moon.yml
@@ -4,14 +4,14 @@ tasks:
   runFromProject:
     command: echo
     args: '"in project"'
-    type: system
+    platform: system
   runFromWorkspace:
     command: echo
     args: '"in workspace"'
     options:
       runFromWorkspaceRoot: true
-    type: system
+    platform: system
   localOnly:
     command: 'echo "local only"'
-    type: system
+    platform: system
     local: true

--- a/tests/fixtures/cases/system-windows/moon.yml
+++ b/tests/fixtures/cases/system-windows/moon.yml
@@ -3,36 +3,36 @@ language: bash
 tasks:
   bat:
     command: cmd.exe /q /c ./standard.bat
-    type: system
+    platform: system
   exitNonZero:
     command: cmd.exe /q /c ./exitNonZero.bat
-    type: system
+    platform: system
   exitZero:
     command: cmd.exe /q /c ./exitZero.bat
-    type: system
+    platform: system
   passthroughArgs:
     command: cmd /q /c ./passthroughArgs.bat
-    type: system
+    platform: system
   envVars:
     command: cmd.exe /q /c ./envVars.bat
     env:
       MOON_FOO: abc
       MOON_BAR: '123'
       MOON_BAZ: 'true'
-    type: system
+    platform: system
   envVarsMoon:
     command: cmd /q /c ./envVarsMoon.bat
-    type: system
+    platform: system
   runFromProject:
     command: cmd.exe /q /c ./cwd.bat
-    type: system
+    platform: system
   runFromWorkspace:
     command: cmd /q /c ./system-windows/cwd.bat
-    type: system
+    platform: system
     options:
       runFromWorkspaceRoot: true
   retryCount:
     command: cmd.exe /q /c ./exitNonZero.bat
-    type: system
+    platform: system
     options:
       retryCount: 3

--- a/tests/fixtures/cases/system/moon.yml
+++ b/tests/fixtures/cases/system/moon.yml
@@ -4,27 +4,27 @@ tasks:
   ls:
     command: ls
     args: '-1 .'
-    type: system
+    platform: system
   echo:
     command: echo
     args: 'hello'
-    type: system
+    platform: system
   bash:
     command: bash
     args: ./standard.sh
-    type: system
+    platform: system
   exitNonZero:
     command: bash
     args: ./exitNonZero.sh
-    type: system
+    platform: system
   exitZero:
     command: bash
     args: ./exitZero.sh
-    type: system
+    platform: system
   passthroughArgs:
     command: bash
     args: ./passthroughArgs.sh
-    type: system
+    platform: system
   envVars:
     command: bash
     args: ./envVars.sh
@@ -32,24 +32,24 @@ tasks:
       MOON_FOO: abc
       MOON_BAR: '123'
       MOON_BAZ: 'true'
-    type: system
+    platform: system
   envVarsMoon:
     command: bash
     args: ./envVarsMoon.sh
-    type: system
+    platform: system
   runFromProject:
     command: bash
     args: ./cwd.sh
-    type: system
+    platform: system
   runFromWorkspace:
     command: bash
     args: ./system/cwd.sh
-    type: system
+    platform: system
     options:
       runFromWorkspaceRoot: true
   retryCount:
     command: bash
     args: ./exitNonZero.sh
-    type: system
+    platform: system
     options:
       retryCount: 3

--- a/tests/fixtures/tasks/merge-append/moon.yml
+++ b/tests/fixtures/tasks/merge-append/moon.yml
@@ -1,6 +1,6 @@
 tasks:
   standard:
-    type: system
+    platform: system
     deps:
       - b:standard
     args:

--- a/tests/fixtures/tasks/merge-prepend/moon.yml
+++ b/tests/fixtures/tasks/merge-prepend/moon.yml
@@ -1,6 +1,6 @@
 tasks:
   standard:
-    type: system
+    platform: system
     command: newcmd
     deps:
       - b:standard

--- a/tests/fixtures/tasks/merge-replace/moon.yml
+++ b/tests/fixtures/tasks/merge-replace/moon.yml
@@ -1,6 +1,6 @@
 tasks:
   standard:
-    type: system
+    platform: system
     command: newcmd
     deps:
       - b:standard

--- a/website/blog/2022-10-21_v0.17.mdx
+++ b/website/blog/2022-10-21_v0.17.mdx
@@ -1,6 +1,6 @@
 ---
 slug: v0.17
-title: v0.17 - Webhooks and improved runtime performance
+title: v0.17 - Webhooks, extended YAML, and improved runtime performance
 authors: [milesj]
 tags: [notifier, runner, editors, vscode]
 # image: ./img/v0.17.png
@@ -13,6 +13,51 @@ With this release, we're landing the first iteration of our notifier service, st
 webhooks! We've also spent some time working on quality of life improvements.
 
 <!--truncate-->
+
+## Breaking changes
+
+To start, we have a few breaking changes this release to be aware of!
+
+### Task `type` has been renamed to `platform`
+
+This setting was renamed for a few reasons. To start, tasks actually have a
+[type internally](../docs/concepts/task#types) that is not configured, but is inferred based on
+what's configured. This was a bit confusing.
+
+And secondly, our toolchain refers to language integrations as platforms, and since this setting
+determines which tool to run with, we wanted to align on the platform terminology.
+
+<Tabs
+  groupId="task-type"
+  defaultValue="before"
+  values={[
+    { label: 'Before', value: 'before' },
+    { label: 'After', value: 'after' },
+  ]}
+>
+<TabItem value="before">
+
+```yaml
+tasks:
+  clean:
+    command: 'rm -rf ./dist'
+    type: 'system'
+```
+
+</TabItem>
+<TabItem value="after">
+
+```yaml
+tasks:
+  clean:
+    command: 'rm -rf ./dist'
+    platform: 'system'
+```
+
+</TabItem>
+</Tabs>
+
+> Because of this change, the `$taskType` token was also renamed to `$taskPlatform`!
 
 ## Webhook events
 

--- a/website/docs/concepts/token.mdx
+++ b/website/docs/concepts/token.mdx
@@ -438,7 +438,7 @@ tasks:
       - '--task=build'
 ```
 
-### `$taskPlatform`<VersionLabel version="0.7" />
+### `$taskPlatform`<VersionLabel version="0.17" />
 
 The platform that task will run against.
 
@@ -446,7 +446,26 @@ The platform that task will run against.
 # Configured as
 tasks:
   build:
-    command: 'example --type $taskPlatform'
+    command: 'example --platform $taskPlatform'
+
+# Resolves to
+tasks:
+  build:
+    command:
+      - 'example'
+      - '--platform'
+      - 'system'
+```
+
+### `$taskType`<VersionLabel version="0.17" />
+
+The [type of task](./task#types), based on its configured settings.
+
+```yaml
+# Configured as
+tasks:
+  build:
+    command: 'example --type $taskType'
 
 # Resolves to
 tasks:
@@ -454,7 +473,7 @@ tasks:
     command:
       - 'example'
       - '--type'
-      - 'system'
+      - 'build'
 ```
 
 ### `$workspaceRoot`

--- a/website/docs/concepts/token.mdx
+++ b/website/docs/concepts/token.mdx
@@ -438,15 +438,15 @@ tasks:
       - '--task=build'
 ```
 
-### `$taskType`<VersionLabel version="0.7" />
+### `$taskPlatform`<VersionLabel version="0.7" />
 
-The type of task that is currently running.
+The platform that task will run against.
 
 ```yaml
 # Configured as
 tasks:
   build:
-    command: 'example --type $taskType'
+    command: 'example --type $taskPlatform'
 
 # Resolves to
 tasks:

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -218,14 +218,14 @@ tasks:
 ```
 
 By default a task assumes the command name is an npm binary, and if you'd like to reference a system
-command, you'll also need to set the [`type`](#type-1) to "system". We do our best to automatically
-detect this, but it's not accurate in all scenarios.
+command, you'll also need to set the [`platform`](#platform) to "system". We do our best to
+automatically detect this, but it's not accurate in all scenarios.
 
 ```yaml title="moon.yml"
 tasks:
   clean:
     command: 'rm -rf ./dist'
-    type: 'system'
+    platform: 'system'
 ```
 
 #### Special commands
@@ -234,9 +234,9 @@ For interoperability reasons, the following command names have special handling.
 
 - `noop`, `no-op`, `nop` - Marks the task as a "no operation". Will not execute a command in the
   action runner but can define dependencies.
-- When `type` is "node":
+- When `platform` is "node":
   - `node`, `npm`, `pnpm`, `yarn` - Uses the binaries from the toolchain.
-- When `type` is "system":
+- When `platform` is "system":
   - `cmd`, `cmd.exe` - Will execute the arguments with `cmd.exe` (Windows only).
   - `powershell`, `powershell.exe` - Will execute the arguments with `powershell.exe` (Windows
     only).
@@ -574,12 +574,13 @@ tasks:
       runFromWorkspaceRoot: true
 ```
 
-### `type`
+### `platform`
 
-<HeadingApiLink to="/api/types/interface/TaskConfig#type" />
+<HeadingApiLink to="/api/types/interface/TaskConfig#platform" />
 
-The `type` field defines the type of command to run, where to locate its executable, and which tool
-to execute it with. By default will set to a value based on the project's [`language`](#language).
+The `platform` field defines the platform the command runs on, where to locate its executable, and
+which tool to execute it with. By default moon will set to a value based on the project's
+[`language`](#language).
 
 - `node` - Command is a binary within node modules and will be executed with Node.js.
 - `system` - Command is expected to exist within the system's environment.
@@ -589,7 +590,7 @@ to execute it with. By default will set to a value based on the project's [`lang
 tasks:
   env:
     command: 'printenv'
-    type: 'system'
+    platform: 'system'
 ```
 
 > This field exists because of our [toolchain](../concepts/toolchain), and moon ensuring the correct

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -29,7 +29,7 @@ to be language agnostic and easily pluggable in the future. If we're to guess wh
 be next, it would most likely be Ruby to support React Native based applications.
 
 With that being said, for languages not supported in our toolchain, you can still execute them
-within at task by setting the [`type` to "system"](./config/project#type-1).
+within at task by setting the [`platform` to "system"](./config/project#platform).
 
 ### Will moon support continuous deployment?
 
@@ -111,7 +111,7 @@ moon project foo --json | jq ...
 tasks:
 	pipe:
 		command: 'bash ./scripts/pipe.sh'
-		type: 'system'
+		platform: 'system'
 ```
 
 ### How to run multiple commands within a task?
@@ -138,32 +138,32 @@ the shell manually like so:
 tasks:
   bash:
     command: 'bash -c some-command'
-    type: 'system'
+    platform: 'system'
   # Windows
   cmd:
     command: 'cmd.exe /d /s /c some-command'
-    type: 'system'
+    platform: 'system'
   pwsh:
     command: 'pwsh.exe -c some-command'
-    type: 'system'
+    platform: 'system'
 ```
 
 ### Can we run other languages?
 
 Yes! Although our toolchain only supports JavaScript/Node.js at this time, you can still run other
-languages within tasks by setting their [`type`](./config/project#type-1) to "system". System tasks
-are an escape hatch that will use any command available on the current machine.
+languages within tasks by setting their [`platform`](./config/project#platform) to "system". System
+tasks are an escape hatch that will use any command available on the current machine.
 
 ```yaml title="moon.yml"
 tasks:
   # Ruby
   lint:
     command: 'rubocop'
-    type: 'system'
+    platform: 'system'
   # PHP
   test:
     command: 'phpunit tests'
-    type: 'system'
+    platform: 'system'
 ```
 
 However, because these languages are not supported directly within our toolchain, they will not


### PR DESCRIPTION
This aligns our terminology.