### PR TITLE
fix: Fix byte out of bounds panic.

### DIFF
--- a/.yarn/versions/38005fb8.yml
+++ b/.yarn/versions/38005fb8.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -781,13 +781,13 @@ mod outputs {
 
             sandbox.enable_git();
 
-            let assert1 = sandbox.run_moon(|cmd| {
+            sandbox.run_moon(|cmd| {
                 cmd.arg("run").arg("outputs:noOutput");
             });
 
             let hash1 = extract_hash_from_run(sandbox.path(), "outputs:noOutput").await;
 
-            let assert2 = sandbox.run_moon(|cmd| {
+            sandbox.run_moon(|cmd| {
                 cmd.arg("run").arg("outputs:noOutput");
             });
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed a "byte index is out of bounds" panic when a task has caching disabled.
+
 ## 0.20.0
 
 #### 💥 Breaking


### PR DESCRIPTION
Ran into this while running against a task that has cache disabled:

```
thread 'tokio-runtime-worker' panicked at 'byte index 8 is out of bounds of ``', crates/core/runner/src/actions/run_target.rs:341:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```