### PR TITLE
fix: Invalidate hashes if a dependencies hash changes.

### DIFF
--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -6,7 +6,7 @@ use moon_logger::{color, map_list};
 use moon_runner::{DepGraph, Runner};
 use moon_task::Target;
 use moon_workspace::Workspace;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::string::ToString;
 
 #[derive(Default)]
@@ -87,6 +87,7 @@ pub async fn run(
         passthrough_args: options.passthrough,
         primary_targets: FxHashSet::from_iter(primary_targets),
         profile: options.profile,
+        target_hashes: FxHashMap::default(),
         touched_files: touched_files.unwrap_or_default(),
     };
 

--- a/crates/cli/tests/snapshots/run_system_test__system_windows__caching__creates_run_state_cache.snap
+++ b/crates/cli/tests/snapshots/run_system_test__system_windows__caching__creates_run_state_cache.snap
@@ -10,7 +10,7 @@ expression: "fs::read_to_string(fixture.path().join(format!(\".moon/cache/hashes
       "/c",
       "/q"
     ],
-    "deps": [],
+    "deps": {},
     "envVars": {},
     "inputs": {
       ".moon/workspace.yml": "c448710a2eaaec20fe6897f6d62d1e77f39edf4e",

--- a/crates/cli/tests/snapshots/run_system_test__unix__caching__creates_run_state_cache.snap
+++ b/crates/cli/tests/snapshots/run_system_test__unix__caching__creates_run_state_cache.snap
@@ -9,7 +9,7 @@ expression: "fs::read_to_string(fixture.path().join(format!(\".moon/cache/hashes
     "args": [
       "./outputs.sh"
     ],
-    "deps": [],
+    "deps": {},
     "envVars": {},
     "inputs": {
       ".moon/workspace.yml": "c448710a2eaaec20fe6897f6d62d1e77f39edf4e",

--- a/crates/core/action/src/context.rs
+++ b/crates/core/action/src/context.rs
@@ -1,5 +1,5 @@
 use clap::ValueEnum;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -19,6 +19,8 @@ pub struct ActionContext {
     pub primary_targets: FxHashSet<String>,
 
     pub profile: Option<ProfileType>,
+
+    pub target_hashes: FxHashMap<String, String>,
 
     pub touched_files: FxHashSet<PathBuf>,
 }

--- a/crates/core/runner/src/actions/setup_toolchain.rs
+++ b/crates/core/runner/src/actions/setup_toolchain.rs
@@ -13,7 +13,7 @@ const HOUR_MILLIS: u128 = 36000;
 
 pub async fn setup_toolchain(
     _action: &mut Action,
-    _context: &ActionContext,
+    _context: Arc<RwLock<ActionContext>>,
     workspace: Arc<RwLock<Workspace>>,
     runtime: &Runtime,
 ) -> Result<ActionStatus, WorkspaceError> {

--- a/crates/node/platform/src/actions/install_deps.rs
+++ b/crates/node/platform/src/actions/install_deps.rs
@@ -96,12 +96,13 @@ async fn sync_workspace(workspace: &Workspace, node: &NodeTool) -> Result<(), Mo
 
 pub async fn install_deps(
     _action: &mut Action,
-    context: &ActionContext,
+    context: Arc<RwLock<ActionContext>>,
     workspace: Arc<RwLock<Workspace>>,
     runtime: &Runtime,
     project: Option<&Project>,
 ) -> Result<ActionStatus, WorkspaceError> {
     let workspace = workspace.read().await;
+    let context = context.read().await;
     let node = workspace.toolchain.node.get_for_runtime(runtime)?;
     let pm = node.get_package_manager();
     let lock_filename = pm.get_lock_filename();

--- a/crates/node/platform/src/actions/sync_project.rs
+++ b/crates/node/platform/src/actions/sync_project.rs
@@ -75,7 +75,7 @@ fn sync_root_tsconfig(
 
 pub async fn sync_project(
     _action: &mut Action,
-    _context: &ActionContext,
+    _context: Arc<RwLock<ActionContext>>,
     workspace: Arc<RwLock<Workspace>>,
     project: &Project,
 ) -> Result<ActionStatus, WorkspaceError> {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - Fixed an issue where passthrough args were incorrectly being passed to non-primary targets when
   using `moon run`.
+- Task hashes will now properly invalidate if their dependencies hashes have also changed.
 
 #### ⚙️ Internal
 

--- a/packages/types/src/runner.ts
+++ b/packages/types/src/runner.ts
@@ -34,6 +34,7 @@ export interface ActionContext {
 	passthroughArgs: string[];
 	primaryTargets: string[];
 	profile: 'cpu' | 'heap' | null;
+	targetHashes: Record<string, string>;
 	touchedFiles: string[];
 }
 

--- a/tests/fixtures/cases/outputs/generate.js
+++ b/tests/fixtures/cases/outputs/generate.js
@@ -3,11 +3,11 @@ const path = require('path');
 
 const type = process.argv[2];
 
-function createFile(file) {
+function createFile(file, content) {
 	const filePath = path.join(__dirname, file);
 
 	fs.mkdirSync(path.dirname(filePath), { recursive: true });
-	fs.writeFileSync(filePath, String(Date.now()), 'utf8');
+	fs.writeFileSync(filePath, content ?? String(Date.now()), 'utf8');
 }
 
 switch (type) {
@@ -23,5 +23,8 @@ switch (type) {
 	case 'both':
 		createFile('lib/one.js');
 		createFile('esm/two.js');
+		break;
+	case 'custom':
+		createFile(process.argv[3], 'fixed content');
 		break;
 }

--- a/tests/fixtures/cases/outputs/moon.yml
+++ b/tests/fixtures/cases/outputs/moon.yml
@@ -39,6 +39,26 @@ tasks:
     outputs:
       - 'lib/one.js'
       - 'esm'
+
+  # Dependency hashing
+  asDep:
+    command: node
+    args: generate.js custom test.js
+    inputs:
+      - '*.js'
+    outputs:
+      - 'test.js'
+  withDeps:
+    command: node
+    args: generate.js custom test.mjs
+    deps:
+      - '~:asDep'
+    inputs:
+      - '*.mjs'
+    outputs:
+      - 'test.mjs'
+
+  # Other cases
   noCache:
     command: node
     args: generate.js both


### PR DESCRIPTION
This was an oversight on my part. If A depends on B, and B's hash changes, then A should generate a new hash. This wasn't working previously.