### PR TITLE
new: Cache stdout/stderr as individual log files.

### DIFF
--- a/crates/cache/src/helpers.rs
+++ b/crates/cache/src/helpers.rs
@@ -1,6 +1,5 @@
 use moon_logger::warn;
 use std::env;
-use std::time::SystemTime;
 
 pub const LOG_TARGET: &str = "moon:cache";
 

--- a/crates/cache/src/helpers.rs
+++ b/crates/cache/src/helpers.rs
@@ -36,10 +36,3 @@ pub fn is_readable() -> bool {
 pub fn is_writable() -> bool {
     get_cache_env_var() == "write"
 }
-
-pub fn to_millis(time: SystemTime) -> u128 {
-    match time.duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(d) => d.as_millis(),
-        Err(_) => 0,
-    }
-}

--- a/crates/cache/src/items.rs
+++ b/crates/cache/src/items.rs
@@ -86,6 +86,33 @@ pub struct RunTargetState {
 
 cache_item!(RunTargetState);
 
+impl RunTargetState {
+    pub async fn load_outputs(&self) -> Result<(String, String), MoonError> {
+        let stdout_path = self.path.parent().unwrap().join("stdout.log");
+        let stdout = if stdout_path.exists() {
+            fs::read(stdout_path).await?
+        } else {
+            String::new()
+        };
+
+        let stderr_path = self.path.parent().unwrap().join("stderr.log");
+        let stderr = if stderr_path.exists() {
+            fs::read(stderr_path).await?
+        } else {
+            String::new()
+        };
+
+        Ok((stdout, stderr))
+    }
+
+    pub async fn save_outputs(&self, stdout: String, stderr: String) -> Result<(), MoonError> {
+        fs::write(self.path.parent().unwrap().join("stdout.log"), stdout).await?;
+        fs::write(self.path.parent().unwrap().join("stderr.log"), stderr).await?;
+
+        Ok(())
+    }
+}
+
 #[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectsState {

--- a/crates/cache/src/items.rs
+++ b/crates/cache/src/items.rs
@@ -1,86 +1,72 @@
-use crate::helpers::{is_readable, is_writable, to_millis};
+use crate::helpers::{is_readable, is_writable};
 use moon_error::MoonError;
 use moon_logger::{color, trace};
-use moon_utils::fs;
-use serde::de::DeserializeOwned;
+use moon_utils::{fs, time};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::time::SystemTime;
 
 const LOG_TARGET: &str = "moon:cache:item";
 
-pub struct CacheItem<T: DeserializeOwned + Serialize> {
-    pub item: T,
+macro_rules! cache_item {
+    ($struct:ident) => {
+        impl $struct {
+            pub async fn load(path: PathBuf, stale_ms: u128) -> Result<Self, MoonError> {
+                let mut item = Self::default();
 
-    pub path: PathBuf,
-}
+                if is_readable() {
+                    if path.exists() {
+                        // If stale, treat as a cache miss
+                        if stale_ms > 0
+                            && time::now_millis()
+                                - time::to_millis(fs::metadata(&path).await?.modified().unwrap())
+                                > stale_ms
+                        {
+                            trace!(
+                                target: LOG_TARGET,
+                                "Cache skip for {}, marked as stale",
+                                color::path(&path)
+                            );
+                        } else {
+                            trace!(
+                                target: LOG_TARGET,
+                                "Cache hit for {}, reading",
+                                color::path(&path)
+                            );
 
-impl<T: DeserializeOwned + Serialize> CacheItem<T> {
-    pub async fn load(
-        path: PathBuf,
-        default: T,
-        stale_ms: u128,
-    ) -> Result<CacheItem<T>, MoonError> {
-        let mut item: T = default;
+                            item = fs::read_json(&path).await?;
+                        }
+                    } else {
+                        trace!(
+                            target: LOG_TARGET,
+                            "Cache miss for {}, does not exist",
+                            color::path(&path)
+                        );
 
-        if is_readable() {
-            if path.exists() {
-                // If stale, treat as a cache miss
-                if stale_ms > 0
-                    && to_millis(SystemTime::now())
-                        - to_millis(fs::metadata(&path).await?.modified().unwrap())
-                        > stale_ms
-                {
-                    trace!(
-                        target: LOG_TARGET,
-                        "Cache skip for {}, marked as stale",
-                        color::path(&path)
-                    );
-                } else {
-                    trace!(
-                        target: LOG_TARGET,
-                        "Cache hit for {}, reading",
-                        color::path(&path)
-                    );
-
-                    item = fs::read_json(&path).await?;
+                        fs::create_dir_all(path.parent().unwrap()).await?;
+                    }
                 }
-            } else {
-                trace!(
-                    target: LOG_TARGET,
-                    "Cache miss for {}, does not exist",
-                    color::path(&path)
-                );
 
-                fs::create_dir_all(path.parent().unwrap()).await?;
+                item.path = path;
+
+                Ok(item)
+            }
+
+            pub async fn save(&self) -> Result<(), MoonError> {
+                if is_writable() {
+                    trace!(
+                        target: LOG_TARGET,
+                        "Writing cache {}",
+                        color::path(&self.path)
+                    );
+
+                    fs::write_json(&self.path, &self, false).await?;
+                }
+
+                Ok(())
             }
         }
-
-        Ok(CacheItem { item, path })
-    }
-
-    pub async fn save(&self) -> Result<(), MoonError> {
-        if is_writable() {
-            trace!(
-                target: LOG_TARGET,
-                "Writing cache {}",
-                color::path(&self.path)
-            );
-
-            fs::write_json(&self.path, &self.item, false).await?;
-        }
-
-        Ok(())
-    }
-
-    pub fn now_millis(&self) -> u128 {
-        to_millis(SystemTime::now())
-    }
-
-    pub fn to_millis(&self, time: SystemTime) -> u128 {
-        to_millis(time)
-    }
+    };
 }
 
 #[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -92,12 +78,13 @@ pub struct RunTargetState {
 
     pub last_run_time: u128,
 
-    pub stderr: String,
-
-    pub stdout: String,
-
     pub target: String,
+
+    #[serde(skip)]
+    pub path: PathBuf,
 }
+
+cache_item!(RunTargetState);
 
 #[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -107,18 +94,33 @@ pub struct ProjectsState {
 
     #[serde(default)]
     pub projects: HashMap<String, String>,
+
+    #[serde(skip)]
+    pub path: PathBuf,
 }
+
+cache_item!(ProjectsState);
 
 #[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolState {
     #[serde(default)]
     pub last_version_check_time: u128,
+
+    #[serde(skip)]
+    pub path: PathBuf,
 }
+
+cache_item!(ToolState);
 
 #[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DependenciesState {
     #[serde(default)]
     pub last_install_time: u128,
+
+    #[serde(skip)]
+    pub path: PathBuf,
 }
+
+cache_item!(DependenciesState);

--- a/crates/cache/tests/engine_test.rs
+++ b/crates/cache/tests/engine_test.rs
@@ -192,6 +192,7 @@ mod cache_run_target_state {
             RunTargetState {
                 exit_code: 123,
                 target: String::from("foo:bar"),
+                path: dir.path().join(".moon/cache/states/foo/bar/lastRun.json"),
                 ..RunTargetState::default()
             }
         );
@@ -218,6 +219,7 @@ mod cache_run_target_state {
             RunTargetState {
                 exit_code: 123,
                 target: String::from("foo:bar"),
+                path: dir.path().join(".moon/cache/states/foo/bar/lastRun.json"),
                 ..RunTargetState::default()
             }
         );
@@ -243,6 +245,7 @@ mod cache_run_target_state {
             item,
             RunTargetState {
                 target: String::from("foo:bar"),
+                path: dir.path().join(".moon/cache/states/foo/bar/lastRun.json"),
                 ..RunTargetState::default()
             }
         );
@@ -263,7 +266,7 @@ mod cache_run_target_state {
 
         assert_eq!(
             fs::read_to_string(item.path).unwrap(),
-            r#"{"exitCode":123,"hash":"","lastRunTime":0,"stderr":"","stdout":"","target":"foo:bar"}"#
+            r#"{"exitCode":123,"hash":"","lastRunTime":0,"target":"foo:bar"}"#
         );
 
         dir.close().unwrap();
@@ -379,7 +382,7 @@ mod cache_tool_state {
     async fn doesnt_load_if_it_exists_but_cache_is_off() {
         let dir = assert_fs::TempDir::new().unwrap();
 
-        dir.child(".moon/cache/states/tool-system.json")
+        dir.child(".moon/cache/states/toolSystem-latest.json")
             .write_str(r#"{"lastVersionCheckTime":123}"#)
             .unwrap();
 
@@ -388,7 +391,13 @@ mod cache_tool_state {
             .await
             .unwrap();
 
-        assert_eq!(item, ToolState::default());
+        assert_eq!(
+            item,
+            ToolState {
+                path: dir.path().join(".moon/cache/states/toolSystem-latest.json"),
+                ..ToolState::default()
+            }
+        );
 
         dir.close().unwrap();
     }
@@ -500,7 +509,13 @@ mod cache_projects_state {
             .await
             .unwrap();
 
-        assert_eq!(item, ProjectsState::default());
+        assert_eq!(
+            item,
+            ProjectsState {
+                path: dir.path().join(".moon/cache/states/projects.json"),
+                ..ProjectsState::default()
+            }
+        );
 
         dir.close().unwrap();
     }
@@ -525,7 +540,13 @@ mod cache_projects_state {
         let cache = CacheEngine::load(dir.path()).await.unwrap();
         let item = cache.cache_projects_state().await.unwrap();
 
-        assert_eq!(item, ProjectsState::default());
+        assert_eq!(
+            item,
+            ProjectsState {
+                path: dir.path().join(".moon/cache/states/projects.json"),
+                ..ProjectsState::default()
+            }
+        );
 
         dir.close().unwrap();
     }

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -253,6 +253,27 @@ mod caching {
             state.hash,
             "b690c7bdbfb85bf385be5b0c6d68e2616a140352f9c854fd376ee3e2096ab688"
         );
+
+        // Outputs are written to their own file
+        assert_eq!(
+            fs::read_to_string(
+                fixture
+                    .path()
+                    .join(".moon/cache/states/node/standard/stdout.log")
+            )
+            .unwrap(),
+            "stdout"
+        );
+
+        assert_eq!(
+            fs::read_to_string(
+                fixture
+                    .path()
+                    .join(".moon/cache/states/node/standard/stderr.log")
+            )
+            .unwrap(),
+            "stderr"
+        );
     }
 }
 

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -15,7 +15,7 @@ async fn extract_hash_from_run(fixture: &Path, target: &str) -> String {
     let engine = CacheEngine::load(fixture).await.unwrap();
     let cache = engine.cache_run_target_state(target).await.unwrap();
 
-    cache.item.hash
+    cache.hash
 }
 
 #[test]
@@ -187,7 +187,7 @@ mod logs {
 
 mod caching {
     use super::*;
-    use moon_cache::{CacheItem, RunTargetState};
+    use moon_cache::RunTargetState;
 
     #[test]
     fn uses_cache_on_subsequent_runs() {
@@ -238,21 +238,19 @@ mod caching {
 
         assert!(cache_path.exists());
 
-        let state = CacheItem::load(cache_path, RunTargetState::default(), 0)
-            .await
-            .unwrap();
+        let state = RunTargetState::load(cache_path, 0).await.unwrap();
 
         assert_snapshot!(fs::read_to_string(
             fixture
                 .path()
-                .join(format!(".moon/cache/hashes/{}.json", state.item.hash))
+                .join(format!(".moon/cache/hashes/{}.json", state.hash))
         )
         .unwrap());
 
-        assert_eq!(state.item.exit_code, 0);
-        assert_eq!(state.item.target, "node:standard");
+        assert_eq!(state.exit_code, 0);
+        assert_eq!(state.target, "node:standard");
         assert_eq!(
-            state.item.hash,
+            state.hash,
             "b690c7bdbfb85bf385be5b0c6d68e2616a140352f9c854fd376ee3e2096ab688"
         );
     }

--- a/crates/platform-node/src/actions/install_deps.rs
+++ b/crates/platform-node/src/actions/install_deps.rs
@@ -9,7 +9,7 @@ use moon_platform::Runtime;
 use moon_project::Project;
 use moon_terminal::{label_checkpoint, Checkpoint};
 use moon_toolchain::tools::node::NodeTool;
-use moon_utils::{fs, is_ci, is_offline};
+use moon_utils::{fs, is_ci, is_offline, time};
 use moon_workspace::{Workspace, WorkspaceError};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -142,7 +142,7 @@ pub async fn install_deps(
         .await?;
 
     if lock_filepath.exists() {
-        last_modified = cache.to_millis(
+        last_modified = time::to_millis(
             fs::metadata(&lock_filepath)
                 .await?
                 .modified()
@@ -151,7 +151,7 @@ pub async fn install_deps(
     }
 
     // Install deps if the lockfile has been modified since the last time they were installed!
-    if has_modified_files || last_modified == 0 || last_modified > cache.item.last_install_time {
+    if has_modified_files || last_modified == 0 || last_modified > cache.last_install_time {
         debug!(
             target: LOG_TARGET,
             "Installing {} dependencies in {}",
@@ -212,7 +212,7 @@ pub async fn install_deps(
         }
 
         // Update the cache with the timestamp
-        cache.item.last_install_time = cache.now_millis();
+        cache.last_install_time = time::now_millis();
         cache.save().await?;
 
         return Ok(ActionStatus::Passed);

--- a/crates/project-graph/src/graph.rs
+++ b/crates/project-graph/src/graph.rs
@@ -38,10 +38,10 @@ async fn load_projects_from_cache(
             let mut cache = engine.cache_projects_state().await?;
 
             // Return the values from the cache
-            if !cache.item.projects.is_empty() {
+            if !cache.projects.is_empty() {
                 debug!(target: LOG_TARGET, "Loading projects from cache");
 
-                return Ok(cache.item.projects);
+                return Ok(cache.projects);
             }
 
             // Generate a new projects map by globbing the filesystem
@@ -56,8 +56,8 @@ async fn load_projects_from_cache(
             detect_projects_with_globs(workspace_root, globs, &mut map)?;
 
             // Update the cache
-            cache.item.globs = globs.clone();
-            cache.item.projects = map.clone();
+            cache.globs = globs.clone();
+            cache.projects = map.clone();
             cache.save().await?;
 
             map

--- a/crates/runner/src/actions/run_target.rs
+++ b/crates/runner/src/actions/run_target.rs
@@ -1,7 +1,7 @@
 use crate::RunnerError;
 use console::Term;
 use moon_action::{Action, ActionContext, ActionStatus, Attempt};
-use moon_cache::{CacheItem, RunTargetState};
+use moon_cache::RunTargetState;
 use moon_config::{PlatformType, TaskOutputStyle};
 use moon_emitter::{Emitter, Event, EventFlow};
 use moon_error::MoonError;
@@ -33,7 +33,7 @@ pub enum HydrateFrom {
 }
 
 pub struct TargetRunner<'a> {
-    pub cache: CacheItem<RunTargetState>,
+    pub cache: RunTargetState,
 
     emitter: &'a Emitter,
 
@@ -70,7 +70,7 @@ impl<'a> TargetRunner<'a> {
     /// so that subsequent builds are faster, and any local outputs
     /// can be rehydrated easily.
     pub async fn archive_outputs(&self) -> Result<(), RunnerError> {
-        let hash = &self.cache.item.hash;
+        let hash = &self.cache.hash;
 
         if self.task.outputs.is_empty() || hash.is_empty() {
             return Ok(());
@@ -114,7 +114,7 @@ impl<'a> TargetRunner<'a> {
     /// If we are cached (hash match), hydrate the project with the
     /// cached task outputs found in the hashed archive.
     pub async fn hydrate_outputs(&self) -> Result<(), RunnerError> {
-        let hash = &self.cache.item.hash;
+        let hash = &self.cache.hash;
 
         if hash.is_empty() {
             return Ok(());
@@ -294,7 +294,7 @@ impl<'a> TargetRunner<'a> {
 
         // Hash is the same as the previous build, so simply abort!
         // However, ensure the outputs also exist, otherwise we should hydrate.
-        if self.cache.item.hash == hash && self.has_outputs() {
+        if self.cache.hash == hash && self.has_outputs() {
             debug!(
                 target: LOG_TARGET,
                 "Cache hit for hash {}, reusing previous build",
@@ -304,7 +304,7 @@ impl<'a> TargetRunner<'a> {
             return Ok(Some(HydrateFrom::PreviousOutput));
         }
 
-        self.cache.item.hash = hash.clone();
+        self.cache.hash = hash.clone();
 
         // Refresh the hash manifest
         self.workspace
@@ -477,19 +477,20 @@ impl<'a> TargetRunner<'a> {
         }
 
         // Write the cache with the result and output
-        self.cache.item.exit_code = output.status.code().unwrap_or(0);
-        self.cache.item.last_run_time = self.cache.now_millis();
-        self.cache.item.stderr = output_to_string(&output.stderr);
-        self.cache.item.stdout = output_to_string(&output.stdout);
+        self.cache.exit_code = output.status.code().unwrap_or(0);
+        self.cache.last_run_time = time::now_millis();
+        // self.cache.item.stderr = output_to_string(&output.stderr);
+        // self.cache.item.stdout = output_to_string(&output.stdout);
         self.cache.save().await?;
 
         Ok(attempts)
     }
 
     pub fn print_cache_item(&self) -> Result<(), MoonError> {
-        let item = &self.cache.item;
+        let item = &self.cache;
 
-        self.print_output_with_style(&item.stdout, &item.stderr, item.exit_code != 0)?;
+        // TODO
+        // self.print_output_with_style(&item.stdout, &item.stderr, item.exit_code != 0)?;
 
         Ok(())
     }
@@ -536,7 +537,7 @@ impl<'a> TargetRunner<'a> {
             }
             // Only show the hash
             Some(TaskOutputStyle::Hash) => {
-                let hash = &self.cache.item.hash;
+                let hash = &self.cache.hash;
 
                 if !hash.is_empty() {
                     // Print to stderr so it can be captured

--- a/crates/runner/src/actions/setup_toolchain.rs
+++ b/crates/runner/src/actions/setup_toolchain.rs
@@ -3,6 +3,7 @@ use moon_config::NodeConfig;
 use moon_logger::debug;
 use moon_platform::Runtime;
 use moon_toolchain::tools::node::NodeTool;
+use moon_utils::time;
 use moon_workspace::{Workspace, WorkspaceError};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -33,9 +34,9 @@ pub async fn setup_toolchain(
     // Only check the versions every 12 hours, as checking every
     // run has considerable overhead spawning all the child processes.
     // Revisit the threshold if need be.
-    let now = cache.now_millis();
-    let check_versions = cache.item.last_version_check_time == 0
-        || (cache.item.last_version_check_time + HOUR_MILLIS * 12) <= now;
+    let now = time::now_millis();
+    let check_versions = cache.last_version_check_time == 0
+        || (cache.last_version_check_time + HOUR_MILLIS * 12) <= now;
 
     // Install and setup the specific tool + version in the toolchain!
     let installed = match runtime {
@@ -65,7 +66,7 @@ pub async fn setup_toolchain(
 
     // Update the cache with the timestamp
     if check_versions {
-        cache.item.last_version_check_time = now;
+        cache.last_version_check_time = now;
         cache.save().await?;
     }
 

--- a/crates/utils/src/fs.rs
+++ b/crates/utils/src/fs.rs
@@ -159,6 +159,16 @@ pub async fn read_dir_all<T: AsRef<Path> + Send>(path: T) -> Result<Vec<fs::DirE
 }
 
 #[inline]
+pub async fn read<T: AsRef<Path>>(path: T) -> Result<String, MoonError> {
+    let path = path.as_ref();
+    let data = fs::read_to_string(path)
+        .await
+        .map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
+
+    Ok(data)
+}
+
+#[inline]
 pub async fn read_json<P, D>(path: P) -> Result<D, MoonError>
 where
     P: AsRef<Path>,
@@ -176,9 +186,7 @@ where
 #[inline]
 pub async fn read_json_string<T: AsRef<Path>>(path: T) -> Result<String, MoonError> {
     let path = path.as_ref();
-    let json = fs::read_to_string(path)
-        .await
-        .map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
+    let json = read(path).await?;
 
     clean_json(json)
 }

--- a/crates/utils/src/time.rs
+++ b/crates/utils/src/time.rs
@@ -1,13 +1,24 @@
 use crate::is_test_env;
 // use chrono::Duration;
 // use chrono_humanize::HumanTime;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 pub use chrono;
 pub use humantime::{format_duration, parse_duration};
 
 pub fn now_timestamp() -> chrono::NaiveDateTime {
     chrono::Utc::now().naive_utc()
+}
+
+pub fn now_millis() -> u128 {
+    to_millis(SystemTime::now())
+}
+
+pub fn to_millis(time: SystemTime) -> u128 {
+    match time.duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(d) => d.as_millis(),
+        Err(_) => 0,
+    }
 }
 
 pub fn elapsed(duration: Duration) -> String {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+#### 🚀 Updates
+
+##### Runner
+
+- The stdout and stderr of ran targets are now stored as individual log files in
+  `.moon/cache/states/<project>/<task>`. This allows CI environments to cache them as artifacts,
+  upload/download them, or simply help developers debug broken jobs.
+
 #### ⚙️ Internal
 
 - Timestamps have been updated to UTC _without timezone_.

--- a/website/docs/concepts/cache.mdx
+++ b/website/docs/concepts/cache.mdx
@@ -56,7 +56,11 @@ The following diagram outlines our cache folder structure and why each piece exi
 			runfile.json
 
 			<task>/
-				# Contents of the child process, including stdout, stderr, and exit code.
-				# Also contains the unique hash that is referenced above.
+				# Contents of the child process, including the exit code and
+				# unique hash that is referenced above.
 				lastRun.json
+
+				# Outputs of last run target.
+				stderr.log
+				stdout.log
 ```


### PR DESCRIPTION
This reworks the cache item layer to write stdout/stderr as their own files, instead of storing them in the item.