### PR TITLE
pre-commit githook with moon example

### DIFF
--- a/website/docs/guides/git-hooks.mdx
+++ b/website/docs/guides/git-hooks.mdx
@@ -18,7 +18,7 @@ changed projects!
 
 ```bash title=".git/hooks/pre-commit"
 #!/bin/sh
-./node_modules/@moonrepo/cli/moon run :lint :format --affected
+./node_modules/@moonrepo/cli/moon run :lint :format --affected --status=staged
 ```
 
 > By default this will run on the _entire_ project (all files). If you want to filter it to only the


### PR DESCRIPTION
Adds the status filter to the moon invocation example. 

I think pre-commit will want to look only at  staged files. Without the status filter untracked files are even included. 

Also, this proposed change shows off a bit more moon power.