### PR TITLE
new: Use task platform instead of project language for installing deps.

### DIFF
--- a/crates/cli/tests/query_test.rs
+++ b/crates/cli/tests/query_test.rs
@@ -61,6 +61,7 @@ mod projects {
                 "foo",
                 "js",
                 "noConfig",
+                "platforms",
                 "tasks",
                 "ts"
             ]

--- a/crates/cli/tests/snapshots/project_graph_test__many_projects.snap
+++ b/crates/cli/tests/snapshots/project_graph_test__many_projects.snap
@@ -14,8 +14,9 @@ digraph {
     7 [ label="emptyConfig" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     8 [ label="foo" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     9 [ label="js" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
-    10 [ label="tasks" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
-    11 [ label="ts" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    10 [ label="platforms" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    11 [ label="tasks" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    12 [ label="ts" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
     0 -> 1 [ arrowhead=none]
     0 -> 2 [ arrowhead=none]
     0 -> 3 [ arrowhead=none]
@@ -30,6 +31,7 @@ digraph {
     0 -> 9 [ arrowhead=none]
     0 -> 10 [ arrowhead=none]
     0 -> 11 [ arrowhead=none]
+    0 -> 12 [ arrowhead=none]
 }
 
 

--- a/crates/cli/tests/snapshots/run_test__general__logs_command_for_project_root.snap
+++ b/crates/cli/tests/snapshots/run_test__general__logs_command_for_project_root.snap
@@ -3,11 +3,9 @@ source: crates/cli/tests/run_test.rs
 assertion_line: 85
 expression: get_assert_output(&assert)
 ---
-▪▪▪▪ npm install
-~/.moon/tools/node/16.0.0/bin/node ~/.moon/tools/npm/8.19.2/bin/npm-cli.js install --no-audit --no-fund (in workspace)
 ▪▪▪▪ base:runFromProject
-node --version (in ./base)
-v16.0.0
+echo 'from project' (in ./base)
+from project
 
 Tasks: 1 completed
  Time: 100ms

--- a/crates/cli/tests/snapshots/run_test__general__logs_command_for_project_root.snap
+++ b/crates/cli/tests/snapshots/run_test__general__logs_command_for_project_root.snap
@@ -3,6 +3,8 @@ source: crates/cli/tests/run_test.rs
 assertion_line: 85
 expression: get_assert_output(&assert)
 ---
+▪▪▪▪ npm install
+~/.moon/tools/node/16.0.0/bin/node ~/.moon/tools/npm/8.19.2/bin/npm-cli.js install --no-audit --no-fund (in workspace)
 ▪▪▪▪ base:runFromProject
 node --version (in ./base)
 v16.0.0

--- a/crates/cli/tests/snapshots/run_test__general__logs_command_for_workspace_root.snap
+++ b/crates/cli/tests/snapshots/run_test__general__logs_command_for_workspace_root.snap
@@ -3,11 +3,9 @@ source: crates/cli/tests/run_test.rs
 assertion_line: 99
 expression: get_assert_output(&assert)
 ---
-▪▪▪▪ npm install
-~/.moon/tools/node/16.0.0/bin/node ~/.moon/tools/npm/8.19.2/bin/npm-cli.js install --no-audit --no-fund (in workspace)
 ▪▪▪▪ base:runFromWorkspace
-node --version (in workspace)
-v16.0.0
+echo 'from workspace' (in workspace)
+from workspace
 
 Tasks: 1 completed
  Time: 100ms

--- a/crates/cli/tests/snapshots/run_test__general__logs_command_for_workspace_root.snap
+++ b/crates/cli/tests/snapshots/run_test__general__logs_command_for_workspace_root.snap
@@ -3,6 +3,8 @@ source: crates/cli/tests/run_test.rs
 assertion_line: 99
 expression: get_assert_output(&assert)
 ---
+▪▪▪▪ npm install
+~/.moon/tools/node/16.0.0/bin/node ~/.moon/tools/npm/8.19.2/bin/npm-cli.js install --no-audit --no-fund (in workspace)
 ▪▪▪▪ base:runFromWorkspace
 node --version (in workspace)
 v16.0.0

--- a/crates/core/config/src/project/local_config.rs
+++ b/crates/core/config/src/project/local_config.rs
@@ -8,6 +8,7 @@ use crate::project::task::TaskConfig;
 use crate::project::workspace::ProjectWorkspaceConfig;
 use crate::types::{FileGroups, ProjectID};
 use crate::validators::validate_id;
+use crate::PlatformType;
 use figment::{
     providers::{Format, Serialized, YamlExtended},
     Figment,
@@ -79,14 +80,12 @@ pub enum ProjectLanguage {
 }
 
 impl ProjectLanguage {
-    pub fn is_node_platform(&self) -> bool {
-        matches!(self, ProjectLanguage::JavaScript) || matches!(self, ProjectLanguage::TypeScript)
-    }
-
-    pub fn is_system_platform(&self) -> bool {
-        matches!(self, ProjectLanguage::Bash)
-            || matches!(self, ProjectLanguage::Batch)
-            || matches!(self, ProjectLanguage::Unknown)
+    pub fn to_platform(&self) -> PlatformType {
+        match self {
+            ProjectLanguage::JavaScript | ProjectLanguage::TypeScript => PlatformType::Node,
+            ProjectLanguage::Unknown => PlatformType::Unknown,
+            _ => PlatformType::System,
+        }
     }
 }
 

--- a/crates/core/config/src/project/task.rs
+++ b/crates/core/config/src/project/task.rs
@@ -47,7 +47,9 @@ fn validate_outputs(list: &[String]) -> Result<(), ValidationError> {
     Ok(())
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Display, Eq, JsonSchema, PartialEq, Serialize)]
+#[derive(
+    Clone, Debug, Default, Deserialize, Display, Eq, Hash, JsonSchema, PartialEq, Serialize,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum PlatformType {
     #[strum(serialize = "node")]

--- a/crates/core/project-graph/src/graph.rs
+++ b/crates/core/project-graph/src/graph.rs
@@ -127,8 +127,7 @@ impl Platformable for ProjectGraph {
             &mut self.aliases_map,
         )?;
 
-        self.platforms
-            .register(&platform.get_default_runtime(), platform);
+        self.platforms.register(platform.get_type(), platform);
 
         Ok(())
     }
@@ -350,7 +349,7 @@ impl ProjectGraph {
         project.alias = self.find_alias_for_id(id);
 
         for platform in self.platforms.list() {
-            if !platform.matches(&project.config, None) {
+            if !platform.matches(&project.config.language.to_platform(), None) {
                 continue;
             }
 

--- a/crates/core/project-graph/tests/project_graph_test.rs
+++ b/crates/core/project-graph/tests/project_graph_test.rs
@@ -174,6 +174,7 @@ mod globs {
                 ("foo".to_owned(), "deps/foo".to_owned()),
                 ("js".to_owned(), "langs/js".to_owned()),
                 ("langs".to_owned(), "langs".to_owned()),
+                ("platforms".to_owned(), "platforms".to_owned()),
                 ("no-config".to_owned(), "no-config".to_owned()),
                 ("package-json".to_owned(), "package-json".to_owned()),
                 ("tasks".to_owned(), "tasks".to_owned()),

--- a/crates/core/runner/src/dep_graph.rs
+++ b/crates/core/runner/src/dep_graph.rs
@@ -65,7 +65,7 @@ impl DepGraph {
         project_graph: &ProjectGraph,
     ) -> Runtime {
         for platform in project_graph.platforms.list() {
-            if platform.matches(&project.config, None) {
+            if platform.matches(&project.config.language.to_platform(), None) {
                 if let Some(runtime) = platform
                     .get_runtime_from_config(Some(&project.config), &project_graph.workspace_config)
                 {
@@ -107,7 +107,10 @@ impl DepGraph {
     ) -> Result<NodeIndex, DepGraphError> {
         let mut node = ActionNode::InstallDeps(runtime.clone());
 
-        if let Some(platform) = project_graph.platforms.get(runtime) {
+        if let Some(platform) = project_graph
+            .platforms
+            .get(&project.config.language.to_platform())
+        {
             // If project is not in the package manager workspace,
             // update the node to install deps into the project directly!
             if !platform.is_project_in_package_manager_workspace(
@@ -355,7 +358,7 @@ impl DepGraph {
             .add_edge(sync_project_index, setup_toolchain_index, ());
 
         // But we need to wait on all dependent nodes
-        for dep_id in project_graph.get_dependencies_of(&project)? {
+        for dep_id in project_graph.get_dependencies_of(project)? {
             let dep_project = project_graph.load(&dep_id)?;
             let dep_runtime = self.get_runtime_from_project(&dep_project, project_graph);
 

--- a/crates/core/runner/src/dep_graph_new.rs
+++ b/crates/core/runner/src/dep_graph_new.rs
@@ -112,7 +112,7 @@ impl DepGraph {
 
         // If project is NOT in the package manager workspace, then we should
         // install dependencies in the project, not the workspace root.
-        if let Some(platform) = project_graph.platforms.get(&task.platform) {
+        if let Some(platform) = project_graph.platforms.get(&project.language.to_platform()) {
             if !platform.is_project_in_package_manager_workspace(
                 &project.id,
                 &project.root,

--- a/crates/core/runner/tests/dep_graph_test.rs
+++ b/crates/core/runner/tests/dep_graph_test.rs
@@ -32,6 +32,7 @@ async fn create_project_graph() -> (ProjectGraph, TempDir) {
             ("bar".to_owned(), "deps/bar".to_owned()),
             ("baz".to_owned(), "deps/baz".to_owned()),
             ("tasks".to_owned(), "tasks".to_owned()),
+            ("platforms".to_owned(), "platforms".to_owned()),
         ])),
         node: Some(NodeConfig {
             // Consistent snapshots
@@ -550,6 +551,30 @@ mod sync_project {
         let mut graph = DepGraph::default();
 
         sync_projects(&mut graph, &projects, &["unknown"]);
+
+        assert_snapshot!(graph.to_dot());
+    }
+}
+
+mod installs_deps {
+    use super::*;
+
+    #[tokio::test]
+    async fn tool_is_based_on_task_platform() {
+        let (projects, _fixture) = create_project_graph().await;
+        let mut graph = DepGraph::default();
+
+        graph
+            .run_target(
+                &Target::new("platforms", "system").unwrap(),
+                &projects,
+                &None,
+            )
+            .unwrap();
+
+        graph
+            .run_target(&Target::new("platforms", "node").unwrap(), &projects, &None)
+            .unwrap();
 
         assert_snapshot!(graph.to_dot());
     }

--- a/crates/core/runner/tests/snapshots/dep_graph_test__installs_deps__tool_is_based_on_task_platform.snap
+++ b/crates/core/runner/tests/snapshots/dep_graph_test__installs_deps__tool_is_based_on_task_platform.snap
@@ -1,0 +1,22 @@
+---
+source: crates/core/runner/tests/dep_graph_test.rs
+assertion_line: 579
+expression: graph.to_dot()
+---
+digraph {
+    0 [ label="SetupSystemTool" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    1 [ label="InstallSystemDeps" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    2 [ label="SyncSystemProject(platforms)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    3 [ label="RunTarget(platforms:system)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    4 [ label="SetupNodeTool(16.0.0)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    5 [ label="InstallNodeDeps(16.0.0)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    6 [ label="RunTarget(platforms:node)" style=filled, shape=oval, fillcolor=gray, fontcolor=black]
+    1 -> 0 [ arrowhead=box, arrowtail=box]
+    2 -> 0 [ arrowhead=box, arrowtail=box]
+    3 -> 1 [ arrowhead=box, arrowtail=box]
+    3 -> 2 [ arrowhead=box, arrowtail=box]
+    5 -> 4 [ arrowhead=box, arrowtail=box]
+    6 -> 5 [ arrowhead=box, arrowtail=box]
+    6 -> 2 [ arrowhead=box, arrowtail=box]
+}
+

--- a/crates/node/platform/src/lib.rs
+++ b/crates/node/platform/src/lib.rs
@@ -4,8 +4,8 @@ pub mod task;
 
 pub use hasher::NodeTargetHasher;
 use moon_config::{
-    DependencyConfig, DependencyScope, NodeProjectAliasFormat, ProjectConfig, ProjectID,
-    ProjectsAliasesMap, ProjectsSourcesMap, TasksConfigsMap, WorkspaceConfig,
+    DependencyConfig, DependencyScope, NodeProjectAliasFormat, PlatformType, ProjectConfig,
+    ProjectID, ProjectsAliasesMap, ProjectsSourcesMap, TasksConfigsMap, WorkspaceConfig,
 };
 use moon_error::MoonError;
 use moon_logger::{color, debug, warn};
@@ -50,8 +50,8 @@ pub struct NodePlatform {
 }
 
 impl Platform for NodePlatform {
-    fn get_default_runtime(&self) -> Runtime {
-        Runtime::Node(Version("latest".into(), false))
+    fn get_type(&self) -> PlatformType {
+        PlatformType::Node
     }
 
     fn get_runtime_from_config(
@@ -261,8 +261,8 @@ impl Platform for NodePlatform {
         Ok(tasks)
     }
 
-    fn matches(&self, project_config: &ProjectConfig, runtime: Option<&Runtime>) -> bool {
-        if project_config.language.is_node_platform() {
+    fn matches(&self, platform: &PlatformType, runtime: Option<&Runtime>) -> bool {
+        if matches!(platform, PlatformType::Node) {
             return true;
         }
 

--- a/crates/system/platform/src/lib.rs
+++ b/crates/system/platform/src/lib.rs
@@ -2,15 +2,15 @@ pub mod actions;
 mod hasher;
 
 pub use hasher::SystemTargetHasher;
-use moon_config::{ProjectConfig, WorkspaceConfig};
+use moon_config::{PlatformType, ProjectConfig, WorkspaceConfig};
 use moon_platform::{Platform, Runtime};
 
 #[derive(Debug, Default)]
 pub struct SystemPlatform;
 
 impl Platform for SystemPlatform {
-    fn get_default_runtime(&self) -> Runtime {
-        Runtime::System
+    fn get_type(&self) -> PlatformType {
+        PlatformType::System
     }
 
     fn get_runtime_from_config(
@@ -21,8 +21,8 @@ impl Platform for SystemPlatform {
         Some(Runtime::System)
     }
 
-    fn matches(&self, project_config: &ProjectConfig, runtime: Option<&Runtime>) -> bool {
-        if project_config.language.is_system_platform() {
+    fn matches(&self, platform: &PlatformType, runtime: Option<&Runtime>) -> bool {
+        if matches!(platform, PlatformType::System) {
             return true;
         }
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,10 @@
   approach worked but was susceptible to collisions, so now, these package managers are installed
   individually as their own tools at `~/.moon/tools/npm`, etc. This change should be transparent to
   you, but we're documenting it just in case something breaks!
+- We've updated the dependency graph so that `InstallDeps` based actions use the task's `platform`
+  instead of the project's `language` as the tool to install. This allows for granular control at
+  the task level, and also unlocks the ability for project's to utilize multiple languages in the
+  future.
 
 #### 🚀 Updates
 

--- a/tests/fixtures/cases/base/moon.yml
+++ b/tests/fixtures/cases/base/moon.yml
@@ -2,11 +2,11 @@ tasks:
   base:
     command: noop
   runFromProject:
-    command: node --version
-    platform: node
+    command: echo 'from project'
+    platform: system
   runFromWorkspace:
-    command: node --version
-    platform: node
+    command: echo 'from workspace'
+    platform: system
     options:
       runFromWorkspaceRoot: true
   localOnly:

--- a/tests/fixtures/projects/.moon/workspace.yml
+++ b/tests/fixtures/projects/.moon/workspace.yml
@@ -18,3 +18,4 @@ projects:
   js: langs/js
   ts: langs/ts
   bash: langs/bash
+  platforms: platforms

--- a/tests/fixtures/projects/platforms/moon.yml
+++ b/tests/fixtures/projects/platforms/moon.yml
@@ -1,0 +1,9 @@
+language: unknown
+
+tasks:
+  system:
+    command: noop
+    platform: system
+  node:
+    command: node --version
+    platform: node


### PR DESCRIPTION
This moves the "install deps for tool" action to each task, instead of the project.