### PR TITLE
fix: Fix project override config defaults.

### DIFF
--- a/crates/core/config/src/workspace/node.rs
+++ b/crates/core/config/src/workspace/node.rs
@@ -202,3 +202,16 @@ impl Default for NodeConfig {
         }
     }
 }
+
+impl NodeConfig {
+    pub fn with_project_override(&self, version: &str) -> Self {
+        let mut config = self.clone();
+        config.version = version.to_owned();
+
+        // These settings should not be ran in a project, only the root
+        config.add_engines_constraint = false;
+        config.sync_version_manager_config = None;
+
+        config
+    }
+}

--- a/crates/core/runner/src/actions/setup_toolchain.rs
+++ b/crates/core/runner/src/actions/setup_toolchain.rs
@@ -1,5 +1,4 @@
 use moon_action::{Action, ActionContext, ActionStatus};
-use moon_config::NodeConfig;
 use moon_logger::debug;
 use moon_platform::Runtime;
 use moon_toolchain::tools::node::NodeTool;
@@ -45,15 +44,12 @@ pub async fn setup_toolchain(
 
             // The workspace version is pre-registered when the toolchain
             // is created, so any missing version must be an override at
-            // the project-level. If so, use config defaults.
+            // the project-level. If so clone, and update defaults.
             if !node.has(&version.0) {
                 node.register(
                     NodeTool::new(
                         &toolchain_paths,
-                        &NodeConfig {
-                            version: version.0.to_owned(),
-                            ..NodeConfig::default()
-                        },
+                        &node.get()?.config.with_project_override(&version.0),
                     )?,
                     false,
                 );

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -29,7 +29,8 @@
 - Fixed an issue where passthrough args were incorrectly being passed to non-primary targets when
   using `moon run`.
 - Fixed an issue where a root-level project was not being marked as affected based on touched files.
-- Fixed an issue where tool version overrides at the project-level were not properly being set.
+- Fixed an issue where tool version overrides at the project-level were not properly being set, and
+  configuration that is root-only was being referenced in projects.
 - Fixed some CLI arguments that should be ran mutually exclusive with other arguments.
 - Task hashes will now properly invalidate if their dependencies hashes have also changed.
 


### PR DESCRIPTION
When a project overrides the workspace tool version, we were inheriting the config defaults. We actually need to inherit the config the consumer has defined, with some minor modifications for the overriding.