### PR TITLE
docs: Add an in-depth "TypeScript project references" article.

### DIFF
--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -610,8 +610,9 @@ The `platform` field defines the platform the command runs on, where to locate i
 which tool to execute it with. By default moon will set to a value based on the project's
 [`language`](#language).
 
-- `node` - Command is a binary within node modules and will be executed with Node.js.
-- `system` - Command is expected to exist within the system's environment.
+- `node` - Command is a binary within node modules and will be executed with Node.js (via our
+  toolchain).
+- `system` - Command is expected to exist within the system's environment / user's shell.
 - `unknown` - When not inferred.
 
 ```yaml title="moon.yml" {4}

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -25,11 +25,10 @@ acronym, as it embraces what moon is trying to solve:
 ### Will moon support other languages besides JavaScript?
 
 Yes! Although we're focusing right now on JavaScript (and TypeScript, Node.js), we've designed moon
-to be language agnostic and easily pluggable in the future. If we're to guess which language would
-be next, it would most likely be Ruby to support React Native based applications.
+to be language agnostic and easily pluggable in the future.
 
 With that being said, for languages not supported in our toolchain, you can still execute them
-within at task by setting the [`platform` to "system"](./config/project#platform).
+within a task by setting the [`platform` to "system"](#can-we-run-other-languages).
 
 ### Will moon support continuous deployment?
 
@@ -170,8 +169,8 @@ However, because these languages are not supported directly within our toolchain
 receive the benefits of the toolchain. Some of which are:
 
 - Automatic installation of the language. System tasks expect the command to already exist in the
-  environment, which requires the user to manually install.
-- Consistent language version across all machines.
+  environment, which requires the user to manually install them.
+- Consistent language and dependency manager versions across all machines.
 - Built-in cpu and heap profiling (language specific).
 - Automatic dependency installs when the lockfile changes.
 - And many more.

--- a/website/docs/guides/examples/typescript.mdx
+++ b/website/docs/guides/examples/typescript.mdx
@@ -9,8 +9,8 @@ import HeadingApiLink from '@site/src/components/Docs/HeadingApiLink';
 <HeadingApiLink to="https://github.com/moonrepo/examples/blob/master/.moon/project.yml#L95" />
 
 In this guide, you'll learn how to integrate [TypeScript](https://eslint.org/) into moon. We'll be
-using [project references](https://www.typescriptlang.org/docs/handbook/project-references.html), as
-it ensures that only affected projects are built, and not the entire repository.
+using [project references](../typescript-project-refs), as it ensures that only affected projects
+are built, and not the entire repository.
 
 Begin by installing `typescript` and any pre-configured tsconfig packages in your root. We suggest
 using the same version across the entire repository.
@@ -110,21 +110,14 @@ Every project will require a `tsconfig.json`, as TypeScript itself requires it. 
   "extends": "../../tsconfig.options.json",
   "compilerOptions": {
     // Declarations are written here
-    "outDir": "dts",
-    // Typecheck the entire project
-    "rootDir": "."
+    "outDir": "dts"
   },
-  // Exclude build folders
-  "exclude": ["dts"],
-  // Include all files in the project
-  "include": ["**/*"],
-  // Reference project dependencies
+  // Include files in the project
+  "include": ["src/**/*", "tests/**/*"],
+  // Depends on other projects
   "references": []
 }
 ```
-
-Be sure to exclude all build and output folders (`dts`, `lib`, `esm`, `dist`, etc), so that
-TypeScript doesn't inadvertently include them in the typechecker.
 
 > The [`typescript.projectConfigFileName`](../../config/workspace#projectconfigfilename) setting can
 > be used to change the project-level config name.

--- a/website/docs/guides/examples/typescript.mdx
+++ b/website/docs/guides/examples/typescript.mdx
@@ -3,8 +3,6 @@ title: TypeScript example
 sidebar_label: TypeScript
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import AddDepsTabs from '@site/src/components/AddDepsTabs';
 import HeadingApiLink from '@site/src/components/Docs/HeadingApiLink';
 

--- a/website/docs/guides/typescript-project-refs.mdx
+++ b/website/docs/guides/typescript-project-refs.mdx
@@ -1,0 +1,282 @@
+---
+title: TypeScript project references
+toc_max_heading_level: 6
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+asdsds
+
+## Why use project references?
+
+- incremental compile
+- boundaries
+- only run on out of date projects
+
+## Configuration
+
+The most complicated part of integrating TypeScript in a monorepo is proper configuration setup.
+Based on our extensive experience, we suggest the following architecture as a base!
+
+### Root-level
+
+In a polyrepo, the root `tsconfig.json` is typically the only configuration file, as it defines
+common compiler options, and includes files to typecheck. In a monorepo, these responsibilites are
+now split across multiple configuration files.
+
+#### `tsconfig.json`
+
+To start, the root `tsconfig.json` file is nothing more than a list of _all_ projects in the
+monorepo, with each project being an individual entry in the `references` field. Each entry must
+contain a `path` field with a relative file system path to the project root (that contains their
+config).
+
+We also _do not_ define compiler options in this file, as project-level configuration files would
+_not_ be able to extend this file, as it would trigger a circular reference. Instead, we define
+common compiler options in a root [`tsconfig.options.json`](#tsconfigoptionsjson) file, that this
+file also `extends` from.
+
+In the end, this file should only contain 3 fields: `extends`, `files` (an empty list), and
+`references`. This abides the
+[official guidance around structure](https://www.typescriptlang.org/docs/handbook/project-references.html#overall-structure).
+
+```json file="tsconfig.json"
+{
+  "extends": "./tsconfig.options.json",
+  "files": [],
+  "references": [
+    {
+      "path": "apps/foo"
+    },
+    {
+      "path": "packages/bar"
+    }
+    // ... more
+  ]
+}
+```
+
+> When using moon, the
+> [`typescript.syncProjectReferences`](../config/workspace#syncprojectreferences) setting will keep
+> this `references` list automatically in sync, and the name of the file can be customized with
+> [`typescript.rootConfigFileName`](../config/workspace#rootconfigfilename).
+
+#### `tsconfig.options.json`
+
+This file will contain common compiler options that will be inherited by _all_ projects in the
+monorepo. For project references to work correctly, the following settings _must_ be enabled at the
+root, and typically should not be disabled in each project.
+
+- `composite` - Enables project references and informs the TypeScript program where to find
+  referenced outputs.
+- `declaration` - Project references rely on the compiled declarations (`.d.ts`) of external
+  projects. If declarations do not exist, TypeScript will generate them on demand.
+- `declarationMap` - Generate sourcemaps for declarations, so that language server integrations in
+  editors like "Go to" resolve correctly.
+- `emitDeclarationOnly` - Project references only require declarations, so avoid compiling to
+  JavaScript.
+- `incremental` - Enables incremental compilation, greatly improving performance.
+- `noEmitOnError` - If the typechecker fails, avoid generating invalid or partial declarations.
+- `skipLibCheck` - Avoids eager loading and analyzing all declarations, greatly improving
+  performance.
+
+```json file="tsconfig.options.json"
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "incremental": true,
+    "noEmitOnError": true,
+    "skipLibCheck": true
+    // ... others
+  }
+}
+```
+
+> When using moon, the name of the file can be customized with
+> [`typescript.rootOptionsConfigFileName`](../config/workspace#rootoptionsconfigfilename).
+
+##### ECMAScript interoperability
+
+ECMAScript modules (ESM) have been around for quite a while now, but the default TypeScript settings
+are not configured for them. We suggest the following compiler options if you want proper ESM
+support with interoperability with the ecosystem.
+
+```json file="tsconfig.options.json"
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "target": "esnext"
+    // ... others
+  }
+}
+```
+
+#### `.gitignore`
+
+Project references unfortunately generate _a ton_ of artifacts that typically shouldn't be committed
+to the repository (but could be if you so choose). We suggest ignoring the following:
+
+```shell title=".gitignore"
+# The `outDir` for declarations
+dts/
+# Build cache manifests
+*.tsbuildinfo
+```
+
+### Project-level
+
+Each project that contains TypeScript files and will utilize the typechecker _must_ contain a
+`tsconfig.json` in the project root, typically as a sibling to `package.json`.
+
+#### `tsconfig.json`
+
+A `tsconfig.json` in the root of a project (application or package) is required, as it informs
+TypeScript that this is a project, and that it can be referenced by other projects. In its simplest
+form, this file should extend the root [`tsconfig.options.json`](#tsconfigoptionsjson) to inherit
+common compiler options, define its own compiler options (below), define includes/excludes, and any
+references.
+
+> When using moon, the name of the file can be customized with
+> [`typescript.projectConfigFileName`](../config/workspace#projectconfigfilename).
+
+<Tabs
+  groupId="project-type"
+  defaultValue="app"
+  values={[
+    { label: 'Applications', value: 'app' },
+    { label: 'Packages', value: 'package' },
+  ]}
+>
+<TabItem value="app">
+
+For applications, declaration emitting can be disabled, since external projects _should not_ be
+importing files from an application. If this use case ever arises, move those files into a package.
+
+```json title="apps/foo/tsconfig.json"
+{
+  "extends": "../../tsconfig.options.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "noEmit": true
+  },
+  "include": [],
+  "references": []
+}
+```
+
+</TabItem>
+<TabItem value="package">
+
+For packages, we must define the location in which to generate declarations. These are the
+declarations that external projects would reference. This location is typically
+[gitignored](#gitignore)!
+
+```json title="packages/bar/tsconfig.json"
+{
+  "extends": "../../tsconfig.options.json",
+  "compilerOptions": {
+    "outDir": "./dts"
+  },
+  "include": [],
+  "references": []
+}
+```
+
+</TabItem>
+</Tabs>
+
+> When using moon, the `outDir` can automatically be re-routed to a shared cache using
+> [`typescript.routeOutDirToCache`](../config/workspace#routeoutdirtocache), to avoid littering the
+> repository with compilation artifacts.
+
+##### Includes and excludes
+
+Based on experience, we suggest defining `include` instead of `exclude`, as managing a whitelist of
+typecheckable files is much easier. When dealing with excludes, there are far too many
+possibilities. To start, you have `node_modules`, and for applications maybe `dist`, `build`,
+`.next`, or another application specific folder, and then for packages you may have `lib`, `cjs`,
+`esm`, etc. It becomes very... tedious.
+
+The other benefit of using `include` is that it forces TypeScript to only load _what's necessary_,
+instead of eager loading everything into memory, and for typechecking files that aren't part of
+source, like configuration.
+
+```json title="<project>/tsconfig.json"
+{
+  // ...
+  "include": ["src/**/*", "tests/**/*", "*.js", "*.ts"]
+}
+```
+
+##### Depending on other projects
+
+When a project depends on another project (by importing code from it), either using relative paths,
+[path aliases](#using-paths-aliases), or its `package.json` name, it must be declared as a
+reference. If not declared, TypeScript will error with a message about importing outside the project
+boundary.
+
+```json title="<project>/tsconfig.json"
+{
+  // ...
+  "references": [
+    {
+      "path": "../foo"
+    },
+    {
+      "path": "../bar"
+    },
+    {
+      "path": "../../baz"
+    }
+  ]
+}
+```
+
+> When using moon, the
+> [`typescript.syncProjectReferences`](../config/workspace#syncprojectreferences) setting will keep
+> this `references` list automatically in sync.
+
+#### `tsconfig.*.json`
+
+TODO
+
+## Running the typechecker
+
+Now that our configuration is place, we can run the typechecker, or attempt to at least! This can be
+done with the `tsc --build` command, which acts as a
+[build orchestrator](https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript).
+We also suggest passing `--verbose` for insights into what projects are compiling, and which are
+out-of-date.
+
+### On all projects
+
+From the root of the repository, run `tsc --build --verbose` to typecheck _all_ projects, as defined
+in [tsconfig.json](#tsconfigjson). TypeScript will generate a directed acyclic graph (DAG) and
+compile projects _in order_ so that dependencies and references are resolved correctly.
+
+### On an individual project
+
+To only typecheck a single project (and its dependencies), there are 2 approaches. The first is to
+run from the root, and pass a relative path to the project, such as
+`tsc --build --verbose packages/foo`. The second is to change the working directory to the project,
+and run from there, such as `cd packages/foo && tsc --build --verbose`.
+
+Both approaches are viable, and either or may be used based on your tooling, build system, task
+runner, so on and so forth.
+
+## Using `paths` aliases
+
+## Sharing types
+
+## Supporting `package.json` exports
+
+## ESLint integration

--- a/website/docs/guides/typescript-project-refs.mdx
+++ b/website/docs/guides/typescript-project-refs.mdx
@@ -14,6 +14,11 @@ asdsds
 - boundaries
 - only run on out of date projects
 
+## Preface
+
+- only typechecking
+- not moon specific
+
 ## Configuration
 
 The most complicated part of integrating TypeScript in a monorepo is proper configuration setup.
@@ -271,9 +276,98 @@ run from the root, and pass a relative path to the project, such as
 and run from there, such as `cd packages/foo && tsc --build --verbose`.
 
 Both approaches are viable, and either or may be used based on your tooling, build system, task
-runner, so on and so forth.
+runner, so on and so forth. This is the approach moon suggests with its
+[`typecheck` task](./examples/typescript).
 
 ## Using `paths` aliases
+
+Path aliases, also known as path mapping or magic imports, is the concept of defining an import
+alias that re-maps its underlying location on the file system. In TypeScript, this is achieved with
+the
+[`paths` compiler option](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping).
+
+In a monorepo world, we suggest using path aliases on a per-project basis, instead of defining them
+"globally" in the root. This gives projects full control of what's available and what they want to
+import, and also plays nice with the mandatory `baseUrl` compiler option.
+
+```json title="<project>/tsconfig.json"
+{
+  // ...
+  "compilerOptions": {
+    // ...
+    "baseUrl": ".",
+    "paths": {
+      // Within the project
+      ":components/*": ["./src/components/*"],
+      // To a referenced project
+      ":shared/*": ["../shared/code/*"]
+    }
+  },
+  "references": [
+    {
+      "path": "../shared/code"
+    }
+  ]
+}
+```
+
+The above alias would be imported like the following:
+
+```ts
+// Before
+import { Button } from '../../components/Button';
+import utils from '../shared/code/utils';
+
+// After
+import { Button } from ':components/Button';
+import utils from ':shared/utils';
+```
+
+:::info
+
+When using path aliases, we suggest prefixing or suffixing the alias with `:` so that it's apparent
+that it's an alias (this also matches the new `node:` import syntax). Using `@` is problematic as it
+risks a chance of collision with a public npm package and may accidentally open your repository to a
+[supply chain attack](https://snyk.io/blog/npm-security-preventing-supply-chain-attacks/). Other
+characters like `~` and `$` have an existing meaning in the ecosystem, so it's best to avoid them
+aswell.
+
+:::
+
+### Importing source files from local packages
+
+If you are importing from a project reference using a `package.json` name, then TypeScript will
+abide by Node.js module resolution logic, and will import using the
+[`main` or `exports` entry points](https://nodejs.org/api/packages.html#package-entry-points). This
+means that you're importing _compiled code_ instead of source code, and will require the package to
+be constantly rebuilt if changes are made to it.
+
+However, why not simply import source files instead? With path aliases, you can do just that, by
+defining a `paths` alias that maps the `package.json` name to its source files, like so.
+
+```json title="<project>/tsconfig.json"
+{
+  // ...
+  "compilerOptions": {
+    // ...
+    "paths": {
+      // Index import
+      "@scope/name": ["../shared/package/src/index.ts"],
+      // Deep imports
+      "@scope/name/*": ["../shared/package/src/*"]
+    }
+  },
+  "references": [
+    {
+      "path": "../shared/package"
+    }
+  ]
+}
+```
+
+> When using moon, the
+> [`typescript.syncProjectReferencesToPaths`](../config/workspace#syncprojectreferencestopaths)
+> setting will automatically create `paths` based on the local references.
 
 ## Sharing types
 

--- a/website/docs/guides/typescript-project-refs.mdx
+++ b/website/docs/guides/typescript-project-refs.mdx
@@ -6,18 +6,45 @@ toc_max_heading_level: 6
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-asdsds
+> The ultimate in-depth guide for using TypeScript in a monorepo effectively!
 
-## Why use project references?
+How to use TypeScript in a monorepo? What are project references? Why use project references? What
+is the best way to use project references? These are just a handful of questions that are
+_constantly_ asked on Twitter, forums, Stack Overflow, and even your workplace.
 
-- incremental compile
-- boundaries
-- only run on out of date projects
+Based on years of experience managing large-scale frontend repositories, we firmly believe that
+TypeScript project references are the proper solution for effectively scaling TypeScript in a
+monorepo. The official
+[TypeScript documentation on project references](https://www.typescriptlang.org/docs/handbook/project-references.html)
+answers many of these questions, but it basically boils down to the following:
+
+- Project references _enforce project boundaries, disallowing imports_ to arbitrary projects unless
+  they have been referenced explicitly in configuration.
+- It enables TypeScript to _process individual units_, instead of the entire repository as a whole.
+  Perfect for reducing CI and local development times.
+- It supports _incremental compilation_, so only out-of-date or affected projects are processed. The
+  more TypeScript's cache is warmed, the faster it will be.
+
+:::success
+
+If you'd like a real-world repository to reference, our
+[moonrepo/examples](https://github.com/moonrepo/examples) repository utilizes this architecture!
+
+:::
 
 ## Preface
 
-- only typechecking
-- not moon specific
+Before you dive into this questionably long article, we'd like to preface with:
+
+- This article is a living document and will continually be updated with best practices and
+  frequently asked questions. Keep returning to learn more!
+- This article assumes a basic level knowledge of TypeScript and how it works.
+- The architecture outlined in this article assumes that TypeScript is _only_ used for typechecking
+  and _not_ compiling. However, supporting compilation should be as easy as modifying a handful of
+  compiler options.
+- Although this article exists within moon's documentation, it _does not_ require moon. We've kept
+  all implementation details generic enough for it be used in any repository, but have also included
+  many notes on how moon would improve this experience.
 
 ## Configuration
 
@@ -252,7 +279,71 @@ boundary.
 
 #### `tsconfig.*.json`
 
-TODO
+Additional configurations may exist in a project that serve a role outside of typechecking, with one
+such role being _npm package publishing_. These configs are sometimes named `tsconfig.build.json`,
+`tsconfig.types.json`, or `tsconfig.lib.json`. Regardless of what they're called, these configs are
+_optional_, so unless you have a business need for them, you may skip this section.
+
+##### Package publishing
+
+As mentioned previously, these configs may be used for npm packages, primarily for generating
+TypeScript declarations that are mapped through the `package.json`
+[`types` (or `typings`) field](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).
+
+Given this `package.json`...
+
+```json title="<project>/package.json"
+{
+  // ...
+  "types": "./lib/index.d.ts"
+}
+```
+
+Our `tsconfig.build.json` may look like...
+
+```json title="<project>/tsconfig.build.json"
+{
+  "extends": "../../tsconfig.options.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}
+```
+
+Simple right? But why do we need an additional configuration? Why not use the other `tsconfig.json`?
+Great questions! The major reason is that we _only want to publish declarations for source files_,
+and the declarations file structure should match 1:1 with the sources structure. The `tsconfig.json`
+_does not_ guarantee this, as it may include test, config, or arbitrary files, all of which may not
+exist in the sources directory (`src`), and will alter the output to an incorrect directory
+structure. Our `tsconfig.build.json` solves this problem by only including source files, and by
+forcing the source root to `src` using the `rootDir` compiler option.
+
+However, there is a giant caveat with this approach! Because TypeScript utilizes Node.js's module
+resolution, it will reference the declarations defined by the `package.json` `types` or
+[`exports`](#supporting-packagejson-exports) fields, instead of the `outDir` compiler option, and
+the other `tsconfig.json` _does not generate_ these files will exist. This results in TypeScript
+failing to find the appropriate types! To solve this, add the `tsconfig.build.json` as a project
+reference to `tsconfig.json`!
+
+```json title="<project>/tsconfig.json"
+{
+  // ...
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+    // ... others
+  ]
+}
+```
+
+##### Vendor specific
+
+Some vendors, like [Vite](./examples/vite), [Vitest](./examples/vite), and [Astro](./examples/astro)
+may include additional `tsconfig.*.json` files unique to their ecosystem. We suggest following their
+guidelines and implementation when applicable.
 
 ## Running the typechecker
 
@@ -267,6 +358,15 @@ out-of-date.
 From the root of the repository, run `tsc --build --verbose` to typecheck _all_ projects, as defined
 in [tsconfig.json](#tsconfigjson). TypeScript will generate a directed acyclic graph (DAG) and
 compile projects _in order_ so that dependencies and references are resolved correctly.
+
+:::info
+
+Why run TypeScript in the root? Typically you would only want to run against projects, but for
+situations where you need to verify that all projects still work, running in the root is the best
+approach. Some such situations are upgrading TypeScript itself, upgrading global `@types` packages,
+updating shared types, reworking build processes, and more.
+
+:::
 
 ### On an individual project
 
@@ -326,8 +426,9 @@ import utils from ':shared/utils';
 :::info
 
 When using path aliases, we suggest prefixing or suffixing the alias with `:` so that it's apparent
-that it's an alias (this also matches the new `node:` import syntax). Using `@` is problematic as it
-risks a chance of collision with a public npm package and may accidentally open your repository to a
+that it's an alias (this also matches the new `node:` import syntax). Using `@` or no character is
+problematic as it risks a chance of collision with a public npm package and may accidentally open
+your repository to a
 [supply chain attack](https://snyk.io/blog/npm-security-preventing-supply-chain-attacks/). Other
 characters like `~` and `$` have an existing meaning in the ecosystem, so it's best to avoid them
 aswell.
@@ -369,7 +470,27 @@ defining a `paths` alias that maps the `package.json` name to its source files, 
 > [`typescript.syncProjectReferencesToPaths`](../config/workspace#syncprojectreferencestopaths)
 > setting will automatically create `paths` based on the local references.
 
-## Sharing types
+## Sharing and augmenting types
+
+Declaring global types, augmenting node modules, and sharing reusable types is a common practice.
+There are many ways to achieve this, so choose what works best for your repository. We use the
+following pattern with great success.
+
+At the root of the repository, create a `types` folder as a sibling to `tsconfig.json`. This folder
+_must only_ contain declarations (`.d.ts`) files for the following reasons:
+
+- Declarations can be `include`ed in a project without having to be a project reference.
+- Hard-coded declarations _do not_ need to be compiled from TypeScript files.
+
+Based on the above, update your project's `tsconfig.json` to include all of these types, or just
+some of these types.
+
+```json title="<project>/tsconfig.json"
+{
+  // ...
+  "include": ["src/**/*", "../../types/**/*"]
+}
+```
 
 ## Supporting `package.json` exports
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -145,6 +145,7 @@ const sidebars = {
 		'guides/remote-cache',
 		'guides/root-project',
 		'guides/sharing-config',
+		'guides/typescript-project-refs',
 		'guides/webhooks',
 		{
 			type: 'category',

--- a/website/src/components/Home/Hero.tsx
+++ b/website/src/components/Home/Hero.tsx
@@ -3,6 +3,7 @@ import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { faRocketLaunch } from '@fortawesome/pro-duotone-svg-icons';
 import Icon from '../../ui/iconography/Icon';
+import DocLink from '../../ui/typography/Link';
 import HeroTerminal from './HeroTerminal';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -29,7 +30,14 @@ export default function Hero() {
 					</p>
 
 					<p className="mt-1 text-white opacity-50 text-sm md:text-base">
-						Supports JavaScript, TypeScript, Bash, and Batch.
+						Supports JavaScript, TypeScript, Bash, Batch,{' '}
+						<DocLink
+							href="/docs/faq#will-moon-support-other-languages-besides-javascript"
+							variant="muted"
+						>
+							and more
+						</DocLink>
+						.
 					</p>
 
 					<div className="mt-3 flex justify-center lg:justify-start">


### PR DESCRIPTION
This is a common question, that requires a very deep answer. Hopefully this solves everyone's problems with TypeScript in a monorepo.