### PR TITLE
new: Support file system diffing when hydrating outputs.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,7 +44,7 @@ jobs:
           command: bench
           # args: --workspace --bench ${{ matrix.bench }} -- --save-baseline base-sha
           args: |
-            --workspace --bench dep_graph_benchmark --bench emitter_benchmark --bench project_graph_benchmark --bench runner_benchmark -- --save-baseline head-sha
+            --workspace --bench dep_graph_benchmark --bench emitter_benchmark --bench project_graph_benchmark --bench runner_benchmark --bench tar_benchmark -- --save-baseline head-sha
 
       # Run on base branch to get a baseline
       - name: Checkout base branch
@@ -58,7 +58,7 @@ jobs:
           command: bench
           # args: --workspace --bench ${{ matrix.bench }} -- --save-baseline base-sha
           args: |
-            --workspace --bench dep_graph_benchmark --bench emitter_benchmark --bench project_graph_benchmark --bench runner_benchmark -- --save-baseline base-sha
+            --workspace --bench dep_graph_benchmark --bench emitter_benchmark --bench project_graph_benchmark --bench runner_benchmark --bench tar_benchmark -- --save-baseline base-sha
 
       # Compare diffs
       - name: Install critcmp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,6 +1815,7 @@ dependencies = [
  "rustc-hash",
  "tar",
  "thiserror",
+ "tokio",
  "zip",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,7 +2257,6 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",
- "async-recursion",
  "cached",
  "chrono",
  "chrono-humanize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,6 +2257,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",
+ "async-recursion",
  "cached",
  "chrono",
  "chrono-humanize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "fake"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d68f517805463f3a896a9d29c1d6ff09d3579ded64a7201b4069f8f9c0d52fd"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,10 +1817,14 @@ dependencies = [
 name = "moon_archive"
 version = "0.1.0"
 dependencies = [
+ "assert_fs",
+ "criterion",
+ "fake",
  "flate2",
  "moon_error",
  "moon_logger",
  "moon_utils",
+ "rand 0.8.5",
  "rustc-hash",
  "tar",
  "thiserror",

--- a/crates/cli/src/commands/docker/scaffold.rs
+++ b/crates/cli/src/commands/docker/scaffold.rs
@@ -33,7 +33,7 @@ async fn copy_files<T: AsRef<str>>(
 
         if source_file.exists() {
             if source_file.is_dir() {
-                fs::copy_dir_all(&source_file, &source_file, &target.join(file))?;
+                fs::copy_dir_all(&source_file, &source_file, &target.join(file)).await?;
             } else {
                 futures.push(fs::copy_file(source_file, target.join(file)));
             }

--- a/crates/cli/src/commands/docker/scaffold.rs
+++ b/crates/cli/src/commands/docker/scaffold.rs
@@ -33,7 +33,7 @@ async fn copy_files<T: AsRef<str>>(
 
         if source_file.exists() {
             if source_file.is_dir() {
-                fs::copy_dir_all(&source_file, &source_file, &target.join(file)).await?;
+                fs::copy_dir_all(&source_file, &source_file, &target.join(file))?;
             } else {
                 futures.push(fs::copy_file(source_file, target.join(file)));
             }

--- a/crates/cli/tests/snapshots/generate_test__doesnt_generate_files_when_dryrun.snap
+++ b/crates/cli/tests/snapshots/generate_test__doesnt_generate_files_when_dryrun.snap
@@ -9,6 +9,7 @@ Some description of the template and its files.
 
 
 created --> ./test/file.ts
+created --> ./test/file.txt
 created --> ./test/folder/nested-file.ts
 
 

--- a/crates/cli/tests/snapshots/generate_test__generates_files_from_template.snap
+++ b/crates/cli/tests/snapshots/generate_test__generates_files_from_template.snap
@@ -9,6 +9,7 @@ Some description of the template and its files.
 
 
 created --> ./test/file.ts
+created --> ./test/file.txt
 created --> ./test/folder/nested-file.ts
 
 

--- a/crates/cli/tests/snapshots/generate_test__overwrites_existing_files_when_forced.snap
+++ b/crates/cli/tests/snapshots/generate_test__overwrites_existing_files_when_forced.snap
@@ -9,6 +9,7 @@ Some description of the template and its files.
 
 
 replaced -> ./test/file.ts
+replaced -> ./test/file.txt
 replaced -> ./test/folder/nested-file.ts
 
 

--- a/crates/core/archive/Cargo.toml
+++ b/crates/core/archive/Cargo.toml
@@ -3,6 +3,13 @@ name = "moon_archive"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+bench = false
+
+[[bench]]
+name = "tar_benchmark"
+harness = false
+
 [dependencies]
 moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }
@@ -13,3 +20,9 @@ tar = "0.4.38"
 thiserror = { workspace = true }
 tokio = { workspace = true }
 zip = "0.6.3"
+
+[dev-dependencies]
+assert_fs = "1.0.9"
+criterion = { workspace = true }
+fake = "2.5.0"
+rand = "0.8.5"

--- a/crates/core/archive/Cargo.toml
+++ b/crates/core/archive/Cargo.toml
@@ -11,4 +11,5 @@ flate2 = "1.0.24"
 rustc-hash = { workspace = true }
 tar = "0.4.38"
 thiserror = { workspace = true }
+tokio = { workspace = true }
 zip = "0.6.3"

--- a/crates/core/archive/benches/tar_benchmark.rs
+++ b/crates/core/archive/benches/tar_benchmark.rs
@@ -1,18 +1,17 @@
 use assert_fs::TempDir;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use fake::{Dummy, Fake, Faker};
+use criterion::{criterion_group, criterion_main, Criterion};
+use fake::{Fake, Faker};
 use moon_archive::{tar, untar, untar_with_diff, TreeDiffer};
-use moon_error::MoonError;
 use moon_utils::string_vec;
 use std::fs;
-use std::sync::Arc;
-use tokio::sync::RwLock;
 
 fn create_tree() -> TempDir {
     let temp_dir = TempDir::new().unwrap();
     let mut dir = 'a';
 
     for i in 1..1000 {
+        fs::create_dir_all(temp_dir.path().join("sources").join(String::from(dir))).unwrap();
+
         fs::write(
             temp_dir
                 .path()
@@ -56,28 +55,106 @@ pub fn tar_benchmark(c: &mut Criterion) {
             untar(&archive_file, &sources, None).unwrap();
         })
     });
-
-    c.bench_function("tar_diff", |b| {
-        b.iter(|| {
-            let mut diff = TreeDiffer::load(&sources, &dirs).unwrap();
-
-            untar_with_diff(&mut diff, &archive_file, &sources, None).unwrap();
-        })
-    });
-
-    // let runtime = tokio::runtime::Runtime::new().unwrap();
 }
 
-// pub fn tar_benchmark(c: &mut Criterion) {
-//     let temp_dir = create_tree();
-//     let runtime = tokio::runtime::Runtime::new().unwrap();
+pub fn tar_remove_benchmark(c: &mut Criterion) {
+    let temp_dir = create_tree();
+    let dirs = string_vec!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'];
+    let sources = temp_dir.path().join("sources");
+    let archive_file = temp_dir.path().join("archive.tar.gz");
 
-//     c.bench_function("emitter_emit", |b| {
-//         b.to_async(&runtime).iter(|| async {
-//             black_box(emitter);
-//         })
-//     });
-// }
+    tar(&sources, &dirs, &archive_file, None).unwrap();
 
-criterion_group!(tar_archive, tar_benchmark);
+    c.bench_function("tar_remove", |b| {
+        b.iter(|| {
+            fs::remove_dir_all(&sources).unwrap();
+
+            untar(&archive_file, &sources, None).unwrap();
+        })
+    });
+}
+
+pub fn tar_diff_benchmark(c: &mut Criterion) {
+    let temp_dir = create_tree();
+    let dirs = string_vec!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'];
+    let sources = temp_dir.path().join("sources");
+    let archive_file = temp_dir.path().join("archive.tar.gz");
+
+    tar(&sources, &dirs, &archive_file, None).unwrap();
+
+    c.bench_function("tar_diff", |b| {
+        b.to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter(|| async {
+                let mut diff = TreeDiffer::load(&sources, &dirs).unwrap();
+
+                untar_with_diff(&mut diff, &archive_file, &sources, None)
+                    .await
+                    .unwrap();
+            })
+    });
+
+    c.bench_function("tar_diff_async", |b| {
+        b.to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter(|| async {
+                let mut diff = TreeDiffer::load_async(&sources, &dirs).await.unwrap();
+
+                untar_with_diff(&mut diff, &archive_file, &sources, None)
+                    .await
+                    .unwrap();
+            })
+    });
+}
+
+pub fn tar_diff_remove_benchmark(c: &mut Criterion) {
+    let temp_dir = create_tree();
+    let dirs = string_vec!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'];
+    let sources = temp_dir.path().join("sources");
+    let archive_file = temp_dir.path().join("archive.tar.gz");
+
+    tar(&sources, &dirs, &archive_file, None).unwrap();
+
+    c.bench_function("tar_diff_remove", |b| {
+        b.to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter(|| async {
+                fs::remove_dir_all(&sources).unwrap();
+
+                let mut diff = TreeDiffer::load(&sources, &dirs).unwrap();
+
+                untar_with_diff(&mut diff, &archive_file, &sources, None)
+                    .await
+                    .unwrap();
+            })
+    });
+}
+
+pub fn tar_diff_async_remove_benchmark(c: &mut Criterion) {
+    let temp_dir = create_tree();
+    let dirs = string_vec!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'];
+    let sources = temp_dir.path().join("sources");
+    let archive_file = temp_dir.path().join("archive.tar.gz");
+
+    tar(&sources, &dirs, &archive_file, None).unwrap();
+
+    c.bench_function("tar_diff_async_remove", |b| {
+        b.to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter(|| async {
+                fs::remove_dir_all(&sources).unwrap();
+
+                let mut diff = TreeDiffer::load_async(&sources, &dirs).await.unwrap();
+
+                untar_with_diff(&mut diff, &archive_file, &sources, None)
+                    .await
+                    .unwrap();
+            })
+    });
+}
+
+criterion_group!(
+    tar_archive,
+    tar_benchmark,
+    tar_remove_benchmark,
+    tar_diff_benchmark,
+    tar_diff_remove_benchmark,
+    tar_diff_async_remove_benchmark,
+);
 criterion_main!(tar_archive);

--- a/crates/core/archive/benches/tar_benchmark.rs
+++ b/crates/core/archive/benches/tar_benchmark.rs
@@ -92,17 +92,6 @@ pub fn tar_diff_benchmark(c: &mut Criterion) {
                     .unwrap();
             })
     });
-
-    c.bench_function("tar_diff_async", |b| {
-        b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter(|| async {
-                let mut diff = TreeDiffer::load_async(&sources, &dirs).await.unwrap();
-
-                untar_with_diff(&mut diff, &archive_file, &sources, None)
-                    .await
-                    .unwrap();
-            })
-    });
 }
 
 pub fn tar_diff_remove_benchmark(c: &mut Criterion) {
@@ -127,34 +116,11 @@ pub fn tar_diff_remove_benchmark(c: &mut Criterion) {
     });
 }
 
