### PR TITLE
new: Allow moon to be installed globally with pnpm and yarn.

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -116,10 +116,9 @@ async fn main() {
             // locally installed `moon` binary in node modules
             if let Some(workspace_root) = find_workspace_root(&current_dir) {
                 let moon_bin = workspace_root
-                    // .join(NODE.vendor_dir)
-                    // .join("@moonrepo")
-                    // .join("cli")
-                    .join("target/debug")
+                    .join(NODE.vendor_dir)
+                    .join("@moonrepo")
+                    .join("cli")
                     .join(BIN_NAME);
 
                 // The binary exists! So let's run that one to ensure

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -11,8 +11,7 @@ use tokio::process::Command;
 static GLOBAL: MiMalloc = MiMalloc;
 
 #[cfg(target_os = "linux")]
-fn get_global_lookups() -> String<PathBuf> {
-    let home_dir = path::get_home_dir().unwrap_or_else(|| PathBuf::from("."));
+fn get_global_lookups(home_dir: &Path) -> Vec<PathBuf> {
     let mut lookups = vec![];
 
     // Node
@@ -24,8 +23,7 @@ fn get_global_lookups() -> String<PathBuf> {
 }
 
 #[cfg(target_os = "macos")]
-fn get_global_lookups() -> String<PathBuf> {
-    let home_dir = path::get_home_dir().unwrap_or_else(|| PathBuf::from("."));
+fn get_global_lookups(home_dir: &Path) -> Vec<PathBuf> {
     let mut lookups = vec![];
 
     // Node
@@ -37,8 +35,7 @@ fn get_global_lookups() -> String<PathBuf> {
 }
 
 #[cfg(target_os = "windows")]
-fn get_global_lookups() -> String<PathBuf> {
-    let home_dir = path::get_home_dir().unwrap_or_else(|| PathBuf::from("."));
+fn get_global_lookups(home_dir: &Path) -> Vec<PathBuf> {
     let mut lookups = vec![];
 
     // Node
@@ -60,11 +57,12 @@ fn is_globally_installed() -> bool {
 
     // Global installs happen *outside* of moon's toolchain,
     // so we simply assume they are using their environment.
-    let lookups = get_global_lookups();
+    let home_dir = path::get_home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let lookups = get_global_lookups(&home_dir);
 
     // If our executable path starts with the global dir,
     // then we must have been installed globally!
-    lookups.any(|lookup| exe_path.starts_with(lookup))
+    lookups.iter().any(|lookup| exe_path.starts_with(lookup))
 }
 
 fn find_workspace_root(dir: &Path) -> Option<PathBuf> {
@@ -118,9 +116,10 @@ async fn main() {
             // locally installed `moon` binary in node modules
             if let Some(workspace_root) = find_workspace_root(&current_dir) {
                 let moon_bin = workspace_root
-                    .join(NODE.vendor_dir)
-                    .join("@moonrepo")
-                    .join("cli")
+                    // .join(NODE.vendor_dir)
+                    // .join("@moonrepo")
+                    // .join("cli")
+                    .join("target/debug")
                     .join(BIN_NAME);
 
                 // The binary exists! So let's run that one to ensure

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -10,35 +10,30 @@ use tokio::process::Command;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
-#[cfg(target_os = "linux")]
+#[cfg(not(windows))]
 fn get_global_lookups(home_dir: &Path) -> Vec<PathBuf> {
     let mut lookups = vec![];
 
     // Node
+    lookups.push("/usr/local/lib/node".into());
     lookups.push(home_dir.join(".nvm/versions/node"));
+    lookups.push(home_dir.join(".nodenv/versions"));
+    lookups.push(home_dir.join(".fnm/node-versions"));
+    lookups.push(home_dir.join("Library/pnpm"));
     lookups.push(home_dir.join(".local/share/pnpm"));
     lookups.push(home_dir.join(".config/yarn"));
 
     lookups
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(windows)]
 fn get_global_lookups(home_dir: &Path) -> Vec<PathBuf> {
     let mut lookups = vec![];
 
     // Node
-    lookups.push(home_dir.join(".nvm/versions/node"));
-    lookups.push(home_dir.join("Library/pnpm"));
-    lookups.push(home_dir.join(".config/yarn"));
-
-    lookups
-}
-
-#[cfg(target_os = "windows")]
-fn get_global_lookups(home_dir: &Path) -> Vec<PathBuf> {
-    let mut lookups = vec![];
-
-    // Node
+    lookups.push(home_dir.join(".nvm\\versions\\node"));
+    lookups.push(home_dir.join(".nodenv\\versions"));
+    lookups.push(home_dir.join(".fnm\\node-versions"));
     lookups.push(home_dir.join("AppData\\npm"));
     lookups.push(home_dir.join("AppData\\Roaming\\npm"));
     lookups.push(home_dir.join("AppData\\Local\\pnpm"));

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- We've rewritten our project graph to use eager-loading instead of lazy-loading to improve
+  performance, and to avoid mutating borrowed data across threads in Rust. We're no longer cloning
+  project information unnecessarily.
+- We've also rewritten our dependency graph in a similar fashion, and are now able to efficiently
+  reference data from the project graph while building the dependency chain.
+- You may now install the `@moonrepo/cli` package globally with pnpm and yarn. When running these
+  globals, the will attempt to use the binary found in the repo's node modules.
+
 ## 0.20.2
 
 #### 🐞 Fixes

--- a/website/docs/install.mdx
+++ b/website/docs/install.mdx
@@ -143,8 +143,7 @@ package at the root of the repository.
 
 For developers, we suggest installing the
 [`@moonrepo/cli`](https://www.npmjs.com/package/@moonrepo/cli) package globally, so that you can
-easily run `moon` commands from _any_ directory, instead of relying on `package.json` scripts. When
-using this approach, the global must be installed with npm (not pnpm or yarn)!
+easily run `moon` commands from _any_ directory, instead of relying on `package.json` scripts.
 
 ```shell
 npm install -g @moonrepo/cli
@@ -155,10 +154,10 @@ executed that was defined as a dependency in the repo.
 
 ### Adding a package script
 
-For other scenarios or environments, like CI, `moon` can be ran with through a `package.json` script
--- but this comes with a cost -- which is the overhead of launching Node.js and your chosen package
-manager to execute the Rust binary, _instead of_ executing the Rust binary directly. If this is
-problematic, feel free to use the global approach above.
+For other scenarios or environments, like CI, `moon` can be ran with through a root `package.json`
+script -- but this comes with a cost -- which is the overhead of launching Node.js and your chosen
+package manager to execute the Rust binary, _instead of_ executing the Rust binary directly. If this
+is problematic, feel free to use the global approach above.
 
 ```json title="package.json"
 {


### PR DESCRIPTION
Previously, we only supported npm and would query `npm config get prefix`. 

To avoid this upfront cost of calling out to npm, we have hard-coded the global lookup paths. This allows us to easily support pnpm and yarn.