### PR TITLE
new: Add `affectedFiles` task option.

### DIFF
--- a/.moon/project.yml
+++ b/.moon/project.yml
@@ -34,12 +34,13 @@ tasks:
       - '--ignore-path'
       - '@in(2)'
       - '--no-error-on-unmatched-pattern'
-      - '.'
     inputs:
       - '@globs(sources)'
       - '@globs(tests)'
       - '/.prettierignore'
       - '/prettier.config.js'
+    options:
+      affectedFiles: true
 
   lint:
     command: 'eslint'
@@ -56,7 +57,6 @@ tasks:
       - '--exit-on-fatal-error'
       - '--no-error-on-unmatched-pattern'
       - '--report-unused-disable-directives'
-      - '.'
     inputs:
       - '@globs(sources)'
       - '@globs(tests)'
@@ -67,6 +67,8 @@ tasks:
       - '/.eslintrc.js'
       - '/tsconfig.eslint.json'
       - '/tsconfig.options.json'
+    options:
+      affectedFiles: true
 
   test:
     command: 'jest'

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -83,6 +83,7 @@ pub async fn run(
 
     // Process all tasks in the graph
     let context = ActionContext {
+        affected: options.affected,
         initial_targets: FxHashSet::from_iter(target_ids.to_owned()),
         passthrough_args: options.passthrough,
         primary_targets: FxHashSet::from_iter(primary_targets),

--- a/crates/cli/tests/run_node_test.rs
+++ b/crates/cli/tests/run_node_test.rs
@@ -1290,3 +1290,41 @@ mod typescript {
 //         assert.success();
 //     }
 // }
+
+mod affected_files {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn uses_dot_when_not_affected() {
+        let fixture = create_sandbox_with_git("node");
+
+        let assert = create_moon_command(fixture.path())
+            .arg("run")
+            .arg("node:affectedFiles")
+            .assert();
+        let output = get_assert_output(&assert);
+
+        assert!(predicate::str::contains("Args: .\n").eval(&output));
+    }
+
+    #[test]
+    fn uses_rel_paths_when_affected() {
+        let fixture = create_sandbox_with_git("node");
+
+        fs::write(fixture.path().join("base/input1.js"), "").unwrap();
+        fs::write(fixture.path().join("base/input2.js"), "").unwrap();
+
+        let assert = create_moon_command(fixture.path())
+            .arg("run")
+            .arg("node:affectedFiles")
+            .arg("--affected")
+            .assert();
+        let output = get_assert_output(&assert);
+
+        // Order is not deterministic
+        assert!(predicate::str::contains("Args:").eval(&output));
+        assert!(predicate::str::contains("./input1.js").eval(&output));
+        assert!(predicate::str::contains("./input2.js").eval(&output));
+    }
+}

--- a/crates/cli/tests/run_node_test.rs
+++ b/crates/cli/tests/run_node_test.rs
@@ -1324,7 +1324,13 @@ mod affected_files {
 
         // Order is not deterministic
         assert!(predicate::str::contains("Args:").eval(&output));
-        assert!(predicate::str::contains("./input1.js").eval(&output));
-        assert!(predicate::str::contains("./input2.js").eval(&output));
+
+        if cfg!(windows) {
+            assert!(predicate::str::contains(".\\input1.js").eval(&output));
+            assert!(predicate::str::contains(".\\input2.js").eval(&output));
+        } else {
+            assert!(predicate::str::contains("./input1.js").eval(&output));
+            assert!(predicate::str::contains("./input2.js").eval(&output));
+        }
     }
 }

--- a/crates/cli/tests/snapshots/run_node_test__passes_args_through.snap
+++ b/crates/cli/tests/snapshots/run_node_test__passes_args_through.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/cli/tests/run_node_test.rs
-assertion_line: 174
+assertion_line: 173
 expression: get_assert_output(&assert)
 ---
 ▪▪▪▪ npm install
 ▪▪▪▪ node:passthroughArgs
--aBc --opt value --optCamel=value foo 'bar baz' --opt-kebab 123
+Args: -aBc --opt value --optCamel=value foo 'bar baz' --opt-kebab 123
 
 Tasks: 1 completed
  Time: 100ms

--- a/crates/cli/tests/snapshots/run_system_test__unix__caching__creates_run_state_cache.snap
+++ b/crates/cli/tests/snapshots/run_system_test__unix__caching__creates_run_state_cache.snap
@@ -13,14 +13,14 @@ expression: "fs::read_to_string(fixture.path().join(format!(\".moon/cache/hashes
     "envVars": {},
     "inputs": {
       ".moon/workspace.yml": "c448710a2eaaec20fe6897f6d62d1e77f39edf4e",
+      "unix/args.sh": "ac54a54b387de2281f14259a6e974688f6465c57",
       "unix/cwd.sh": "9a5ea47dd8809abadf1c61817ffe6be07883af0d",
       "unix/envVars.sh": "63cd12999af89a6823e908f32f2a08bf7f27182e",
       "unix/envVarsMoon.sh": "357c556827eaccb9fc7cc96fe882c073068b112f",
       "unix/exitNonZero.sh": "73cb4653d441d323178c51ea1ba9c4d82e169a91",
       "unix/exitZero.sh": "1ad12d878a9eac999c1bfd3b033158e22f147918",
-      "unix/moon.yml": "2c8630a34b743dd5f76b59deab92a28bf00bc6d7",
+      "unix/moon.yml": "c915d14c1548df1aeaa61e0d1498711bd70a354f",
       "unix/outputs.sh": "9eb7ff5d58f831c346d39e41f98aac3f937a7e1d",
-      "unix/passthroughArgs.sh": "a0b35aa7e9ed94f337760637aab0ec634f5376df",
       "unix/standard.sh": "5d6a286c841c122f2dcc0df70cbf7cc17629d8c0"
     },
     "outputs": [

--- a/crates/cli/tests/snapshots/run_system_test__unix__handles_ls.snap
+++ b/crates/cli/tests/snapshots/run_system_test__unix__handles_ls.snap
@@ -4,6 +4,7 @@ assertion_line: 33
 expression: get_assert_output(&assert)
 ---
 ▪▪▪▪ unix:ls
+args.sh
 cwd.sh
 envVars.sh
 envVarsMoon.sh
@@ -11,7 +12,6 @@ exitNonZero.sh
 exitZero.sh
 moon.yml
 outputs.sh
-passthroughArgs.sh
 standard.sh
 
 Tasks: 1 completed

--- a/crates/cli/tests/snapshots/run_system_test__unix__passes_args_through.snap
+++ b/crates/cli/tests/snapshots/run_system_test__unix__passes_args_through.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/cli/tests/run_system_test.rs
-assertion_line: 89
+assertion_line: 90
 expression: get_assert_output(&assert)
 ---
 ▪▪▪▪ unix:passthroughArgs
--aBc --opt value --optCamel=value foo 'bar baz' --opt-kebab 123
+Args: -aBc --opt value --optCamel=value foo 'bar baz' --opt-kebab 123
 
 Tasks: 1 completed
  Time: 100ms

--- a/crates/core/action/src/context.rs
+++ b/crates/core/action/src/context.rs
@@ -12,6 +12,8 @@ pub enum ProfileType {
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionContext {
+    pub affected: bool,
+
     pub initial_targets: FxHashSet<String>,
 
     pub passthrough_args: Vec<String>,

--- a/crates/core/config/src/project/task_options.rs
+++ b/crates/core/config/src/project/task_options.rs
@@ -54,6 +54,8 @@ pub enum TaskOutputStyle {
 #[schemars(default)]
 #[serde(default, rename_all = "camelCase")]
 pub struct TaskOptionsConfig {
+    pub affected_files: Option<bool>,
+
     pub cache: Option<bool>,
 
     #[validate(custom = "validate_env_file")]

--- a/crates/core/project/tests/project_test.rs
+++ b/crates/core/project/tests/project_test.rs
@@ -234,52 +234,36 @@ mod tasks {
 
     fn mock_merged_task_options_config(strategy: TaskMergeStrategy) -> TaskOptionsConfig {
         TaskOptionsConfig {
-            cache: None,
-            env_file: None,
             merge_args: Some(strategy.clone()),
             merge_deps: Some(strategy.clone()),
             merge_env: Some(strategy.clone()),
             merge_inputs: Some(strategy.clone()),
             merge_outputs: Some(strategy),
-            output_style: None,
             retry_count: Some(1),
             run_deps_in_parallel: Some(true),
             run_in_ci: Some(true),
-            run_from_workspace_root: None,
+            ..TaskOptionsConfig::default()
         }
     }
 
     fn mock_local_task_options_config(strategy: TaskMergeStrategy) -> TaskOptionsConfig {
         TaskOptionsConfig {
-            cache: None,
-            env_file: None,
             merge_args: Some(strategy.clone()),
             merge_deps: Some(strategy.clone()),
             merge_env: Some(strategy.clone()),
             merge_inputs: Some(strategy.clone()),
             merge_outputs: Some(strategy),
-            output_style: None,
-            retry_count: None,
-            run_deps_in_parallel: None,
-            run_in_ci: None,
-            run_from_workspace_root: None,
+            ..TaskOptionsConfig::default()
         }
     }
 
     fn stub_global_task_options_config() -> TaskOptionsConfig {
         TaskOptionsConfig {
             cache: Some(true),
-            env_file: None,
-            merge_args: None,
-            merge_deps: None,
-            merge_env: None,
-            merge_inputs: None,
-            merge_outputs: None,
-            output_style: None,
             retry_count: Some(1),
             run_deps_in_parallel: Some(true),
             run_in_ci: Some(true),
-            run_from_workspace_root: None,
+            ..TaskOptionsConfig::default()
         }
     }
 
@@ -890,18 +874,12 @@ mod tasks {
                             local: false,
                             outputs: Some(string_vec!["b.ts"]),
                             options: TaskOptionsConfig {
-                                cache: None,
-                                env_file: None,
                                 merge_args: Some(TaskMergeStrategy::Append),
                                 merge_deps: Some(TaskMergeStrategy::Prepend),
                                 merge_env: Some(TaskMergeStrategy::Replace),
                                 merge_inputs: Some(TaskMergeStrategy::Replace),
                                 merge_outputs: Some(TaskMergeStrategy::Append),
-                                output_style: None,
-                                retry_count: None,
-                                run_deps_in_parallel: None,
-                                run_in_ci: None,
-                                run_from_workspace_root: None,
+                                ..TaskOptionsConfig::default()
                             },
                             platform: PlatformType::Unknown,
                         }

--- a/crates/core/runner/src/actions/run_target.rs
+++ b/crates/core/runner/src/actions/run_target.rs
@@ -390,7 +390,9 @@ impl<'a> TargetRunner<'a> {
 
         if self.task.options.affected_files {
             if context.affected {
-                let affected_files = self.task.get_affected_files(&context.touched_files)?;
+                let affected_files = self
+                    .task
+                    .get_affected_files(&context.touched_files, &self.project.root)?;
 
                 if affected_files.is_empty() {
                     command.arg_if_missing(".");

--- a/crates/core/runner/src/actions/run_target.rs
+++ b/crates/core/runner/src/actions/run_target.rs
@@ -388,6 +388,20 @@ impl<'a> TargetRunner<'a> {
             command.args(&context.passthrough_args);
         }
 
+        if self.task.options.affected_files {
+            if context.affected {
+                let affected_files = self.task.get_affected_files(&context.touched_files)?;
+
+                if affected_files.is_empty() {
+                    command.arg_if_missing(".");
+                } else {
+                    command.args(affected_files);
+                }
+            } else {
+                command.arg_if_missing(".");
+            }
+        }
+
         if self.workspace.config.runner.inherit_colors_for_piped_tasks {
             command.inherit_colors();
         }

--- a/crates/core/task/src/task.rs
+++ b/crates/core/task/src/task.rs
@@ -529,6 +529,24 @@ impl Task {
         Ok(())
     }
 
+    /// Return a list of affected files filtered down from the provided touched files list.
+    pub fn get_affected_files(
+        &self,
+        touched_files: &TouchedFilePaths,
+    ) -> Result<Vec<PathBuf>, TaskError> {
+        let mut files = vec![];
+        let has_globs = !self.input_globs.is_empty();
+        let globset = self.create_globset()?;
+
+        for file in touched_files {
+            if self.input_paths.contains(file) || (has_globs && globset.matches(file)?) {
+                files.push(file.clone());
+            }
+        }
+
+        Ok(files)
+    }
+
     /// Return true if this task is affected based on touched files.
     /// Will attempt to find any file that matches our list of inputs.
     pub fn is_affected(&self, touched_files: &TouchedFilePaths) -> Result<bool, TaskError> {

--- a/crates/core/task/tests/task_test.rs
+++ b/crates/core/task/tests/task_test.rs
@@ -39,6 +39,7 @@ mod from_config {
         assert_eq!(
             task.options,
             TaskOptions {
+                affected_files: false,
                 cache: true,
                 env_file: None,
                 merge_args: TaskMergeStrategy::Append,

--- a/crates/core/vcs/src/git.rs
+++ b/crates/core/vcs/src/git.rs
@@ -164,7 +164,7 @@ impl Vcs for Git {
 
         let output = self
             .create_command(vec!["hash-object", "--stdin-paths"])
-            .input(objects.join("\n").as_bytes())
+            .input(&[objects.join("\n")])
             .exec_capture_output()
             .await?;
         let output = output_to_trimmed_string(&output.stdout);

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -15,6 +15,8 @@
 - When writing JSON files, indentation and formatting will be inferred from the closest
   `.editorconfig` as best as possible.
 - When applicable, `moon ci` will group and collapse logs based on the current CI/CD environment.
+- Added an `affectedFiles` task option, allowing a filtered list of paths based on affected files to
+  be passed as command line arguments. Perfect for git hooks!
 - Updated webhook payloads to contain information about the current CI/CD environment under the
   `environment` field.
 

--- a/packages/types/src/project-config.ts
+++ b/packages/types/src/project-config.ts
@@ -14,6 +14,7 @@ export type TaskMergeStrategy = 'append' | 'prepend' | 'replace';
 export type TaskOutputStyle = 'buffer-only-failure' | 'buffer' | 'hash' | 'none' | 'stream';
 
 export interface TaskOptionsConfig {
+	affectedFiles: boolean | null;
 	cache: boolean | null;
 	envFile: boolean | string | null;
 	mergeArgs: TaskMergeStrategy | null;

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -16,6 +16,7 @@ export interface FileGroup {
 }
 
 export interface TaskOptions {
+	affectedFiles: boolean;
 	cache: boolean;
 	envFile: string | null;
 	mergeArgs: TaskMergeStrategy;

--- a/tests/fixtures/node/base/args.js
+++ b/tests/fixtures/node/base/args.js
@@ -1,0 +1,1 @@
+console.log('Args:', process.argv.slice(2).join(' '));

--- a/tests/fixtures/node/base/moon.yml
+++ b/tests/fixtures/node/base/moon.yml
@@ -37,7 +37,7 @@ tasks:
     args: ./topLevelAwait.mjs
   passthroughArgs:
     command: node
-    args: ./passthroughArgs.js
+    args: ./args.js
   envVars:
     command: node
     args: ./envVars.js
@@ -64,3 +64,7 @@ tasks:
   binExecArgs:
     command: node
     args: ./binExecArgs.js
+  affectedFiles:
+    command: node ./args.js
+    options:
+      affectedFiles: true

--- a/tests/fixtures/node/base/passthroughArgs.js
+++ b/tests/fixtures/node/base/passthroughArgs.js
@@ -1,1 +1,0 @@
-console.log(process.argv.slice(2).join(' '));

--- a/tests/fixtures/system/unix/args.sh
+++ b/tests/fixtures/system/unix/args.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-echo "$@"
+echo "Args: $@"

--- a/tests/fixtures/system/unix/moon.yml
+++ b/tests/fixtures/system/unix/moon.yml
@@ -23,7 +23,7 @@ tasks:
     platform: system
   passthroughArgs:
     command: bash
-    args: ./passthroughArgs.sh
+    args: ./args.sh
     platform: system
   envVars:
     command: bash
@@ -59,6 +59,10 @@ tasks:
     outputs:
       - 'file.txt'
       - 'folder'
+  affectedFiles:
+    command: bash ./args.sh
+    options:
+      affectedFiles: true
 
   # Misc
   foo:

--- a/website/.eslintrc.js
+++ b/website/.eslintrc.js
@@ -1,4 +1,3 @@
-//
 module.exports = {
 	ignorePatterns: ['prism.config.js', 'tailwind.config.js'],
 	rules: {

--- a/website/.eslintrc.js
+++ b/website/.eslintrc.js
@@ -1,3 +1,4 @@
+//
 module.exports = {
 	ignorePatterns: ['prism.config.js', 'tailwind.config.js'],
 	rules: {

--- a/website/blog/2022-10-31_v0.18.mdx
+++ b/website/blog/2022-10-31_v0.18.mdx
@@ -86,4 +86,4 @@ Expect the following in the v0.19 release!
 
 - Laying the groundwork for _remote caching_!
 - An in-repo secrets management layer.
-- Performance improvements.
+- Performance and affected improvements.

--- a/website/blog/2022-11-14_v0.19.mdx
+++ b/website/blog/2022-11-14_v0.19.mdx
@@ -1,0 +1,70 @@
+---
+slug: v0.19
+title: v0.19 - ???
+authors: [milesj]
+tags: [affected, remote-cache]
+# image: ./img/v0.19.png
+---
+
+import Image from '@site/src/components/Image';
+
+TODO
+
+<!--truncate-->
+
+## Affected files filtering
+
+We've spent a good portion of this release working on affected detection for projects and tasks,
+primarily through `--affected`, and have uncovered and fixed a handful of edge cases. With that
+being said, we asked ourselves, "How could we improve the developer experience even more"? What
+about passing the affected files list to the running task?
+
+And that's exactly what we've done through the new task option
+[`affectedFiles`](../docs/config/project#affectedfiles)! This option works in unison with the
+`--affected` option, enabling some awesome functionality. Given the following config:
+
+```yaml title="moon.yml" {6}
+tasks:
+  lint:
+    command: 'eslint'
+    options:
+      affectedFiles: true
+```
+
+When we run this task _without_ `--affected`, it will append an argument for the current directory
+(`.`). This will lint the entire project.
+
+```shell
+# moon run project:lint
+eslint .
+```
+
+However, when we run this task _with_ `--affected`, and have have touched files in the working tree,
+it will now append an argument for each file that matches the task's `inputs`. This will now only
+lint the provided files, _instead_ of the entire project.
+
+```shell
+# moon run project:lint --affected
+eslint ./file.ts ./another/file.ts
+```
+
+This functionality is _perfect_ pre-commit hooks, and as such, we've added a
+[guide for utilizing this pattern with git hooks](../docs/guides/git-hooks)!
+
+## Other changes
+
+View the
+[official release](https://github.com/moonrepo/moon/releases/tag/%40moonrepo%2Fcli%400.19.0) for a
+full list of changes.
+
+- Package managers in the toolchain are now installed in isolation, instead of through Node.js.
+- JSON files will now respect the closest `.editorconfig` file.
+- Webhook payloads now include information about the running CI/CD environment.
+
+## What's next?
+
+Expect the following in the v0.20 release!
+
+- Continuation of remote caching work!
+- Performance improvements for output hydration.
+- Optimizations to our project and dependency graphs.

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -412,6 +412,23 @@ tasks:
       runFromWorkspaceRoot: true
 ```
 
+#### `affectedFiles`<VersionLabel version="0.19" />
+
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#affectedFiles" />
+
+When enabled and the [`--affected` option](../run-task#running-based-on-affected-files-only) is
+provided, all affected files that match this task's [`inputs`](#inputs) will be passed as relative
+paths via command line arguments. If there are no affected files, an argument if `.` (current
+directory) will be passed instead.
+
+```yaml title="moon.yml" {6}
+tasks:
+  lint:
+    command: 'eslint'
+    options:
+      affectedFiles: true
+```
+
 #### `cache`<VersionLabel version="0.9" />
 
 <HeadingApiLink to="/api/types/interface/TaskOptionsConfig#cache" />

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -429,6 +429,14 @@ tasks:
       affectedFiles: true
 ```
 
+:::caution
+
+When using this option, ensure that explicit files or `.` _are not present_ in the [`args`](#args)
+list. Furthermore, this functionality will only work if the task's command supports an arbitrary
+list of files being passed as arguments.
+
+:::
+
 #### `cache`<VersionLabel version="0.9" />
 
 <HeadingApiLink to="/api/types/interface/TaskOptionsConfig#cache" />

--- a/website/docs/guides/git-hooks.mdx
+++ b/website/docs/guides/git-hooks.mdx
@@ -1,0 +1,3 @@
+---
+title: Git hooks
+---

--- a/website/docs/guides/git-hooks.mdx
+++ b/website/docs/guides/git-hooks.mdx
@@ -2,4 +2,24 @@
 title: Git hooks
 ---
 
-asdasdasdasds
+[Git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) are a mechanism for running
+scripts at pre-defined phases in git's lifecycle, most commonly pre-commit, pre-push, or pre-merge.
+
+While moon provides no functionality for managing hooks (_yet_), you can run moon itself from hooks!
+This is useful for ensuring that commit messages are formatted correctly, or that source code
+quality thresholds are met.
+
+## Pre-commit
+
+A perfect use case for the `pre-commit` hook is to check linting and formatting of the files being
+committed. If either of these tasks fail, the commit will abort until they are fixed. Be sure to use
+the [`--affected`](../run-task#running-based-on-affected-files-only) option so that we _only run_ on
+changed projects!
+
+```bash title=".git/hooks/pre-commit"
+#!/bin/sh
+./node_modules/@moonrepo/cli/moon run :lint :format --affected
+```
+
+> By default this will run on the _entire_ project (all files). If you want to filter it to only the
+> changed files, enable the [`affectedFiles`](../config/project#affectedfiles) task option.

--- a/website/docs/guides/git-hooks.mdx
+++ b/website/docs/guides/git-hooks.mdx
@@ -1,3 +1,5 @@
 ---
 title: Git hooks
 ---
+
+asdasdasdasds

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -139,6 +139,7 @@ const sidebars = {
 		'guides/ci',
 		'guides/codegen',
 		'guides/docker',
+		'guides/git-hooks',
 		'guides/open-source',
 		'guides/profile',
 		'guides/root-project',


### PR DESCRIPTION
When enabled and `--affected` is passed to `moon run`, a list of affected files for the current task will be passed as CLI arguments.

This is perfect for linting and formatting only a subset of touched files.