-pub fn tar_diff_async_remove_benchmark(c: &mut Criterion) {
-    let temp_dir = create_tree();
-    let dirs = string_vec!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'];
-    let sources = temp_dir.path().join("sources");
-    let archive_file = temp_dir.path().join("archive.tar.gz");
-
-    tar(&sources, &dirs, &archive_file, None).unwrap();
-
-    c.bench_function("tar_diff_async_remove", |b| {
-        b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter(|| async {
-                fs::remove_dir_all(&sources).unwrap();
-
-                let mut diff = TreeDiffer::load_async(&sources, &dirs).await.unwrap();
-
-                untar_with_diff(&mut diff, &archive_file, &sources, None)
-                    .await
-                    .unwrap();
-            })
-    });
-}
-
 criterion_group!(
     tar_archive,
     tar_benchmark,
     tar_remove_benchmark,
     tar_diff_benchmark,
     tar_diff_remove_benchmark,
-    tar_diff_async_remove_benchmark,
 );
 criterion_main!(tar_archive);

--- a/crates/core/archive/benches/tar_benchmark.rs
+++ b/crates/core/archive/benches/tar_benchmark.rs
@@ -1,0 +1,83 @@
+use assert_fs::TempDir;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use fake::{Dummy, Fake, Faker};
+use moon_archive::{tar, untar, untar_with_diff, TreeDiffer};
+use moon_error::MoonError;
+use moon_utils::string_vec;
+use std::fs;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+fn create_tree() -> TempDir {
+    let temp_dir = TempDir::new().unwrap();
+    let mut dir = 'a';
+
+    for i in 1..1000 {
+        fs::write(
+            temp_dir
+                .path()
+                .join("sources")
+                .join(String::from(dir))
+                .join(format!("{}.txt", i)),
+            Faker.fake::<String>(),
+        )
+        .unwrap();
+
+        if i % 100 == 0 {
+            dir = match i {
+                100 => 'b',
+                200 => 'c',
+                300 => 'd',
+                400 => 'e',
+                500 => 'f',
+                600 => 'g',
+                700 => 'h',
+                800 => 'i',
+                900 => 'j',
+                1000 => 'k',
+                _ => 'a',
+            };
+        }
+    }
+
+    temp_dir
+}
+
+pub fn tar_benchmark(c: &mut Criterion) {
+    let temp_dir = create_tree();
+    let dirs = string_vec!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'];
+    let sources = temp_dir.path().join("sources");
+    let archive_file = temp_dir.path().join("archive.tar.gz");
+
+    tar(&sources, &dirs, &archive_file, None).unwrap();
+
+    c.bench_function("tar", |b| {
+        b.iter(|| {
+            untar(&archive_file, &sources, None).unwrap();
+        })
+    });
+
+    c.bench_function("tar_diff", |b| {
+        b.iter(|| {
+            let mut diff = TreeDiffer::load(&sources, &dirs).unwrap();
+
+            untar_with_diff(&mut diff, &archive_file, &sources, None).unwrap();
+        })
+    });
+
+    // let runtime = tokio::runtime::Runtime::new().unwrap();
+}
+
+// pub fn tar_benchmark(c: &mut Criterion) {
+//     let temp_dir = create_tree();
+//     let runtime = tokio::runtime::Runtime::new().unwrap();
+
+//     c.bench_function("emitter_emit", |b| {
+//         b.to_async(&runtime).iter(|| async {
+//             black_box(emitter);
+//         })
+//     });
+// }
+
+criterion_group!(tar_archive, tar_benchmark);
+criterion_main!(tar_archive);

--- a/crates/core/archive/benches/tar_benchmark.rs
+++ b/crates/core/archive/benches/tar_benchmark.rs
@@ -1,93 +1,75 @@
+// Allow `temp_dir` so that files arent removed when dropping scope
+#![allow(unused_variables)]
+
 use assert_fs::TempDir;
 use criterion::{criterion_group, criterion_main, Criterion};
 use fake::{Fake, Faker};
 use moon_archive::{tar, untar, untar_with_diff, TreeDiffer};
 use moon_utils::string_vec;
 use std::fs;
