### PR TITLE
internal: Update UTC timestamps to not include timezone information.

### DIFF
--- a/.yarn/versions/de0bc3b3.yml
+++ b/.yarn/versions/de0bc3b3.yml
@@ -1,9 +1,15 @@
 releases:
-  "@moonrepo/cli": minor
-  "@moonrepo/core-linux-arm64-gnu": minor
-  "@moonrepo/core-linux-arm64-musl": minor
-  "@moonrepo/core-linux-x64-gnu": minor
-  "@moonrepo/core-linux-x64-musl": minor
-  "@moonrepo/core-macos-arm64": minor
-  "@moonrepo/core-macos-x64": minor
-  "@moonrepo/core-windows-x64-msvc": minor
+  '@moonrepo/cli': minor
+  '@moonrepo/core-linux-arm64-gnu': minor
+  '@moonrepo/core-linux-arm64-musl': minor
+  '@moonrepo/core-linux-x64-gnu': minor
+  '@moonrepo/core-linux-x64-musl': minor
+  '@moonrepo/core-macos-arm64': minor
+  '@moonrepo/core-macos-x64': minor
+  '@moonrepo/core-windows-x64-msvc': minor
+  '@moonrepo/types': patch
+
+declined:
+  - '@moonrepo/report'
+  - '@moonrepo/runtime'
+  - 'website'

--- a/crates/action/src/action.rs
+++ b/crates/action/src/action.rs
@@ -1,4 +1,4 @@
-use moon_utils::time::chrono::prelude::*;
+use moon_utils::time::{chrono::prelude::*, now_timestamp};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 
@@ -24,11 +24,11 @@ pub enum ActionStatus {
 pub struct Attempt {
     pub duration: Option<Duration>,
 
-    pub finished_at: Option<DateTime<Utc>>,
+    pub finished_at: Option<NaiveDateTime>,
 
     pub index: u8,
 
-    pub started_at: DateTime<Utc>,
+    pub started_at: NaiveDateTime,
 
     #[serde(skip)]
     pub start_time: Option<Instant>,
@@ -42,14 +42,14 @@ impl Attempt {
             duration: None,
             finished_at: None,
             index,
-            started_at: Utc::now(),
+            started_at: now_timestamp(),
             start_time: Some(Instant::now()),
             status: ActionStatus::Running,
         }
     }
 
     pub fn done(&mut self, status: ActionStatus) {
-        self.finished_at = Some(Utc::now());
+        self.finished_at = Some(now_timestamp());
         self.status = status;
 
         if let Some(start) = &self.start_time {
@@ -63,7 +63,7 @@ impl Attempt {
 pub struct Action {
     pub attempts: Option<Vec<Attempt>>,
 
-    pub created_at: DateTime<Utc>,
+    pub created_at: NaiveDateTime,
 
     pub duration: Option<Duration>,
 
@@ -85,7 +85,7 @@ impl Action {
     pub fn new(node_index: usize, label: Option<String>) -> Self {
         Action {
             attempts: None,
-            created_at: Utc::now(),
+            created_at: now_timestamp(),
             duration: None,
             error: None,
             flaky: false,

--- a/crates/action/src/action.rs
+++ b/crates/action/src/action.rs
@@ -69,6 +69,8 @@ pub struct Action {
 
     pub error: Option<String>,
 
+    pub finished_at: Option<NaiveDateTime>,
+
     pub flaky: bool,
 
     pub label: Option<String>,
@@ -88,6 +90,7 @@ impl Action {
             created_at: now_timestamp(),
             duration: None,
             error: None,
+            finished_at: None,
             flaky: false,
             label,
             node_index,
@@ -101,6 +104,7 @@ impl Action {
     }
 
     pub fn done(&mut self, status: ActionStatus) {
+        self.finished_at = Some(now_timestamp());
         self.status = status;
 
         if let Some(start) = &self.start_time {

--- a/crates/notifier/src/webhooks.rs
+++ b/crates/notifier/src/webhooks.rs
@@ -1,7 +1,7 @@
 use moon_emitter::{Event, EventFlow, Subscriber};
 use moon_error::MoonError;
 use moon_logger::{color, error, trace};
-use moon_utils::time::chrono::prelude::*;
+use moon_utils::time::{chrono::prelude::*, now_timestamp};
 use moon_workspace::Workspace;
 use serde::{Deserialize, Serialize};
 use tokio::task::JoinHandle;
@@ -12,7 +12,7 @@ const LOG_TARGET: &str = "moon:notifier:webhooks";
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WebhookPayload<T: Serialize> {
-    pub created_at: DateTime<Utc>,
+    pub created_at: NaiveDateTime,
 
     // Only for testing!
     #[serde(skip_deserializing)]
@@ -69,7 +69,7 @@ impl Subscriber for WebhooksSubscriber {
         }
 
         let payload = WebhookPayload {
-            created_at: Utc::now(),
+            created_at: now_timestamp(),
             event,
             type_of: event.get_type(),
             uuid: self.uuid.clone(),

--- a/crates/utils/src/time.rs
+++ b/crates/utils/src/time.rs
@@ -6,6 +6,10 @@ use std::time::Duration;
 pub use chrono;
 pub use humantime::{format_duration, parse_duration};
 
+pub fn now_timestamp() -> chrono::NaiveDateTime {
+    chrono::Utc::now().naive_utc()
+}
+
 pub fn elapsed(duration: Duration) -> String {
     if is_test_env() {
         return String::from("100ms"); // Snapshots

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### ⚙️ Internal
+
+- Timestamps have been updated to UTC _without timezone_.
+
 ## 0.17.0
 
 #### 💥 Breaking

--- a/packages/types/src/runner.ts
+++ b/packages/types/src/runner.ts
@@ -22,6 +22,7 @@ export interface Action {
 	createdAt: string;
 	duration: Duration | null;
 	error: string | null;
+	finishedAt: string | null;
 	flaky: boolean;
 	label: string | null;
 	nodeIndex: number;


### PR DESCRIPTION
We're already UTC, we don't need the timezone. The upstream service doesn't require it either.