### PR TITLE
fix: Fix stdout/stderr logs not existing.

### DIFF
--- a/crates/cache/src/items/run_target_state.rs
+++ b/crates/cache/src/items/run_target_state.rs
@@ -42,8 +42,13 @@ impl RunTargetState {
             // Also include stdout/stderr logs at the root of the tarball
             let (stdout_path, stderr_path) = self.get_output_logs();
 
-            tar.add_source(stdout_path, Some("stdout.log"));
-            tar.add_source(stderr_path, Some("stderr.log"));
+            if stdout_path.exists() {
+                tar.add_source(stdout_path, Some("stdout.log"));
+            }
+
+            if stderr_path.exists() {
+                tar.add_source(stderr_path, Some("stderr.log"));
+            }
 
             tar.pack().map_err(|e| MoonError::Generic(e.to_string()))?;
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Improved the resolution and hashing of `package.json` dependencies for Yarn and pnpm.
+
+#### 🐞 Fixes
+
+- Fixed an issue where caching would fail on missing `stdout.log` and `stderr.log` files.
+
 ## 0.18.0
 
 #### 🚀 Updates


### PR DESCRIPTION
It's weird that a command would not produce these files, but let's check for this anyways.