+use std::path::PathBuf;
 
-fn create_tree() -> TempDir {
+fn create_tree() -> (TempDir, PathBuf, PathBuf, Vec<String>) {
     let temp_dir = TempDir::new().unwrap();
-    let mut dir = 'a';
+    let sources_dir = temp_dir.path().join("sources");
+    let archive_file = temp_dir.path().join("archive.tar.gz");
+    let dirs = string_vec!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'];
+    let mut dir_index = 0;
 
     for i in 1..1000 {
-        fs::create_dir_all(temp_dir.path().join("sources").join(String::from(dir))).unwrap();
+        let parent = sources_dir.join(&dirs[dir_index]);
 
-        fs::write(
-            temp_dir
-                .path()
-                .join("sources")
-                .join(String::from(dir))
-                .join(format!("{}.txt", i)),
-            Faker.fake::<String>(),
-        )
-        .unwrap();
+        if !parent.exists() {
+            fs::create_dir_all(&parent).unwrap();
+        }
+
+        fs::write(parent.join(format!("{}.txt", i)), Faker.fake::<String>()).unwrap();
 
         if i % 100 == 0 {
-            dir = match i {
-                100 => 'b',
-                200 => 'c',
-                300 => 'd',
-                400 => 'e',
-                500 => 'f',
-                600 => 'g',
-                700 => 'h',
-                800 => 'i',
-                900 => 'j',
-                1000 => 'k',
-                _ => 'a',
-            };
+            dir_index += 1;
         }
     }
 
-    temp_dir
+    (temp_dir, sources_dir, archive_file, dirs)
 }
 
-pub fn tar_benchmark(c: &mut Criterion) {
-    let temp_dir = create_tree();
-    let dirs = string_vec!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'];
-    let sources = temp_dir.path().join("sources");
-    let archive_file = temp_dir.path().join("archive.tar.gz");
+pub fn tar_base_benchmark(c: &mut Criterion) {
+    let (temp_dir, sources_dir, archive_file, dirs) = create_tree();
 
-    tar(&sources, &dirs, &archive_file, None).unwrap();
+    tar(&sources_dir, &dirs, &archive_file, None).unwrap();
 
-    c.bench_function("tar", |b| {
+    c.bench_function("tar_base", |b| {
         b.iter(|| {
-            untar(&archive_file, &sources, None).unwrap();
+            untar(&archive_file, &sources_dir, None).unwrap();
         })
     });
 }
 
-pub fn tar_remove_benchmark(c: &mut Criterion) {
-    let temp_dir = create_tree();
-    let dirs = string_vec!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'];
-    let sources = temp_dir.path().join("sources");
-    let archive_file = temp_dir.path().join("archive.tar.gz");
+pub fn tar_base_remove_benchmark(c: &mut Criterion) {
+    let (temp_dir, sources_dir, archive_file, dirs) = create_tree();
 
-    tar(&sources, &dirs, &archive_file, None).unwrap();
+    tar(&sources_dir, &dirs, &archive_file, None).unwrap();
 
-    c.bench_function("tar_remove", |b| {
+    c.bench_function("tar_base_remove", |b| {
         b.iter(|| {
-            fs::remove_dir_all(&sources).unwrap();
+            fs::remove_dir_all(&sources_dir).unwrap();
 
-            untar(&archive_file, &sources, None).unwrap();
+            untar(&archive_file, &sources_dir, None).unwrap();
         })
     });
 }
 
 pub fn tar_diff_benchmark(c: &mut Criterion) {
-    let temp_dir = create_tree();
-    let dirs = string_vec!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'];
-    let sources = temp_dir.path().join("sources");
-    let archive_file = temp_dir.path().join("archive.tar.gz");
+    let (temp_dir, sources_dir, archive_file, dirs) = create_tree();
 
-    tar(&sources, &dirs, &archive_file, None).unwrap();
+    tar(&sources_dir, &dirs, &archive_file, None).unwrap();
 
     c.bench_function("tar_diff", |b| {
         b.to_async(tokio::runtime::Runtime::new().unwrap())
             .iter(|| async {
-                let mut diff = TreeDiffer::load(&sources, &dirs).unwrap();
+                let mut diff = TreeDiffer::load(&sources_dir, &dirs).unwrap();
 
-                untar_with_diff(&mut diff, &archive_file, &sources, None)
+                untar_with_diff(&mut diff, &archive_file, &sources_dir, None)
                     .await
                     .unwrap();
             })
@@ -95,21 +77,18 @@ pub fn tar_diff_benchmark(c: &mut Criterion) {
 }
 
 pub fn tar_diff_remove_benchmark(c: &mut Criterion) {
-    let temp_dir = create_tree();
-    let dirs = string_vec!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'];
-    let sources = temp_dir.path().join("sources");
-    let archive_file = temp_dir.path().join("archive.tar.gz");
+    let (temp_dir, sources_dir, archive_file, dirs) = create_tree();
 
-    tar(&sources, &dirs, &archive_file, None).unwrap();
+    tar(&sources_dir, &dirs, &archive_file, None).unwrap();
 
     c.bench_function("tar_diff_remove", |b| {
         b.to_async(tokio::runtime::Runtime::new().unwrap())
             .iter(|| async {
-                fs::remove_dir_all(&sources).unwrap();
+                fs::remove_dir_all(&sources_dir).unwrap();
 
-                let mut diff = TreeDiffer::load(&sources, &dirs).unwrap();
+                let mut diff = TreeDiffer::load(&sources_dir, &dirs).unwrap();
 
-                untar_with_diff(&mut diff, &archive_file, &sources, None)
+                untar_with_diff(&mut diff, &archive_file, &sources_dir, None)
                     .await
                     .unwrap();
             })
@@ -118,8 +97,8 @@ pub fn tar_diff_remove_benchmark(c: &mut Criterion) {
 
 criterion_group!(
     tar_archive,
-    tar_benchmark,
-    tar_remove_benchmark,
+    tar_base_benchmark,
+    tar_base_remove_benchmark,
     tar_diff_benchmark,
     tar_diff_remove_benchmark,
 );

--- a/crates/core/archive/src/lib.rs
+++ b/crates/core/archive/src/lib.rs
@@ -1,6 +1,7 @@
 mod errors;
 mod helpers;
 mod tar;
+mod tree_differ;
 mod zip;
 
 pub use crate::tar::*;

--- a/crates/core/archive/src/lib.rs
+++ b/crates/core/archive/src/lib.rs
@@ -7,3 +7,4 @@ mod zip;
 pub use crate::tar::*;
 pub use crate::zip::*;
 pub use errors::ArchiveError;
+pub use tree_differ::TreeDiffer;

--- a/crates/core/archive/src/tar.rs
+++ b/crates/core/archive/src/tar.rs
@@ -231,11 +231,14 @@ pub async fn untar_new<I: AsRef<Path>, O: AsRef<Path>>(
         }
 
         // Unpack the file if different than destination
-        if diff.should_write(entry.size(), entry, &output_path)? {
+        if diff.should_write(entry.size(), &mut entry, &output_path)? {
             entry.unpack(&output_path)?;
-            diff.untrack(&output_path);
         }
+
+        diff.untrack(&output_path);
     }
+
+    diff.remove_stale_files().await?;
 
     Ok(())
 }

--- a/crates/core/archive/src/tar.rs
+++ b/crates/core/archive/src/tar.rs
@@ -184,14 +184,13 @@ pub fn untar<I: AsRef<Path>, O: AsRef<Path>>(
 
 #[track_caller]
 pub async fn untar_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
+    diff: &mut TreeDiffer,
     input_file: I,
-    files: &[String],
     output_dir: O,
     remove_prefix: Option<&str>,
 ) -> Result<(), ArchiveError> {
     let input_file = input_file.as_ref();
     let output_dir = output_dir.as_ref();
-    let mut diff = TreeDiffer::load(&output_dir, files).await?;
 
     debug!(
         target: LOG_TARGET,

--- a/crates/core/archive/src/tar.rs
+++ b/crates/core/archive/src/tar.rs
@@ -183,7 +183,7 @@ pub fn untar<I: AsRef<Path>, O: AsRef<Path>>(
 }
 
 #[track_caller]
-pub async fn untar_new<I: AsRef<Path>, O: AsRef<Path>>(
+pub async fn untar_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
     input_file: I,
     files: &[String],
     output_dir: O,

--- a/crates/core/archive/src/tar.rs
+++ b/crates/core/archive/src/tar.rs
@@ -1,5 +1,6 @@
 use crate::errors::ArchiveError;
 use crate::helpers::{ensure_dir, prepend_name};
+use crate::tree_differ::TreeDiffer;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -176,6 +177,64 @@ pub fn untar<I: AsRef<Path>, O: AsRef<Path>>(
         }
 
         entry.unpack(&output_path)?;
+    }
+
+    Ok(())
+}
+
+#[track_caller]
+pub async fn untar_new<I: AsRef<Path>, O: AsRef<Path>>(
+    input_file: I,
+    files: &[String],
+    output_dir: O,
+    remove_prefix: Option<&str>,
+) -> Result<(), ArchiveError> {
+    let input_file = input_file.as_ref();
+    let output_dir = output_dir.as_ref();
+    let mut diff = TreeDiffer::load(&output_dir, files).await?;
+
+    debug!(
+        target: LOG_TARGET,
+        "Unpacking tar archive {} to {}",
+        color::path(input_file),
+        color::path(output_dir),
+    );
+
+    ensure_dir(output_dir)?;
+
+    // Open .tar.gz file
+    let tar_gz =
+        File::open(input_file).map_err(|e| map_io_to_fs_error(e, input_file.to_path_buf()))?;
+
+    // Decompress to .tar
+    let tar = GzDecoder::new(tar_gz);
+
+    // Unpack the archive into the output dir
+    let mut archive = Archive::new(tar);
+
+    for entry_result in archive.entries()? {
+        let mut entry = entry_result?;
+        let mut path: PathBuf = entry.path()?.into_owned();
+
+        // Remove the prefix
+        if let Some(prefix) = remove_prefix {
+            if path.starts_with(prefix) {
+                path = path.strip_prefix(prefix).unwrap().to_owned();
+            }
+        }
+
+        let output_path = output_dir.join(path);
+
+        // Create parent dirs
+        if let Some(parent_dir) = output_path.parent() {
+            ensure_dir(parent_dir)?;
+        }
+
+        // Unpack the file if different than destination
+        if diff.should_write(entry.size(), entry, &output_path)? {
+            entry.unpack(&output_path)?;
+            diff.untrack(&output_path);
+        }
     }
 
     Ok(())

--- a/crates/core/archive/src/tar.rs
+++ b/crates/core/archive/src/tar.rs
@@ -237,7 +237,7 @@ pub async fn untar_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
         differ.untrack_file(&output_path);
     }
 
-    differ.remove_stale_tracked_files().await?;
+    differ.remove_stale_tracked_files();
 
     Ok(())
 }

--- a/crates/core/archive/src/tar.rs
+++ b/crates/core/archive/src/tar.rs
@@ -184,7 +184,7 @@ pub fn untar<I: AsRef<Path>, O: AsRef<Path>>(
 
 #[track_caller]
 pub async fn untar_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
-    diff: &mut TreeDiffer,
+    differ: &mut TreeDiffer,
     input_file: I,
     output_dir: O,
     remove_prefix: Option<&str>,
@@ -230,14 +230,14 @@ pub async fn untar_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
         }
 
         // Unpack the file if different than destination
-        if diff.should_write(entry.size(), &mut entry, &output_path)? {
+        if differ.should_write_source(entry.size(), &mut entry, &output_path)? {
             entry.unpack(&output_path)?;
         }
 
-        diff.untrack(&output_path);
+        differ.untrack_file(&output_path);
     }
 
-    diff.remove_stale_files().await?;
+    differ.remove_stale_tracked_files().await?;
 
     Ok(())
 }

--- a/crates/core/archive/src/tree_differ.rs
+++ b/crates/core/archive/src/tree_differ.rs
@@ -12,7 +12,7 @@ pub fn read_dir_all<T: AsRef<Path> + Send>(
 ) -> Result<Vec<std::fs::DirEntry>, std::io::Error> {
     let path = path.as_ref();
 
-    let mut entries = std::fs::read_dir(path)?;
+    let entries = std::fs::read_dir(path)?;
     let mut results = vec![];
 
     for entry in entries {

--- a/crates/core/archive/src/tree_differ.rs
+++ b/crates/core/archive/src/tree_differ.rs
@@ -1,0 +1,112 @@
+use moon_error::MoonError;
+use moon_utils::fs;
+use rustc_hash::FxHashMap;
+use std::path::{Path, PathBuf};
+use std::{
+    fs::File,
+    io::{BufReader, Read},
+};
+
+pub enum DiffState {}
+
+pub struct TreeDiffer {
+    /// A mapping of all files in the destination directory
+    /// to their current file sizes.
+    files: FxHashMap<PathBuf, u64>,
+}
+
+impl TreeDiffer {
+    pub async fn load(dest_root: &Path, paths: &[String]) -> Result<Self, MoonError> {
+        let mut files = vec![];
+
+        for path in paths {
+            let path = dest_root.join(path);
+
+            if path.is_file() {
+                files.push(path);
+            } else if path.is_dir() {
+                for file in fs::read_dir_all(path).await? {
+                    files.push(file.path());
+                }
+            }
+        }
+
+        let mut tracked = FxHashMap::default();
+
+        for file in files {
+            if !file.exists() {
+                continue;
+            }
+
+            let size = match fs::metadata(&file).await {
+                Ok(meta) => meta.len(),
+                Err(_) => 0,
+            };
+
+            tracked.insert(file, size);
+        }
+
+        Ok(TreeDiffer { files: tracked })
+    }
+
+    /// Determine whether the source should be written to the destination.
+    /// If a file exists at the destination, run a handful of checks to
+    /// determine whether we overwrite the file or keep it.
+    pub fn should_write<T: Read>(
+        &self,
+        source_size: u64,
+        source: T,
+        dest_path: &Path,
+    ) -> Result<bool, MoonError> {
+        // If the destination doesn't exist, always use the source
+        if !dest_path.exists() || !self.files.contains_key(dest_path) {
+            return Ok(true);
+        }
+
+        // If the file sizes are different, use the source
+        let Some(dest_size) = self.files.get(dest_path) else {
+            return Ok(true);
+        };
+
+        if source_size != *dest_size {
+            return Ok(true);
+        }
+
+        // If the file sizes are the same, compare byte ranges to determine a difference
+        Ok(!self.are_files_equal(source, dest_path)?)
+    }
+
+    /// Untrack a destination file from the internal registry.
+    pub fn untrack(&mut self, dest: &Path) {
+        self.files.remove(dest);
+    }
+
+    /// Compare 2 files byte by byte and return true if both files are equal.
+    fn are_files_equal<T: Read>(&self, source: T, dest_path: &Path) -> Result<bool, MoonError> {
+        let mut areader = BufReader::new(source);
+        let mut breader = BufReader::new(File::open(dest_path)?);
+        let mut abuf = [0; 512];
+        let mut bbuf = [0; 512];
+
+        loop {
+            match (areader.read(&mut abuf), breader.read(&mut bbuf)) {
+                (Ok(av), Ok(bv)) => {
+                    // We've reached the end of the file for either one
+                    if av < 512 || bv < 512 {
+                        return Ok(abuf == bbuf);
+                    }
+
+                    // Otherwise, compare buffer
+                    if abuf != bbuf {
+                        return Ok(false);
+                    }
+                }
+                _ => {
+                    break;
+                }
+            }
+        }
+
+        Ok(false)
+    }
+}

--- a/crates/core/archive/src/tree_differ.rs
+++ b/crates/core/archive/src/tree_differ.rs
@@ -14,6 +14,9 @@ pub struct TreeDiffer {
 }
 
 impl TreeDiffer {
+    /// Load the tree at the defined destination root and scan the file system
+    /// using the defined lists of paths, either files or folders. If a folder,
+    /// recursively scan all files and create an internal manifest to track diffing.
     pub fn load(dest_root: &Path, paths: &[String]) -> Result<Self, MoonError> {
         let mut files = vec![];
 
@@ -47,10 +50,36 @@ impl TreeDiffer {
         Ok(TreeDiffer { files: tracked })
     }
 
+    /// Compare 2 files byte by byte and return true if both files are equal.
+    pub fn are_files_equal<T: Read>(
+        &self,
+        source: &mut T,
+        dest_path: &Path,
+    ) -> Result<bool, MoonError> {
+        let mut areader = BufReader::new(source);
+        let mut breader = BufReader::new(File::open(dest_path)?);
+        let mut abuf = [0; 512];
+        let mut bbuf = [0; 512];
+
+        while let (Ok(av), Ok(bv)) = (areader.read(&mut abuf), breader.read(&mut bbuf)) {
+            // We've reached the end of the file for either one
+            if av < 512 || bv < 512 {
+                return Ok(abuf == bbuf);
+            }
+
+            // Otherwise, compare buffer
+            if abuf != bbuf {
+                return Ok(false);
+            }
+        }
+
+        Ok(false)
+    }
+
     /// Remove all files in the destination directory that have not been
     /// overwritten with a source file, or are the same size as a source file.
     /// We can assume these are stale artifacts that should no longer exist!
-    pub async fn remove_stale_files(&mut self) -> Result<(), MoonError> {
+    pub async fn remove_stale_tracked_files(&mut self) -> Result<(), MoonError> {
         for (file, _) in self.files.drain() {
             fs::remove(file).await?;
         }
@@ -61,7 +90,7 @@ impl TreeDiffer {
     /// Determine whether the source should be written to the destination.
     /// If a file exists at the destination, run a handful of checks to
     /// determine whether we overwrite the file or keep it (equal content).
-    pub fn should_write<T: Read>(
+    pub fn should_write_source<T: Read>(
         &self,
         source_size: u64,
         source: &mut T,
@@ -86,33 +115,7 @@ impl TreeDiffer {
     }
 
     /// Untrack a destination file from the internal registry.
-    pub fn untrack(&mut self, dest: &Path) {
+    pub fn untrack_file(&mut self, dest: &Path) {
         self.files.remove(dest);
-    }
-
-    /// Compare 2 files byte by byte and return true if both files are equal.
-    fn are_files_equal<T: Read>(
-        &self,
-        source: &mut T,
-        dest_path: &Path,
-    ) -> Result<bool, MoonError> {
-        let mut areader = BufReader::new(source);
-        let mut breader = BufReader::new(File::open(dest_path)?);
-        let mut abuf = [0; 512];
-        let mut bbuf = [0; 512];
-
-        while let (Ok(av), Ok(bv)) = (areader.read(&mut abuf), breader.read(&mut bbuf)) {
-            // We've reached the end of the file for either one
-            if av < 512 || bv < 512 {
-                return Ok(abuf == bbuf);
-            }
-
-            // Otherwise, compare buffer
-            if abuf != bbuf {
-                return Ok(false);
-            }
-        }
-
-        Ok(false)
     }
 }

--- a/crates/core/archive/src/tree_differ.rs
+++ b/crates/core/archive/src/tree_differ.rs
@@ -7,29 +7,6 @@ use std::{
     io::{BufReader, Read},
 };
 
-pub fn read_dir_all<T: AsRef<Path> + Send>(
-    path: T,
-) -> Result<Vec<std::fs::DirEntry>, std::io::Error> {
-    let path = path.as_ref();
-
-    let entries = std::fs::read_dir(path)?;
-    let mut results = vec![];
-
-    for entry in entries {
-        let entry = entry?;
-
-        if let Ok(file_type) = entry.file_type() {
-            if file_type.is_dir() {
-                results.extend(read_dir_all(&entry.path())?);
-            } else {
-                results.push(entry);
-            }
-        }
-    }
-
-    Ok(results)
-}
-
 pub struct TreeDiffer {
     /// A mapping of all files in the destination directory
     /// to their current file sizes.
@@ -46,7 +23,7 @@ impl TreeDiffer {
             if path.is_file() {
                 files.push(path);
             } else if path.is_dir() {
-                for file in read_dir_all(path)? {
+                for file in fs::read_dir_all(path)? {
                     files.push(file.path());
                 }
             }
@@ -60,39 +37,6 @@ impl TreeDiffer {
             }
 
             let size = match std::fs::metadata(&file) {
-                Ok(meta) => meta.len(),
-                Err(_) => 0,
-            };
-
-            tracked.insert(file, size);
-        }
-
-        Ok(TreeDiffer { files: tracked })
-    }
-
-    pub async fn load_async(dest_root: &Path, paths: &[String]) -> Result<Self, MoonError> {
-        let mut files = vec![];
-
-        for path in paths {
-            let path = dest_root.join(path);
-
-            if path.is_file() {
-                files.push(path);
-            } else if path.is_dir() {
-                for file in fs::read_dir_all(path).await? {
-                    files.push(file.path());
-                }
-            }
-        }
-
-        let mut tracked = FxHashMap::default();
-
-        for file in files {
-            if !file.exists() {
-                continue;
-            }
-
-            let size = match fs::metadata(&file).await {
                 Ok(meta) => meta.len(),
                 Err(_) => 0,
             };
@@ -157,22 +101,15 @@ impl TreeDiffer {
         let mut abuf = [0; 512];
         let mut bbuf = [0; 512];
 
-        loop {
-            match (areader.read(&mut abuf), breader.read(&mut bbuf)) {
-                (Ok(av), Ok(bv)) => {
-                    // We've reached the end of the file for either one
-                    if av < 512 || bv < 512 {
-                        return Ok(abuf == bbuf);
-                    }
+        while let (Ok(av), Ok(bv)) = (areader.read(&mut abuf), breader.read(&mut bbuf)) {
+            // We've reached the end of the file for either one
+            if av < 512 || bv < 512 {
+                return Ok(abuf == bbuf);
+            }
 
-                    // Otherwise, compare buffer
-                    if abuf != bbuf {
-                        return Ok(false);
-                    }
-                }
-                _ => {
-                    break;
-                }
+            // Otherwise, compare buffer
+            if abuf != bbuf {
+                return Ok(false);
             }
         }
 

--- a/crates/core/archive/src/zip.rs
+++ b/crates/core/archive/src/zip.rs
@@ -169,7 +169,7 @@ pub fn unzip<I: AsRef<Path>, O: AsRef<Path>>(
 }
 
 #[track_caller]
-pub async fn unzip_new<I: AsRef<Path>, O: AsRef<Path>>(
+pub async fn unzip_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
     input_file: I,
     files: &[String],
     output_dir: O,

--- a/crates/core/archive/src/zip.rs
+++ b/crates/core/archive/src/zip.rs
@@ -1,6 +1,6 @@
 use crate::errors::ArchiveError;
 use crate::helpers::{ensure_dir, prepend_name};
-use crate::tree_differ::TreeDiffer;
+// use crate::tree_differ::TreeDiffer;
 use moon_error::map_io_to_fs_error;
 use moon_logger::{color, debug, map_list, trace};
 use moon_utils::path::to_string;
@@ -168,83 +168,84 @@ pub fn unzip<I: AsRef<Path>, O: AsRef<Path>>(
     Ok(())
 }
 
-#[track_caller]
-pub async fn unzip_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
-    differ: &mut TreeDiffer,
-    input_file: I,
-    output_dir: O,
-    remove_prefix: Option<&str>,
-) -> Result<(), ArchiveError> {
-    let input_file = input_file.as_ref();
-    let output_dir = output_dir.as_ref();
+// Uncomment when needed!
+// #[track_caller]
+// pub async fn unzip_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
+//     differ: &mut TreeDiffer,
+//     input_file: I,
+//     output_dir: O,
+//     remove_prefix: Option<&str>,
+// ) -> Result<(), ArchiveError> {
+//     let input_file = input_file.as_ref();
+//     let output_dir = output_dir.as_ref();
 
-    debug!(
-        target: LOG_TARGET,
-        "Unzipping archive {} to {}",
-        color::path(input_file),
-        color::path(output_dir),
-    );
+//     debug!(
+//         target: LOG_TARGET,
+//         "Unzipping archive {} to {}",
+//         color::path(input_file),
+//         color::path(output_dir),
+//     );
 
-    ensure_dir(output_dir)?;
+//     ensure_dir(output_dir)?;
 
-    // Open .zip file
-    let zip =
-        File::open(input_file).map_err(|e| map_io_to_fs_error(e, input_file.to_path_buf()))?;
+//     // Open .zip file
+//     let zip =
+//         File::open(input_file).map_err(|e| map_io_to_fs_error(e, input_file.to_path_buf()))?;
 
-    // Unpack the archive into the output dir
-    let mut archive = ZipArchive::new(zip)?;
+//     // Unpack the archive into the output dir
+//     let mut archive = ZipArchive::new(zip)?;
 
-    for i in 0..archive.len() {
-        let mut file = archive.by_index(i)?;
+//     for i in 0..archive.len() {
+//         let mut file = archive.by_index(i)?;
 
-        let mut path = match file.enclosed_name() {
-            Some(path) => path.to_owned(),
-            None => continue,
-        };
+//         let mut path = match file.enclosed_name() {
+//             Some(path) => path.to_owned(),
+//             None => continue,
+//         };
 
-        // Remove the prefix
-        if let Some(prefix) = remove_prefix {
-            if path.starts_with(prefix) {
-                path = path.strip_prefix(prefix).unwrap().to_owned();
-            }
-        }
+//         // Remove the prefix
+//         if let Some(prefix) = remove_prefix {
+//             if path.starts_with(prefix) {
+//                 path = path.strip_prefix(prefix).unwrap().to_owned();
+//             }
+//         }
 
-        let output_path = output_dir.join(&path);
-        let handle_error = |e: io::Error| map_io_to_fs_error(e, output_path.to_path_buf());
+//         let output_path = output_dir.join(&path);
+//         let handle_error = |e: io::Error| map_io_to_fs_error(e, output_path.to_path_buf());
 
-        // Create parent dirs
-        if let Some(parent_dir) = &output_path.parent() {
-            ensure_dir(parent_dir)?;
-        }
+//         // Create parent dirs
+//         if let Some(parent_dir) = &output_path.parent() {
+//             ensure_dir(parent_dir)?;
+//         }
 
-        // If a folder, create the dir
-        if file.is_dir() {
-            ensure_dir(&output_path)?;
-        }
+//         // If a folder, create the dir
+//         if file.is_dir() {
+//             ensure_dir(&output_path)?;
+//         }
 
-        // If a file, copy it to the output dir and only
-        // unpack the file if different than destination
-        if file.is_file() && differ.should_write_source(file.size(), &mut file, &output_path)? {
-            let mut out = File::create(&output_path).map_err(handle_error)?;
+//         // If a file, copy it to the output dir and only
+//         // unpack the file if different than destination
+//         if file.is_file() && differ.should_write_source(file.size(), &mut file, &output_path)? {
+//             let mut out = File::create(&output_path).map_err(handle_error)?;
 
-            io::copy(&mut file, &mut out).map_err(handle_error)?;
+//             io::copy(&mut file, &mut out).map_err(handle_error)?;
 
-            // Update permissions when on a nix machine
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
+//             // Update permissions when on a nix machine
+//             #[cfg(unix)]
+//             {
+//                 use std::os::unix::fs::PermissionsExt;
 
-                if let Some(mode) = file.unix_mode() {
-                    fs::set_permissions(&output_path, fs::Permissions::from_mode(mode))
-                        .map_err(handle_error)?;
-                }
-            }
+//                 if let Some(mode) = file.unix_mode() {
+//                     fs::set_permissions(&output_path, fs::Permissions::from_mode(mode))
+//                         .map_err(handle_error)?;
+//                 }
+//             }
 
-            differ.untrack_file(&output_path);
-        }
-    }
+//             differ.untrack_file(&output_path);
+//         }
+//     }
 
-    differ.remove_stale_tracked_files().await?;
+//     differ.remove_stale_tracked_files().await?;
 
-    Ok(())
-}
+//     Ok(())
+// }

--- a/crates/core/archive/src/zip.rs
+++ b/crates/core/archive/src/zip.rs
@@ -177,7 +177,7 @@ pub async fn unzip_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
 ) -> Result<(), ArchiveError> {
     let input_file = input_file.as_ref();
     let output_dir = output_dir.as_ref();
-    let mut diff = TreeDiffer::load(&output_dir, files).await?;
+    let mut diff = TreeDiffer::load(&output_dir, files)?;
 
     debug!(
         target: LOG_TARGET,

--- a/crates/core/archive/src/zip.rs
+++ b/crates/core/archive/src/zip.rs
@@ -177,7 +177,7 @@ pub async fn unzip_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
 ) -> Result<(), ArchiveError> {
     let input_file = input_file.as_ref();
     let output_dir = output_dir.as_ref();
-    let mut diff = TreeDiffer::load(&output_dir, files)?;
+    let mut diff = TreeDiffer::load(output_dir, files)?;
 
     debug!(
         target: LOG_TARGET,

--- a/crates/core/archive/tests/tree_differ_test.rs
+++ b/crates/core/archive/tests/tree_differ_test.rs
@@ -1,0 +1,76 @@
+use moon_archive::TreeDiffer;
+use moon_utils::{string_vec, test::create_sandbox};
+use std::fs::{self, File};
+
+#[test]
+fn loads_all_files() {
+    let fixture = create_sandbox("generator");
+    let differ = TreeDiffer::load(fixture.path(), &string_vec!["templates"]).unwrap();
+
+    assert_eq!(differ.files.len(), 100);
+}
+
+#[test]
+fn removes_stale_files() {
+    let fixture = create_sandbox("generator");
+    let mut differ = TreeDiffer::load(fixture.path(), &string_vec!["templates"]).unwrap();
+
+    // Delete everything, hah
+    differ.remove_stale_tracked_files();
+
+    let differ = TreeDiffer::load(fixture.path(), &string_vec!["templates"]).unwrap();
+
+    assert_eq!(differ.files.len(), 0);
+}
+
+mod equal_check {
+    use super::*;
+
+    #[test]
+    fn returns_true_if_equal() {
+        let fixture = create_sandbox("generator");
+        let differ = TreeDiffer::load(fixture.path(), &string_vec!["templates"]).unwrap();
+
+        let source_path = fixture.path().join("templates/standard/file-source.txt");
+        fs::write(&source_path, "content").unwrap();
+        let mut source = File::open(&source_path).unwrap();
+
+        let dest_path = fixture.path().join("templates/standard/file.txt");
+        fs::write(&dest_path, "content").unwrap();
+        let mut dest = File::open(&dest_path).unwrap();
+
+        assert!(differ.are_files_equal(&mut source, &mut dest).unwrap());
+    }
+
+    #[test]
+    fn returns_false_if_diff_sizes() {
+        let fixture = create_sandbox("generator");
+        let differ = TreeDiffer::load(fixture.path(), &string_vec!["templates"]).unwrap();
+
+        let source_path = fixture.path().join("templates/standard/file-source.txt");
+        fs::write(&source_path, "data").unwrap();
+        let mut source = File::open(&source_path).unwrap();
+
+        let dest_path = fixture.path().join("templates/standard/file.txt");
+        fs::write(&dest_path, "content").unwrap();
+        let mut dest = File::open(&dest_path).unwrap();
+
+        assert!(!differ.are_files_equal(&mut source, &mut dest).unwrap());
+    }
+
+    #[test]
+    fn returns_false_if_diff_data() {
+        let fixture = create_sandbox("generator");
+        let differ = TreeDiffer::load(fixture.path(), &string_vec!["templates"]).unwrap();
+
+        let source_path = fixture.path().join("templates/standard/file-source.txt");
+        fs::write(&source_path, "cont...").unwrap();
+        let mut source = File::open(&source_path).unwrap();
+
+        let dest_path = fixture.path().join("templates/standard/file.txt");
+        fs::write(&dest_path, "content").unwrap();
+        let mut dest = File::open(&dest_path).unwrap();
+
+        assert!(!differ.are_files_equal(&mut source, &mut dest).unwrap());
+    }
+}

--- a/crates/core/archive/tests/tree_differ_test.rs
+++ b/crates/core/archive/tests/tree_differ_test.rs
@@ -7,7 +7,7 @@ fn loads_all_files() {
     let fixture = create_sandbox("generator");
     let differ = TreeDiffer::load(fixture.path(), &string_vec!["templates"]).unwrap();
 
-    assert_eq!(differ.files.len(), 100);
+    assert_eq!(differ.files.len(), 18);
 }
 
 #[test]

--- a/crates/core/cache/src/items/run_target_state.rs
+++ b/crates/core/cache/src/items/run_target_state.rs
@@ -1,6 +1,6 @@
 use crate::cache_item;
 use crate::helpers::{is_readable, is_writable};
-use moon_archive::{untar_with_diff, TarArchiver};
+use moon_archive::{untar_with_diff, TarArchiver, TreeDiffer};
 use moon_error::MoonError;
 use moon_logger::{color, trace};
 use moon_utils::{fs, json, time};
@@ -65,7 +65,9 @@ impl RunTargetState {
         outputs: &[String],
     ) -> Result<bool, MoonError> {
         if is_readable() && archive_file.exists() {
-            untar_with_diff(archive_file, outputs, project_root, None)
+            let mut diff = TreeDiffer::load(project_root, outputs)?;
+
+            untar_with_diff(&mut diff, archive_file, project_root, None)
                 .await
                 .map_err(|e| MoonError::Generic(e.to_string()))?;
 

--- a/crates/core/cache/src/items/run_target_state.rs
+++ b/crates/core/cache/src/items/run_target_state.rs
@@ -65,9 +65,9 @@ impl RunTargetState {
         outputs: &[String],
     ) -> Result<bool, MoonError> {
         if is_readable() && archive_file.exists() {
-            let mut diff = TreeDiffer::load(project_root, outputs)?;
+            let mut differ = TreeDiffer::load(project_root, outputs)?;
 
-            untar_with_diff(&mut diff, archive_file, project_root, None)
+            untar_with_diff(&mut differ, archive_file, project_root, None)
                 .await
                 .map_err(|e| MoonError::Generic(e.to_string()))?;
 

--- a/crates/core/cache/src/items/run_target_state.rs
+++ b/crates/core/cache/src/items/run_target_state.rs
@@ -1,6 +1,6 @@
 use crate::cache_item;
 use crate::helpers::{is_readable, is_writable};
-use moon_archive::{untar, TarArchiver};
+use moon_archive::{untar_with_diff, TarArchiver};
 use moon_error::MoonError;
 use moon_logger::{color, trace};
 use moon_utils::{fs, json, time};
@@ -62,9 +62,11 @@ impl RunTargetState {
         &self,
         archive_file: &Path,
         project_root: &Path,
+        outputs: &[String],
     ) -> Result<bool, MoonError> {
         if is_readable() && archive_file.exists() {
-            untar(archive_file, project_root, None)
+            untar_with_diff(archive_file, outputs, project_root, None)
+                .await
                 .map_err(|e| MoonError::Generic(e.to_string()))?;
 
             let cache_logs = self.get_output_logs();

--- a/crates/core/generator/src/template.rs
+++ b/crates/core/generator/src/template.rs
@@ -171,7 +171,7 @@ impl Template {
     ) -> Result<(), GeneratorError> {
         let mut files = vec![];
 
-        for entry in fs::read_dir_all(&self.root).await? {
+        for entry in fs::read_dir_all(&self.root)? {
             // This is moon's schema, so skip it
             if entry.file_name() == CONFIG_TEMPLATE_FILENAME {
                 continue;

--- a/crates/core/runner/src/actions/run_target.rs
+++ b/crates/core/runner/src/actions/run_target.rs
@@ -68,7 +68,7 @@ impl<'a> TargetRunner<'a> {
 
     /// Cache outputs to the `.moon/cache/outputs` folder and to the cloud,
     /// so that subsequent builds are faster, and any local outputs
-    /// can be rehydrated easily.
+    /// can be hydrated easily.
     pub async fn archive_outputs(&self) -> Result<(), RunnerError> {
         let hash = &self.cache.hash;
 

--- a/crates/core/runner/src/actions/run_target.rs
+++ b/crates/core/runner/src/actions/run_target.rs
@@ -14,7 +14,7 @@ use moon_task::{Target, Task, TaskError};
 use moon_terminal::label_checkpoint;
 use moon_terminal::Checkpoint;
 use moon_utils::{
-    fs, is_ci, is_test_env, path,
+    is_ci, is_test_env, path,
     process::{self, format_running_command, output_to_string, Command, Output},
     time,
 };
@@ -119,11 +119,6 @@ impl<'a> TargetRunner<'a> {
 
         if hash.is_empty() {
             return Ok(());
-        }
-
-        // Remove previous outputs so we avoid stale artifacts
-        for output in &self.task.output_paths {
-            fs::remove(output).await?;
         }
 
         // Hydrate outputs from the cache

--- a/crates/core/runner/src/subscribers/local_cache.rs
+++ b/crates/core/runner/src/subscribers/local_cache.rs
@@ -59,11 +59,16 @@ impl Subscriber for LocalCacheSubscriber {
                 cache,
                 hash,
                 project,
+                task,
                 ..
             } => {
                 let archive_path = workspace.cache.get_hash_archive_path(hash);
 
-                if is_readable() && cache.hydrate_outputs(&archive_path, &project.root).await? {
+                if is_readable()
+                    && cache
+                        .hydrate_outputs(&archive_path, &project.root, &task.outputs)
+                        .await?
+                {
                     return Ok(EventFlow::Return(path::to_string(archive_path)?));
                 }
             }

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -9,7 +9,6 @@ moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }
 assert_cmd = "2.0.6"
 assert_fs = "1.0.9"
-async-recursion = "1.0.0"
 cached = { workspace = true }
 chrono = { version = "0.4.23", features = ["serde"] }
 chrono-humanize = "0.2.2"

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -9,6 +9,7 @@ moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }
 assert_cmd = "2.0.6"
 assert_fs = "1.0.9"
+async-recursion = "1.0.0"
 cached = { workspace = true }
 chrono = { version = "0.4.23", features = ["serde"] }
 chrono-humanize = "0.2.2"

--- a/crates/core/utils/src/fs.rs
+++ b/crates/core/utils/src/fs.rs
@@ -1,5 +1,3 @@
-use async_recursion::async_recursion;
-use futures::future::try_join_all;
 use moon_error::{map_io_to_fs_error, MoonError};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
@@ -20,8 +18,9 @@ pub async fn copy_file<S: AsRef<Path>, D: AsRef<Path>>(from: S, to: D) -> Result
     Ok(())
 }
 
-#[async_recursion]
-pub async fn copy_dir_all<T: AsRef<Path> + Send>(
+// Sync is much faster than async here because of recursion!
+#[inline]
+pub fn copy_dir_all<T: AsRef<Path> + Send>(
     from_root: T,
     from: T,
     to_root: T,
@@ -29,29 +28,22 @@ pub async fn copy_dir_all<T: AsRef<Path> + Send>(
     let from_root = from_root.as_ref();
     let from = from.as_ref();
     let to_root = to_root.as_ref();
-    let entries = read_dir(from).await?;
-    let mut files = vec![];
+    let entries = std::fs::read_dir(from)?;
     let mut dirs = vec![];
 
     for entry in entries {
-        let path = entry.path();
+        let path = entry?.path();
 
         if path.is_file() {
-            files.push(copy_file(
-                path.to_owned(),
-                to_root.join(path.strip_prefix(from_root).unwrap()),
-            ));
+            std::fs::copy(&path, to_root.join(path.strip_prefix(from_root).unwrap()))?;
         } else {
             dirs.push(path);
         }
     }
 
-    // Copy files before dirs incase an error occurs
-    try_join_all(files).await?;
-
     // Copy dirs in sequence for the same reason
     for dir in dirs {
-        copy_dir_all(from_root, &dir, to_root).await?;
+        copy_dir_all(from_root, &dir, to_root)?;
     }
 
     Ok(())
@@ -153,18 +145,21 @@ pub async fn read_dir<T: AsRef<Path>>(path: T) -> Result<Vec<fs::DirEntry>, Moon
     Ok(results)
 }
 
-#[async_recursion]
-pub async fn read_dir_all<T: AsRef<Path> + Send>(path: T) -> Result<Vec<fs::DirEntry>, MoonError> {
+// Sync is much faster than async here because of recursion!
+#[inline]
+pub fn read_dir_all<T: AsRef<Path> + Send>(path: T) -> Result<Vec<std::fs::DirEntry>, MoonError> {
     let path = path.as_ref();
     let handle_error = |e| map_io_to_fs_error(e, path.to_path_buf());
 
-    let mut entries = fs::read_dir(path).await.map_err(handle_error)?;
+    let entries = std::fs::read_dir(path).map_err(handle_error)?;
     let mut results = vec![];
 
-    while let Some(entry) = entries.next_entry().await.map_err(handle_error)? {
-        if let Ok(file_type) = entry.file_type().await {
+    for entry in entries {
+        let entry = entry?;
+
+        if let Ok(file_type) = entry.file_type() {
             if file_type.is_dir() {
-                results.extend(read_dir_all(&entry.path()).await?);
+                results.extend(read_dir_all(&entry.path())?);
             } else {
                 results.push(entry);
             }

--- a/crates/core/utils/src/fs.rs
+++ b/crates/core/utils/src/fs.rs
@@ -20,7 +20,6 @@ pub async fn copy_file<S: AsRef<Path>, D: AsRef<Path>>(from: S, to: D) -> Result
     Ok(())
 }
 
-// Sync is much faster than async here because of recursion!
 #[async_recursion]
 pub async fn copy_dir_all<T: AsRef<Path> + Send>(
     from_root: T,

--- a/crates/core/utils/src/yaml.rs
+++ b/crates/core/utils/src/yaml.rs
@@ -57,14 +57,14 @@ pub fn write_with_config<P: AsRef<Path>>(path: P, yaml: YamlValue) -> Result<(),
     // a double space (the default). Can be customized with `.editorconfig`.
     if editor_config.indent != "  " {
         data = data
-            .split("\n")
+            .split('\n')
             .map(|line| {
                 if !line.starts_with("  ") {
                     return line.to_string();
                 }
 
                 LINE_WS_START
-                    .replace_all(&line, |caps: &regex::Captures| {
+                    .replace_all(line, |caps: &regex::Captures| {
                         editor_config
                             .indent
                             .repeat(caps.get(1).unwrap().as_str().len() / 2)

--- a/tests/fixtures/generator/templates/standard/file.txt
+++ b/tests/fixtures/generator/templates/standard/file.txt
@@ -1,0 +1,1 @@
+content

--- a/website/blog/2022-11-28_v0.20.mdx
+++ b/website/blog/2022-11-28_v0.20.mdx
@@ -1,0 +1,26 @@
+---
+slug: v0.20
+title: v0.20 - ???
+authors: [milesj]
+tags: [hydration]
+# image: ./img/v0.19.png
+---
+
+TODO
+
+<!--truncate-->
+
+# Increased output hydration by 8-10x
+
+In moon, hydration is the concept of unpacking an existing hashed artifact into a
+[task's outputs](../docs/config/project#outputs) during a cache hit. In our previous implementation,
+we would delete all existing outputs before unpacking the archive to ensure a clean slate and to
+avoid stale files. While this worked, it wasn't the most performant, taking about 280ms for 1,000
+files (which is still reasonably fast!).
+
+In our new implementation, we now utilize a smart file tree diffing algorithm that will only unpack
+files _with different content_, and will automatically remove stale files in the process. This has
+resulted in a 10x performance increase, taking about 30ms! Multiply this by many projects, the
+results should be very apparent.
+
+We hope you enjoy this improvement, as it's the first of many to come!

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -381,8 +381,8 @@ The `outputs` field is a list of files and folders that are _created_ as a resul
 task, excluding internal cache files that are created from the underlying command (for example,
 `.eslintcache`).
 
-Outputs are necessary for [incremental caching and rehydration](../concepts/cache). If you'd prefer
-to avoid that functionality, omit this field.
+Outputs are necessary for [incremental caching and hydration](../concepts/cache). If you'd prefer to
+avoid that functionality, omit this field.
 
 ```yaml title="moon.yml" {4-6}
 tasks:


### PR DESCRIPTION
When hydrating outputs from a tarball, we now compare the dest and source files to determine whether to write the source or not. Previously we would just wipe all files before hand, which wasn't very performant. This change has resulted in 10x the speed.

time:   [226.88 ms 235.45 ms 244.67 ms]
time:   [27.861 ms 28.181 ms 28.542 ms]