### PR TITLE
fix: Fix passthrough args being passed to dependent targets.

### DIFF
--- a/.yarn/versions/5c64ed6a.yml
+++ b/.yarn/versions/5c64ed6a.yml
@@ -1,9 +1,15 @@
 releases:
-  "@moonrepo/cli": minor
-  "@moonrepo/core-linux-arm64-gnu": minor
-  "@moonrepo/core-linux-arm64-musl": minor
-  "@moonrepo/core-linux-x64-gnu": minor
-  "@moonrepo/core-linux-x64-musl": minor
-  "@moonrepo/core-macos-arm64": minor
-  "@moonrepo/core-macos-x64": minor
-  "@moonrepo/core-windows-x64-msvc": minor
+  '@moonrepo/cli': minor
+  '@moonrepo/core-linux-arm64-gnu': minor
+  '@moonrepo/core-linux-arm64-musl': minor
+  '@moonrepo/core-linux-x64-gnu': minor
+  '@moonrepo/core-linux-x64-musl': minor
+  '@moonrepo/core-macos-arm64': minor
+  '@moonrepo/core-macos-x64': minor
+  '@moonrepo/core-windows-x64-msvc': minor
+  '@moonrepo/types': patch
+
+declined:
+  - '@moonrepo/report'
+  - '@moonrepo/runtime'
+  - 'website'

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -83,6 +83,7 @@ pub async fn run(
 
     // Process all tasks in the graph
     let context = ActionContext {
+        initial_targets: FxHashSet::from_iter(target_ids.to_owned()),
         passthrough_args: options.passthrough,
         primary_targets: FxHashSet::from_iter(primary_targets),
         profile: options.profile,

--- a/crates/cli/tests/dep_graph_test.rs
+++ b/crates/cli/tests/dep_graph_test.rs
@@ -11,7 +11,7 @@ fn all_by_default() {
     let dot = get_assert_output(&assert);
 
     // Snapshot is not deterministic
-    assert_eq!(dot.split('\n').count(), 320);
+    assert_eq!(dot.split('\n').count(), 336);
 }
 
 #[test]

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -251,7 +251,7 @@ mod caching {
         assert_eq!(state.target, "node:standard");
         assert_eq!(
             state.hash,
-            "d6d8b9ac59dd7d574c7f38b6ed646b3237537b590c21520f4ae960e988715f57"
+            "2f6c69d1ee266d4b3bc5cdc6b1cd501068677e8a5c7402aca22c3010bf076efb"
         );
 
         // Outputs are written to their own file
@@ -542,6 +542,24 @@ mod system {
             .assert();
 
         assert_snapshot!(get_assert_output(&assert));
+    }
+
+    mod passthrough {
+        use super::*;
+
+        #[test]
+        fn doesnt_pass_to_non_primary() {
+            let fixture = create_sandbox_with_git("cases");
+
+            let assert = create_moon_command(fixture.path())
+                .arg("run")
+                .arg("passthroughArgs:b")
+                .arg("--")
+                .arg("-aBc")
+                .assert();
+
+            assert_snapshot!(get_assert_output(&assert));
+        }
     }
 }
 

--- a/crates/cli/tests/snapshots/run_test__caching__creates_run_state_cache.snap
+++ b/crates/cli/tests/snapshots/run_test__caching__creates_run_state_cache.snap
@@ -12,7 +12,7 @@ expression: "fs::read_to_string(fixture.path().join(format!(\".moon/cache/hashes
     "deps": [],
     "envVars": {},
     "inputs": {
-      ".moon/workspace.yml": "ec07941c11e1b121e5fcbf07a3d4e193a1e3c3b8",
+      ".moon/workspace.yml": "15bf5ce475106c26a7f11ff12589c2b354b97ef7",
       "node/binExecArgs.js": "efbc46d56304f43ae64c5616b2135d7a95d55263",
       "node/cjsFile.cjs": "91382f667258361b9397214d0aec54d8d576ae19",
       "node/cwd.js": "47d4aa44cd6363251821ab9c59f4c68df455445c",

--- a/crates/cli/tests/snapshots/run_test__output_styles__hash.snap
+++ b/crates/cli/tests/snapshots/run_test__output_styles__hash.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/cli/tests/run_test.rs
-assertion_line: 1010
+assertion_line: 1105
 expression: get_assert_output(&assert)
 ---
 ▪▪▪▪ npm install
@@ -11,6 +11,6 @@ expression: get_assert_output(&assert)
 Tasks: 2 completed
  Time: 100ms
 
-9d80de2c5a351bcf70e81cfdd07f892e95c79b3b75454359a750e9c1363b7540
+df3f9de539ee1874bc434e5d58d2895be67b73034548563214bea83f3d3b783c
 
 

--- a/crates/cli/tests/snapshots/run_test__system__passthrough__doesnt_pass_to_non_primary.snap
+++ b/crates/cli/tests/snapshots/run_test__system__passthrough__doesnt_pass_to_non_primary.snap
@@ -1,0 +1,17 @@
+---
+source: crates/cli/tests/run_test.rs
+assertion_line: 561
+expression: get_assert_output(&assert)
+---
+▪▪▪▪ passthroughArgs:dep
+▪▪▪▪ passthroughArgs:dep (100ms)
+
+
+▪▪▪▪ passthroughArgs:b
+-aBc
+
+Tasks: 2 completed
+ Time: 100ms
+
+
+

--- a/crates/core/action/src/context.rs
+++ b/crates/core/action/src/context.rs
@@ -9,9 +9,11 @@ pub enum ProfileType {
     Heap,
 }
 
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionContext {
+    pub initial_targets: FxHashSet<String>,
+
     pub passthrough_args: Vec<String>,
 
     pub primary_targets: FxHashSet<String>,
@@ -19,4 +21,26 @@ pub struct ActionContext {
     pub profile: Option<ProfileType>,
 
     pub touched_files: FxHashSet<PathBuf>,
+}
+
+impl ActionContext {
+    pub fn should_inherit_args(&self, target: &str) -> bool {
+        if self.passthrough_args.is_empty() {
+            return false;
+        }
+
+        // project:task == project:task
+        if self.primary_targets.contains(target) {
+            return true;
+        }
+
+        // :task == project:task
+        for initial_target in &self.initial_targets {
+            if target.ends_with(initial_target) {
+                return true;
+            }
+        }
+
+        false
+    }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where passthrough args were incorrectly being passed to non-primary targets when
+  using `moon run`.
+
 ## 0.18.1
 
 #### 🚀 Updates

--- a/packages/types/src/runner.ts
+++ b/packages/types/src/runner.ts
@@ -30,6 +30,7 @@ export interface Action {
 }
 
 export interface ActionContext {
+	initialTargets: string[];
 	passthroughArgs: string[];
 	primaryTargets: string[];
 	profile: 'cpu' | 'heap' | null;

--- a/tests/fixtures/cases/.moon/workspace.yml
+++ b/tests/fixtures/cases/.moon/workspace.yml
@@ -25,6 +25,9 @@ projects:
   outputs: 'outputs'
   outputStyles: 'output-styles'
 
+  # Runner
+  passthroughArgs: 'passthrough-args'
+
 typescript:
   syncProjectReferences: false
 

--- a/tests/fixtures/cases/passthrough-args/moon.yml
+++ b/tests/fixtures/cases/passthrough-args/moon.yml
@@ -1,0 +1,15 @@
+tasks:
+  dep:
+    command: bash ./passthroughArgs.sh
+    platform: system
+  a:
+    command: bash ./passthroughArgs.sh
+    platform: system
+  b:
+    command: bash ./passthroughArgs.sh
+    deps: [dep]
+    platform: system
+  c:
+    command: bash ./passthroughArgs.sh
+    deps: [dep]
+    platform: system

--- a/tests/fixtures/cases/passthrough-args/passthroughArgs.sh
+++ b/tests/fixtures/cases/passthrough-args/passthroughArgs.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "$@"


### PR DESCRIPTION
When running `moon run :build -- --arg`, the `--arg` _should only_ be passed to `:build` targets and not their dependencies.