### PR TITLE
internal: Make all fs calls synchronous.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,17 +106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,13 +1869,11 @@ dependencies = [
 name = "moon_cli"
 version = "0.20.2"
 dependencies = [
- "async-recursion",
  "clap 4.0.23",
  "clap_lex 0.3.0",
  "console",
  "console-subscriber",
  "dialoguer",
- "futures",
  "indicatif",
  "itertools",
  "mimalloc",
@@ -2012,7 +1999,6 @@ name = "moon_generator"
 version = "0.1.0"
 dependencies = [
  "convert_case",
- "futures",
  "lazy_static",
  "moon_config",
  "moon_constants",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,7 +1843,6 @@ dependencies = [
  "rustc-hash",
  "tar",
  "thiserror",
- "tokio",
  "zip",
 ]
 
@@ -1862,7 +1861,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serial_test",
- "tokio",
 ]
 
 [[package]]
@@ -1934,7 +1932,6 @@ dependencies = [
  "serde_yaml",
  "strum",
  "thiserror",
- "tokio",
  "validator",
 ]
 
@@ -2009,7 +2006,6 @@ dependencies = [
  "serde_json",
  "tera",
  "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -2062,7 +2058,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
- "tokio",
  "yarn-lock-parser",
 ]
 
@@ -2306,7 +2301,6 @@ dependencies = [
  "moon_utils",
  "serde",
  "serde_json",
- "tokio",
 ]
 
 [[package]]
@@ -2373,7 +2367,6 @@ dependencies = [
  "moonbase",
  "reqwest",
  "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,7 +2327,6 @@ dependencies = [
 name = "moon_utils"
 version = "0.1.0"
 dependencies = [
- "async-recursion",
  "cached",
  "chrono",
  "chrono-humanize",
@@ -2335,7 +2334,6 @@ dependencies = [
  "dirs",
  "dunce",
  "ec4rs",
- "futures",
  "humantime",
  "json_comments",
  "lazy_static",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -37,13 +37,11 @@ moon_typescript_lang = { path = "../typescript/lang" }
 moon_utils = { path = "../core/utils" }
 moon_vcs = { path = "../core/vcs" }
 moon_workspace = { path = "../core/workspace" }
-async-recursion = "1.0.0"
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 clap_lex = "0.3.0"
 console = "0.15.2"
 console-subscriber = "0.1.8"
 dialoguer = "0.10.2"
-futures = "0.3.25"
 indicatif = "0.17.2"
 itertools = "0.10.5"
 mimalloc = { version = "0.1.32", default-features = false }

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -14,7 +14,7 @@ const LOG_TARGET: &str = "moon:check";
 
 pub async fn check(project_ids: &Vec<String>, options: CheckOptions) -> Result<(), AnyError> {
     let mut workspace = load_workspace().await?;
-    let project_graph = generate_project_graph(&mut workspace).await?;
+    let project_graph = generate_project_graph(&mut workspace)?;
     let mut projects: Vec<&Project> = vec![];
 
     // Load projects

--- a/crates/cli/src/commands/ci.rs
+++ b/crates/cli/src/commands/ci.rs
@@ -182,7 +182,7 @@ pub struct CiOptions {
 pub async fn ci(options: CiOptions) -> Result<(), AnyError> {
     let mut workspace = load_workspace().await?;
     let ci_provider = get_pipeline_output();
-    let project_graph = generate_project_graph(&mut workspace).await?;
+    let project_graph = generate_project_graph(&mut workspace)?;
     let touched_files = gather_touched_files(&ci_provider, &workspace, &options).await?;
     let targets = gather_runnable_targets(&ci_provider, &project_graph, &touched_files)?;
 

--- a/crates/cli/src/commands/clean.rs
+++ b/crates/cli/src/commands/clean.rs
@@ -13,10 +13,8 @@ pub async fn clean(options: CleanOptions) -> Result<(), AnyError> {
         options.cache_lifetime
     ));
 
-    let (files_deleted, bytes_saved) = workspace
-        .cache
-        .clean_stale_cache(&options.cache_lifetime)
-        .await?;
+    let (files_deleted, bytes_saved) =
+        workspace.cache.clean_stale_cache(&options.cache_lifetime)?;
 
     done(
         format!(

--- a/crates/cli/src/commands/dep_graph.rs
+++ b/crates/cli/src/commands/dep_graph.rs
@@ -4,7 +4,7 @@ use moon_task::Target;
 
 pub async fn dep_graph(target_id: &Option<String>) -> Result<(), AnyError> {
     let mut workspace = load_workspace().await?;
-    let project_graph = generate_project_graph(&mut workspace).await?;
+    let project_graph = generate_project_graph(&mut workspace)?;
     let mut dep_builder = build_dep_graph(&workspace, &project_graph);
 
     // Focus a target and its dependencies/dependents

--- a/crates/cli/src/commands/docker/prune.rs
+++ b/crates/cli/src/commands/docker/prune.rs
@@ -41,17 +41,11 @@ pub async fn prune_node(
         .await?;
 
     // Remove extraneous node module folders for unfocused projects
-    // let mut futures = vec![];
-
     // for project_id in &manifest.unfocused_projects {
     //     if let Some(project_source) = project_graph.sources.get(project_id) {
-    //         futures.push(fs::remove_dir_all(
-    //             workspace.root.join(project_source).join(NODE.vendor_dir),
-    //         ));
+    //         fs::remove_dir_all(workspace.root.join(project_source).join(NODE.vendor_dir))?;
     //     }
     // }
-
-    // try_join_all(futures).await?;
 
     Ok(())
 }

--- a/crates/cli/src/commands/docker/prune.rs
+++ b/crates/cli/src/commands/docker/prune.rs
@@ -1,6 +1,5 @@
 use crate::commands::docker::scaffold::DockerManifest;
 use crate::helpers::AnyError;
-use futures::future::try_join_all;
 use moon::{generate_project_graph, load_workspace_with_toolchain};
 use moon_config::ProjectLanguage;
 use moon_node_lang::{PackageJson, NODE};
@@ -28,15 +27,11 @@ pub async fn prune_node(
     }
 
     // Some package managers do not delete stale node modules
-    let mut futures = vec![fs::remove_dir_all(workspace.root.join(NODE.vendor_dir))];
+    fs::remove_dir_all(workspace.root.join(NODE.vendor_dir))?;
 
     for project_source in project_graph.sources.values() {
-        futures.push(fs::remove_dir_all(
-            workspace.root.join(project_source).join(NODE.vendor_dir),
-        ));
+        fs::remove_dir_all(workspace.root.join(project_source).join(NODE.vendor_dir))?;
     }
-
-    try_join_all(futures).await?;
 
     // Install production only dependencies for focused projects
     let node = toolchain.node.get()?;
@@ -70,7 +65,7 @@ pub async fn prune() -> Result<(), AnyError> {
         safe_exit(1);
     }
 
-    let project_graph = generate_project_graph(&mut workspace).await?;
+    let project_graph = generate_project_graph(&mut workspace)?;
     let manifest: DockerManifest = json::read(manifest_path)?;
     let mut is_using_node = false;
 

--- a/crates/cli/src/commands/generate.rs
+++ b/crates/cli/src/commands/generate.rs
@@ -328,7 +328,7 @@ pub async fn generate(name: &str, options: GenerateOptions) -> Result<(), AnyErr
     }
 
     // Create the template instance
-    let mut template = generator.load_template(name).await?;
+    let mut template = generator.load_template(name)?;
     let term = Term::buffered_stdout();
 
     term.write_line("")?;
@@ -376,7 +376,7 @@ pub async fn generate(name: &str, options: GenerateOptions) -> Result<(), AnyErr
     context.insert("workspace_root", &workspace.root);
 
     // Load template files and determine when to overwrite
-    template.load_files(&dest, &context).await?;
+    template.load_files(&dest, &context)?;
 
     for file in &mut template.files {
         if file.is_skipped() {

--- a/crates/cli/src/commands/generate.rs
+++ b/crates/cli/src/commands/generate.rs
@@ -312,7 +312,7 @@ pub async fn generate(name: &str, options: GenerateOptions) -> Result<(), AnyErr
 
     // This is a special case for creating a new template with the generator itself!
     if options.template {
-        let template = generator.create_template(name).await?;
+        let template = generator.create_template(name)?;
 
         println!(
             "Created a new template {} at {}",
@@ -431,7 +431,7 @@ pub async fn generate(name: &str, options: GenerateOptions) -> Result<(), AnyErr
 
     // Generate the files in the destination and print the results
     if !options.dry_run {
-        generator.generate(&template).await?;
+        generator.generate(&template)?;
     }
 
     term.write_line("")?;

--- a/crates/cli/src/commands/init/mod.rs
+++ b/crates/cli/src/commands/init/mod.rs
@@ -58,7 +58,7 @@ pub struct InitOptions {
 
 /// Verify the destination and return a path to the `.moon` folder
 /// if all questions have passed.
-async fn verify_dest_dir(
+fn verify_dest_dir(
     dest_dir: &Path,
     options: &InitOptions,
     theme: &ColorfulTheme,
@@ -79,7 +79,7 @@ async fn verify_dest_dir(
             return Ok(None);
         }
 
-        fs::create_dir_all(&moon_dir).await?;
+        fs::create_dir_all(&moon_dir)?;
 
         return Ok(Some(moon_dir));
     }
@@ -148,7 +148,7 @@ pub async fn init(
     }
 
     // Extract template variables
-    let Some(moon_dir) = verify_dest_dir(&dest_dir, &options, &theme).await? else {
+    let Some(moon_dir) = verify_dest_dir(&dest_dir, &options, &theme)? else {
         return Ok(())
     };
     let mut context = create_default_context();
@@ -189,20 +189,17 @@ pub async fn init(
             .map(|c| c.trim().to_owned())
             .collect::<Vec<String>>()
             .join("\n\n"),
-    )
-    .await?;
+    )?;
 
     fs::write(
         &moon_dir.join(CONFIG_WORKSPACE_FILENAME),
         render_workspace_template(&context)?,
-    )
-    .await?;
+    )?;
 
     fs::write(
         &moon_dir.join(CONFIG_GLOBAL_PROJECT_FILENAME),
         Tera::one_off(load_global_project_config_template(), &context, false)?,
-    )
-    .await?;
+    )?;
 
     // Append to ignore file
     let mut file = OpenOptions::new()

--- a/crates/cli/src/commands/init/node.rs
+++ b/crates/cli/src/commands/init/node.rs
@@ -24,11 +24,10 @@ pub fn render_template(context: Context) -> Result<String, Error> {
 
 /// Detect the Node.js version from local configuration files,
 /// otherwise fallback to the configuration default.
-async fn detect_node_version(dest_dir: &Path) -> Result<(String, String), AnyError> {
+fn detect_node_version(dest_dir: &Path) -> Result<(String, String), AnyError> {
     if is_using_version_manager(dest_dir, &NVMRC) {
         return Ok((
-            fs::read(dest_dir.join(NVMRC.version_filename))
-                .await?
+            fs::read(dest_dir.join(NVMRC.version_filename))?
                 .trim()
                 .to_owned(),
             NVMRC.binary.to_owned(),
@@ -37,8 +36,7 @@ async fn detect_node_version(dest_dir: &Path) -> Result<(String, String), AnyErr
 
     if is_using_version_manager(dest_dir, &NODENV) {
         return Ok((
-            fs::read(dest_dir.join(NODENV.version_filename))
-                .await?
+            fs::read(dest_dir.join(NODENV.version_filename))?
                 .trim()
                 .to_owned(),
             NODENV.binary.to_owned(),
@@ -50,7 +48,7 @@ async fn detect_node_version(dest_dir: &Path) -> Result<(String, String), AnyErr
 
 /// Verify the package manager to use. If a `package.json` exists,
 /// and the `packageManager` field is defined, use that.
-async fn detect_package_manager(
+fn detect_package_manager(
     dest_dir: &Path,
     options: &InitOptions,
     theme: &ColorfulTheme,
@@ -118,7 +116,7 @@ async fn detect_package_manager(
 
 // Detect potential projects (for existing repos only) by
 // inspecting the `workspaces` field in a root `package.json`.
-async fn detect_projects(
+fn detect_projects(
     dest_dir: &Path,
     options: &InitOptions,
     parent_context: &mut Context,
@@ -191,11 +189,11 @@ pub async fn init_node(
         println!("\n{}\n", label_header("Node"));
     }
 
-    let node_version = detect_node_version(dest_dir).await?;
-    let package_manager = detect_package_manager(dest_dir, options, theme).await?;
+    let node_version = detect_node_version(dest_dir)?;
+    let package_manager = detect_package_manager(dest_dir, options, theme)?;
 
     if let Some(parent_context) = parent_context {
-        detect_projects(dest_dir, options, parent_context, theme).await?;
+        detect_projects(dest_dir, options, parent_context, theme)?;
     }
 
     let alias_names = if options.yes {

--- a/crates/cli/src/commands/migrate/from_package_json.rs
+++ b/crates/cli/src/commands/migrate/from_package_json.rs
@@ -152,7 +152,7 @@ pub async fn from_package_json(
     };
 
     // Create a mapping of `package.json` names to project IDs
-    let project_graph = generate_project_graph(&mut workspace).await?;
+    let project_graph = generate_project_graph(&mut workspace)?;
     let mut package_map: FxHashMap<String, String> = FxHashMap::default();
 
     for project in project_graph.get_all()? {

--- a/crates/cli/src/commands/node/run_script.rs
+++ b/crates/cli/src/commands/node/run_script.rs
@@ -16,7 +16,7 @@ pub async fn run_script(name: &str, project: &Option<String>) -> Result<(), AnyE
 
         // Otherwise try and find the project in the graph
     } else if let Some(project_id) = project {
-        let mut project_graph = build_project_graph(&mut workspace).await?;
+        let mut project_graph = build_project_graph(&mut workspace)?;
         project_graph.load(project_id)?;
 
         command.cwd(&project_graph.build().get(project_id)?.root);

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -8,7 +8,7 @@ use moon_utils::is_test_env;
 
 pub async fn project(id: &str, json: bool) -> Result<(), AnyError> {
     let mut workspace = load_workspace().await?;
-    let mut project_builder = build_project_graph(&mut workspace).await?;
+    let mut project_builder = build_project_graph(&mut workspace)?;
     project_builder.load(id)?;
 
     let project_graph = project_builder.build();

--- a/crates/cli/src/commands/project_graph.rs
+++ b/crates/cli/src/commands/project_graph.rs
@@ -3,7 +3,7 @@ use moon::{build_project_graph, load_workspace};
 
 pub async fn project_graph(project_id: &Option<String>) -> Result<(), AnyError> {
     let mut workspace = load_workspace().await?;
-    let mut project_build = build_project_graph(&mut workspace).await?;
+    let mut project_build = build_project_graph(&mut workspace)?;
 
     if let Some(id) = project_id {
         project_build.load(id)?;

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -121,7 +121,7 @@ pub async fn run_target(
 
 pub async fn run(target_ids: &[String], options: RunOptions) -> Result<(), AnyError> {
     let mut workspace = load_workspace().await?;
-    let project_graph = generate_project_graph(&mut workspace).await?;
+    let project_graph = generate_project_graph(&mut workspace)?;
 
     run_target(target_ids, options, workspace, project_graph).await?;
 

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -8,7 +8,7 @@ pub async fn setup() -> Result<(), AnyError> {
     let done = create_progress_bar("Downloading and installing tools...");
 
     let mut workspace = load_workspace().await?;
-    let project_graph = generate_project_graph(&mut workspace).await?;
+    let project_graph = generate_project_graph(&mut workspace)?;
     let mut dep_builder = build_dep_graph(&workspace, &project_graph);
 
     if let Some(node) = &workspace.toolchain.config.node {

--- a/crates/cli/src/commands/sync.rs
+++ b/crates/cli/src/commands/sync.rs
@@ -6,7 +6,7 @@ pub async fn sync() -> Result<(), AnyError> {
     let done = create_progress_bar("Syncing projects...");
 
     let mut workspace = load_workspace().await?;
-    let project_graph = generate_project_graph(&mut workspace).await?;
+    let project_graph = generate_project_graph(&mut workspace)?;
     let mut project_count = 0;
     let mut dep_builder = build_dep_graph(&workspace, &project_graph);
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -12,34 +12,30 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 #[cfg(not(windows))]
 fn get_global_lookups(home_dir: &Path) -> Vec<PathBuf> {
-    let mut lookups = vec![];
-
-    // Node
-    lookups.push("/usr/local/lib/node".into());
-    lookups.push(home_dir.join(".nvm/versions/node"));
-    lookups.push(home_dir.join(".nodenv/versions"));
-    lookups.push(home_dir.join(".fnm/node-versions"));
-    lookups.push(home_dir.join("Library/pnpm"));
-    lookups.push(home_dir.join(".local/share/pnpm"));
-    lookups.push(home_dir.join(".config/yarn"));
-
-    lookups
+    vec![
+        // Node
+        "/usr/local/lib/node".into(),
+        home_dir.join(".nvm/versions/node"),
+        home_dir.join(".nodenv/versions"),
+        home_dir.join(".fnm/node-versions"),
+        home_dir.join("Library/pnpm"),
+        home_dir.join(".local/share/pnpm"),
+        home_dir.join(".config/yarn"),
+    ]
 }
 
 #[cfg(windows)]
 fn get_global_lookups(home_dir: &Path) -> Vec<PathBuf> {
-    let mut lookups = vec![];
-
-    // Node
-    lookups.push(home_dir.join(".nvm\\versions\\node"));
-    lookups.push(home_dir.join(".nodenv\\versions"));
-    lookups.push(home_dir.join(".fnm\\node-versions"));
-    lookups.push(home_dir.join("AppData\\npm"));
-    lookups.push(home_dir.join("AppData\\Roaming\\npm"));
-    lookups.push(home_dir.join("AppData\\Local\\pnpm"));
-    lookups.push(home_dir.join("AppData\\Yarn\\config"));
-
-    lookups
+    vec![
+        // Node
+        home_dir.join(".nvm\\versions\\node"),
+        home_dir.join(".nodenv\\versions"),
+        home_dir.join(".fnm\\node-versions"),
+        home_dir.join("AppData\\npm"),
+        home_dir.join("AppData\\Roaming\\npm"),
+        home_dir.join("AppData\\Local\\pnpm"),
+        home_dir.join("AppData\\Yarn\\config"),
+    ]
 }
 
 /// Check whether this binary has been installed globally or not.

--- a/crates/cli/src/queries/projects.rs
+++ b/crates/cli/src/queries/projects.rs
@@ -91,7 +91,7 @@ pub async fn query_projects(
         None
     };
 
-    let project_graph = generate_project_graph(workspace).await?;
+    let project_graph = generate_project_graph(workspace)?;
     let mut projects = vec![];
 
     for project in project_graph.get_all()? {

--- a/crates/cli/tests/run_system_test.rs
+++ b/crates/cli/tests/run_system_test.rs
@@ -214,8 +214,8 @@ mod unix {
                 .exists());
         }
 
-        #[tokio::test]
-        async fn creates_run_state_cache() {
+        #[test]
+        fn creates_run_state_cache() {
             let sandbox = system_sandbox();
 
             sandbox.run_moon(|cmd| {
@@ -228,7 +228,7 @@ mod unix {
 
             assert!(cache_path.exists());
 
-            let state = RunTargetState::load(cache_path, 0).await.unwrap();
+            let state = RunTargetState::load(cache_path, 0).unwrap();
 
             assert_snapshot!(fs::read_to_string(
                 sandbox
@@ -472,8 +472,8 @@ mod system_windows {
                 .exists());
         }
 
-        #[tokio::test]
-        async fn creates_run_state_cache() {
+        #[test]
+        fn creates_run_state_cache() {
             let sandbox = system_sandbox();
 
             sandbox.run_moon(|cmd| {
@@ -486,7 +486,7 @@ mod system_windows {
 
             assert!(cache_path.exists());
 
-            let state = RunTargetState::load(cache_path, 0).await.unwrap();
+            let state = RunTargetState::load(cache_path, 0).unwrap();
 
             assert_snapshot!(fs::read_to_string(
                 sandbox

--- a/crates/core/archive/Cargo.toml
+++ b/crates/core/archive/Cargo.toml
@@ -18,7 +18,6 @@ flate2 = "1.0.25"
 rustc-hash = { workspace = true }
 tar = "0.4.38"
 thiserror = { workspace = true }
-tokio = { workspace = true }
 zip = "0.6.3"
 
 [dev-dependencies]

--- a/crates/core/archive/benches/tar_benchmark.rs
+++ b/crates/core/archive/benches/tar_benchmark.rs
@@ -65,14 +65,11 @@ pub fn tar_diff_benchmark(c: &mut Criterion) {
     tar(&sources_dir, &dirs, &archive_file, None).unwrap();
 
     c.bench_function("tar_diff", |b| {
-        b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter(|| async {
-                let mut diff = TreeDiffer::load(&sources_dir, &dirs).unwrap();
+        b.iter(|| {
+            let mut diff = TreeDiffer::load(&sources_dir, &dirs).unwrap();
 
-                untar_with_diff(&mut diff, &archive_file, &sources_dir, None)
-                    .await
-                    .unwrap();
-            })
+            untar_with_diff(&mut diff, &archive_file, &sources_dir, None).unwrap();
+        })
     });
 }
 
@@ -82,16 +79,13 @@ pub fn tar_diff_remove_benchmark(c: &mut Criterion) {
     tar(&sources_dir, &dirs, &archive_file, None).unwrap();
 
     c.bench_function("tar_diff_remove", |b| {
-        b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter(|| async {
-                fs::remove_dir_all(&sources_dir).unwrap();
+        b.iter(|| {
+            fs::remove_dir_all(&sources_dir).unwrap();
 
-                let mut diff = TreeDiffer::load(&sources_dir, &dirs).unwrap();
+            let mut diff = TreeDiffer::load(&sources_dir, &dirs).unwrap();
 
-                untar_with_diff(&mut diff, &archive_file, &sources_dir, None)
-                    .await
-                    .unwrap();
-            })
+            untar_with_diff(&mut diff, &archive_file, &sources_dir, None).unwrap();
+        })
     });
 }
 

--- a/crates/core/archive/src/tar.rs
+++ b/crates/core/archive/src/tar.rs
@@ -183,7 +183,7 @@ pub fn untar<I: AsRef<Path>, O: AsRef<Path>>(
 }
 
 #[track_caller]
-pub async fn untar_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
+pub fn untar_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
     differ: &mut TreeDiffer,
     input_file: I,
     output_dir: O,

--- a/crates/core/archive/src/zip.rs
+++ b/crates/core/archive/src/zip.rs
@@ -170,7 +170,7 @@ pub fn unzip<I: AsRef<Path>, O: AsRef<Path>>(
 
 // Uncomment when needed!
 // #[track_caller]
-// pub async fn unzip_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
+// pub fn unzip_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
 //     differ: &mut TreeDiffer,
 //     input_file: I,
 //     output_dir: O,
@@ -245,7 +245,7 @@ pub fn unzip<I: AsRef<Path>, O: AsRef<Path>>(
 //         }
 //     }
 
-//     differ.remove_stale_tracked_files().await?;
+//     differ.remove_stale_tracked_files()?;
 
 //     Ok(())
 // }

--- a/crates/core/cache/Cargo.toml
+++ b/crates/core/cache/Cargo.toml
@@ -17,4 +17,3 @@ serde = { workspace = true }
 moon_test_utils = { path = "../test-utils" }
 filetime = "0.2.18"
 serial_test = "0.9.0"
-tokio = { workspace = true }

--- a/crates/core/cache/src/item.rs
+++ b/crates/core/cache/src/item.rs
@@ -2,12 +2,12 @@
 macro_rules! cache_item {
     ($struct:ident) => {
         impl $struct {
-            pub async fn load(path: PathBuf, stale_ms: u128) -> Result<Self, MoonError> {
+            pub fn load(path: PathBuf, stale_ms: u128) -> Result<Self, MoonError> {
                 let mut item = Self::default();
                 let log_target = "moon:cache:item";
 
                 if let Some(parent) = path.parent() {
-                    fs::create_dir_all(parent).await?;
+                    fs::create_dir_all(parent)?;
                 }
 
                 if is_readable() {
@@ -15,7 +15,7 @@ macro_rules! cache_item {
                         // If stale, treat as a cache miss
                         if stale_ms > 0
                             && time::now_millis()
-                                - time::to_millis(fs::metadata(&path).await?.modified().unwrap())
+                                - time::to_millis(fs::metadata(&path)?.modified().unwrap())
                                 > stale_ms
                         {
                             trace!(
@@ -46,7 +46,7 @@ macro_rules! cache_item {
                 Ok(item)
             }
 
-            pub async fn save(&self) -> Result<(), MoonError> {
+            pub fn save(&self) -> Result<(), MoonError> {
                 let log_target = "moon:cache:item";
 
                 if is_writable() {

--- a/crates/core/cache/src/items/run_target_state.rs
+++ b/crates/core/cache/src/items/run_target_state.rs
@@ -25,7 +25,7 @@ pub struct RunTargetState {
 cache_item!(RunTargetState);
 
 impl RunTargetState {
-    pub async fn archive_outputs(
+    pub fn archive_outputs(
         &self,
         archive_file: &Path,
         input_root: &Path,
@@ -60,7 +60,7 @@ impl RunTargetState {
         Ok(false)
     }
 
-    pub async fn hydrate_outputs(
+    pub fn hydrate_outputs(
         &self,
         archive_file: &Path,
         project_root: &Path,
@@ -70,7 +70,6 @@ impl RunTargetState {
             let mut differ = TreeDiffer::load(project_root, outputs)?;
 
             untar_with_diff(&mut differ, archive_file, project_root, None)
-                .await
                 .map_err(|e| MoonError::Generic(e.to_string()))?;
 
             let cache_logs = self.get_output_logs();

--- a/crates/core/cache/src/items/run_target_state.rs
+++ b/crates/core/cache/src/items/run_target_state.rs
@@ -78,11 +78,11 @@ impl RunTargetState {
             let stderr_log = project_root.join("stderr.log");
 
             if stdout_log.exists() {
-                fs::rename(&stdout_log, cache_logs.0).await?;
+                fs::rename(&stdout_log, cache_logs.0)?;
             }
 
             if stderr_log.exists() {
-                fs::rename(&stderr_log, cache_logs.1).await?;
+                fs::rename(&stderr_log, cache_logs.1)?;
             }
 
             return Ok(true);
@@ -99,17 +99,17 @@ impl RunTargetState {
     }
 
     /// Load the stdout.log and stderr.log files from the cache directory.
-    pub async fn load_output_logs(&self) -> Result<(String, String), MoonError> {
+    pub fn load_output_logs(&self) -> Result<(String, String), MoonError> {
         let (stdout_path, stderr_path) = self.get_output_logs();
 
         let stdout = if stdout_path.exists() {
-            fs::read(stdout_path).await?
+            fs::read(stdout_path)?
         } else {
             String::new()
         };
 
         let stderr = if stderr_path.exists() {
-            fs::read(stderr_path).await?
+            fs::read(stderr_path)?
         } else {
             String::new()
         };
@@ -118,11 +118,11 @@ impl RunTargetState {
     }
 
     /// Write stdout and stderr log files to the cache directory.
-    pub async fn save_output_logs(&self, stdout: String, stderr: String) -> Result<(), MoonError> {
+    pub fn save_output_logs(&self, stdout: String, stderr: String) -> Result<(), MoonError> {
         let (stdout_path, stderr_path) = self.get_output_logs();
 
-        fs::write(stdout_path, stdout).await?;
-        fs::write(stderr_path, stderr).await?;
+        fs::write(stdout_path, stdout)?;
+        fs::write(stderr_path, stderr)?;
 
         Ok(())
     }

--- a/crates/core/cache/src/runfiles.rs
+++ b/crates/core/cache/src/runfiles.rs
@@ -10,13 +10,13 @@ pub struct Runfile {
 }
 
 impl Runfile {
-    pub async fn load<T: DeserializeOwned + Serialize>(
+    pub fn load<T: DeserializeOwned + Serialize>(
         path: PathBuf,
         data: &T,
     ) -> Result<Runfile, MoonError> {
         trace!(target: "moon:cache:runfile", "Writing runfile {}", color::path(&path));
 
-        fs::create_dir_all(path.parent().unwrap()).await?;
+        fs::create_dir_all(path.parent().unwrap())?;
 
         // Always write a runfile, regardless of MOON_CACHE,
         // since consumers expect this to exist at runtime

--- a/crates/core/config/Cargo.toml
+++ b/crates/core/config/Cargo.toml
@@ -30,4 +30,3 @@ validator = { version = "0.16.0", features = ["derive"] }
 
 [dev-dependencies]
 moon_test_utils = { path = "../test-utils" }
-tokio = { workspace = true }

--- a/crates/core/dep-graph/benches/dep_graph_benchmark.rs
+++ b/crates/core/dep-graph/benches/dep_graph_benchmark.rs
@@ -17,7 +17,7 @@ pub fn build_benchmark(c: &mut Criterion) {
         b.to_async(tokio::runtime::Runtime::new().unwrap())
             .iter(|| async {
                 let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-                let project_graph = generate_project_graph(&mut workspace).await.unwrap();
+                let project_graph = generate_project_graph(&mut workspace).unwrap();
                 let mut dep_graph = build_dep_graph(&workspace, &project_graph);
 
                 dep_graph

--- a/crates/core/dep-graph/tests/dep_graph_test.rs
+++ b/crates/core/dep-graph/tests/dep_graph_test.rs
@@ -56,7 +56,7 @@ async fn create_project_graph() -> (Workspace, ProjectGraph, Sandbox) {
     );
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-    let project_graph = generate_project_graph(&mut workspace).await.unwrap();
+    let project_graph = generate_project_graph(&mut workspace).unwrap();
 
     (workspace, project_graph, sandbox)
 }
@@ -104,7 +104,7 @@ async fn create_tasks_project_graph() -> (Workspace, ProjectGraph, Sandbox) {
     );
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-    let project_graph = generate_project_graph(&mut workspace).await.unwrap();
+    let project_graph = generate_project_graph(&mut workspace).unwrap();
 
     (workspace, project_graph, sandbox)
 }

--- a/crates/core/emitter/benches/emitter_benchmark.rs
+++ b/crates/core/emitter/benches/emitter_benchmark.rs
@@ -25,7 +25,7 @@ pub fn emit_benchmark(c: &mut Criterion) {
 
     c.bench_function("emitter_emit", |b| {
         b.to_async(&runtime).iter(|| async {
-            let workspace = Workspace::load_from(&workspace_root).await.unwrap();
+            let workspace = Workspace::load_from(&workspace_root).unwrap();
             let emitter = Emitter::new(Arc::new(RwLock::new(workspace)));
 
             emitter

--- a/crates/core/generator/Cargo.toml
+++ b/crates/core/generator/Cargo.toml
@@ -17,4 +17,3 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 moon_test_utils = { path = "../test-utils" }
-tokio = { workspace = true }

--- a/crates/core/generator/Cargo.toml
+++ b/crates/core/generator/Cargo.toml
@@ -10,7 +10,6 @@ moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }
 moon_utils = { path = "../utils" }
 convert_case = "0.6.0"
-futures = "0.3.25"
 lazy_static = "1.4.0"
 serde_json = { workspace = true }
 tera = { version = "1.17.1", features = ["preserve_order"] }

--- a/crates/core/generator/src/generator.rs
+++ b/crates/core/generator/src/generator.rs
@@ -56,7 +56,7 @@ impl Generator {
 
     /// Load the template with the provided name, using the first match amongst
     /// the list of template paths. Will error if no match is found.
-    pub async fn load_template(&self, name: &str) -> Result<Template, GeneratorError> {
+    pub fn load_template(&self, name: &str) -> Result<Template, GeneratorError> {
         let name = clean_id(name);
 
         trace!(

--- a/crates/core/generator/src/template.rs
+++ b/crates/core/generator/src/template.rs
@@ -275,7 +275,7 @@ impl Template {
     }
 
     /// Write the template file to the defined destination path.
-    pub async fn write_file(&self, file: &TemplateFile) -> Result<(), GeneratorError> {
+    pub fn write_file(&self, file: &TemplateFile) -> Result<(), GeneratorError> {
         match file.state {
             FileState::Merge => {
                 trace!(
@@ -303,7 +303,7 @@ impl Template {
             }
         }
 
-        fs::create_dir_all(file.dest_path.parent().unwrap()).await?;
+        fs::create_dir_all(file.dest_path.parent().unwrap())?;
 
         if matches!(file.state, FileState::Merge) {
             match file.is_mergeable() {
@@ -322,7 +322,7 @@ impl Template {
                 _ => {}
             }
         } else {
-            fs::write(&file.dest_path, &file.content).await?;
+            fs::write(&file.dest_path, &file.content)?;
         }
 
         Ok(())

--- a/crates/core/generator/src/template.rs
+++ b/crates/core/generator/src/template.rs
@@ -185,11 +185,7 @@ impl Template {
 
     /// Load all template files from the source directory and return a list
     /// of template file structs. These will later be used for rendering and generating.
-    pub async fn load_files(
-        &mut self,
-        dest: &Path,
-        context: &Context,
-    ) -> Result<(), GeneratorError> {
+    pub fn load_files(&mut self, dest: &Path, context: &Context) -> Result<(), GeneratorError> {
         let mut files = vec![];
 
         for entry in fs::read_dir_all(&self.root)? {

--- a/crates/core/generator/tests/generator_test.rs
+++ b/crates/core/generator/tests/generator_test.rs
@@ -6,26 +6,24 @@ use moon_utils::string_vec;
 mod create_template {
     use super::*;
 
-    #[tokio::test]
+    #[test]
     #[should_panic(expected = "ExistingTemplate(\"standard\"")]
-    async fn errors_if_already_exists() {
+    fn errors_if_already_exists() {
         let sandbox = create_sandbox("generator");
 
         Generator::load(sandbox.path(), &GeneratorConfig::default())
             .unwrap()
             .create_template("standard")
-            .await
             .unwrap();
     }
 
-    #[tokio::test]
-    async fn creates_the_template() {
+    #[test]
+    fn creates_the_template() {
         let sandbox = create_sandbox("generator");
 
         let template = Generator::load(sandbox.path(), &GeneratorConfig::default())
             .unwrap()
             .create_template("new-template")
-            .await
             .unwrap();
 
         assert!(sandbox.path().join("templates/new-template").exists());
@@ -38,8 +36,8 @@ mod create_template {
         assert_eq!(template.root, sandbox.path().join("templates/new-template"));
     }
 
-    #[tokio::test]
-    async fn creates_the_template_from_another_dir() {
+    #[test]
+    fn creates_the_template_from_another_dir() {
         let sandbox = create_sandbox("generator");
 
         let template = Generator::load(
@@ -50,7 +48,6 @@ mod create_template {
         )
         .unwrap()
         .create_template("new-template")
-        .await
         .unwrap();
 
         assert!(sandbox.path().join("scaffolding/new-template").exists());
@@ -66,14 +63,13 @@ mod create_template {
         );
     }
 
-    #[tokio::test]
-    async fn cleans_and_formats_the_name() {
+    #[test]
+    fn cleans_and_formats_the_name() {
         let sandbox = create_sandbox("generator");
 
         let template = Generator::load(sandbox.path(), &GeneratorConfig::default())
             .unwrap()
             .create_template("so&me temPlatE- with Ran!dom-Valu^es 123_")
-            .await
             .unwrap();
 
         assert!(sandbox

--- a/crates/core/generator/tests/template_test.rs
+++ b/crates/core/generator/tests/template_test.rs
@@ -26,13 +26,12 @@ fn create_context() -> TemplateContext {
 mod load_files {
     use super::*;
 
-    #[tokio::test]
-    async fn filters_out_schema_file() {
+    #[test]
+    fn filters_out_schema_file() {
         let mut template = create_template();
 
         template
             .load_files(&get_fixtures_path("generator"), &create_context())
-            .await
             .unwrap();
 
         let has_schema = template

--- a/crates/core/moon/src/lib.rs
+++ b/crates/core/moon/src/lib.rs
@@ -19,7 +19,7 @@ pub fn register_platforms(workspace: &mut Workspace) {
 
 /// Loads the workspace from the current working directory.
 pub async fn load_workspace() -> Result<Workspace, WorkspaceError> {
-    let mut workspace = Workspace::load().await?;
+    let mut workspace = Workspace::load()?;
 
     register_platforms(&mut workspace);
 
@@ -32,7 +32,7 @@ pub async fn load_workspace() -> Result<Workspace, WorkspaceError> {
 
 /// Loads the workspace from a provided directory.
 pub async fn load_workspace_from(path: &Path) -> Result<Workspace, WorkspaceError> {
-    let mut workspace = Workspace::load_from(path).await?;
+    let mut workspace = Workspace::load_from(path)?;
 
     register_platforms(&mut workspace);
 
@@ -75,9 +75,7 @@ pub fn build_dep_graph<'g>(
     DepGraphBuilder::new(&workspace.platforms, project_graph)
 }
 
-pub async fn build_project_graph(
-    workspace: &mut Workspace,
-) -> Result<ProjectGraphBuilder, ProjectError> {
+pub fn build_project_graph(workspace: &mut Workspace) -> Result<ProjectGraphBuilder, ProjectError> {
     ProjectGraphBuilder::new(
         &workspace.cache,
         &workspace.projects_config,
@@ -85,13 +83,10 @@ pub async fn build_project_graph(
         &workspace.config,
         &workspace.root,
     )
-    .await
 }
 
-pub async fn generate_project_graph(
-    workspace: &mut Workspace,
-) -> Result<ProjectGraph, ProjectError> {
-    let mut builder = build_project_graph(workspace).await?;
+pub fn generate_project_graph(workspace: &mut Workspace) -> Result<ProjectGraph, ProjectError> {
+    let mut builder = build_project_graph(workspace)?;
 
     builder.load_all()?;
 

--- a/crates/core/project-graph/benches/project_graph_benchmark.rs
+++ b/crates/core/project-graph/benches/project_graph_benchmark.rs
@@ -16,7 +16,7 @@ pub fn get_benchmark(c: &mut Criterion) {
         b.to_async(tokio::runtime::Runtime::new().unwrap())
             .iter(|| async {
                 let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-                let graph = generate_project_graph(&mut workspace).await.unwrap();
+                let graph = generate_project_graph(&mut workspace).unwrap();
 
                 for _ in 0..1000 {
                     graph.get("base").unwrap();
@@ -39,7 +39,7 @@ pub fn get_all_benchmark(c: &mut Criterion) {
         b.to_async(tokio::runtime::Runtime::new().unwrap())
             .iter(|| async {
                 let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-                let graph = generate_project_graph(&mut workspace).await.unwrap();
+                let graph = generate_project_graph(&mut workspace).unwrap();
 
                 for _ in 0..1000 {
                     graph.get_all().unwrap();

--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -28,7 +28,7 @@ pub struct ProjectGraphBuilder<'ws> {
 }
 
 impl<'ws> ProjectGraphBuilder<'ws> {
-    pub async fn new(
+    pub fn new(
         cache: &'ws CacheEngine,
         config: &'ws GlobalProjectConfig,
         platforms: &'ws mut PlatformManager,
@@ -49,8 +49,8 @@ impl<'ws> ProjectGraphBuilder<'ws> {
             workspace_root,
         };
 
-        graph.load_sources().await?;
-        graph.load_aliases().await?;
+        graph.load_sources()?;
+        graph.load_aliases()?;
 
         Ok(graph)
     }
@@ -197,7 +197,7 @@ impl<'ws> ProjectGraphBuilder<'ws> {
         Ok(node_index)
     }
 
-    async fn load_aliases(&mut self) -> Result<(), ProjectError> {
+    fn load_aliases(&mut self) -> Result<(), ProjectError> {
         for platform in self.platforms.list_mut() {
             platform.load_project_graph_aliases(&self.sources, &mut self.aliases)?;
         }
@@ -205,7 +205,7 @@ impl<'ws> ProjectGraphBuilder<'ws> {
         Ok(())
     }
 
-    async fn load_sources(&mut self) -> Result<(), ProjectError> {
+    fn load_sources(&mut self) -> Result<(), ProjectError> {
         let mut globs = vec![];
         let mut sources = FxHashMap::default();
 
@@ -227,7 +227,7 @@ impl<'ws> ProjectGraphBuilder<'ws> {
 
         // Only check the cache when using globs
         if !globs.is_empty() {
-            let mut cache = self.cache.cache_projects_state().await?;
+            let mut cache = self.cache.cache_projects_state()?;
 
             // Return the values from the cache
             if !cache.projects.is_empty() {
@@ -250,7 +250,7 @@ impl<'ws> ProjectGraphBuilder<'ws> {
             // Update the cache
             cache.globs = globs.clone();
             cache.projects = sources.clone();
-            cache.save().await?;
+            cache.save()?;
         }
 
         debug!(

--- a/crates/core/project-graph/tests/project_graph_test.rs
+++ b/crates/core/project-graph/tests/project_graph_test.rs
@@ -20,7 +20,7 @@ async fn get_aliases_graph() -> (ProjectGraph, Sandbox) {
     );
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-    let graph = generate_project_graph(&mut workspace).await.unwrap();
+    let graph = generate_project_graph(&mut workspace).unwrap();
 
     (graph, sandbox)
 }
@@ -44,7 +44,7 @@ async fn get_dependencies_graph() -> (ProjectGraph, Sandbox) {
     );
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-    let graph = generate_project_graph(&mut workspace).await.unwrap();
+    let graph = generate_project_graph(&mut workspace).unwrap();
 
     (graph, sandbox)
 }
@@ -68,7 +68,7 @@ async fn get_dependents_graph() -> (ProjectGraph, Sandbox) {
     );
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-    let graph = generate_project_graph(&mut workspace).await.unwrap();
+    let graph = generate_project_graph(&mut workspace).unwrap();
 
     (graph, sandbox)
 }
@@ -89,7 +89,7 @@ async fn can_use_map_and_globs_setting() {
     let sandbox = create_sandbox_with_config("projects", Some(&workspace_config), None, None);
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-    let graph = generate_project_graph(&mut workspace).await.unwrap();
+    let graph = generate_project_graph(&mut workspace).unwrap();
 
     assert_eq!(
         graph.sources,
@@ -120,7 +120,7 @@ mod globs {
         sandbox.create_file("node_modules/moon/package.json", "{}");
 
         let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-        let graph = generate_project_graph(&mut workspace).await.unwrap();
+        let graph = generate_project_graph(&mut workspace).unwrap();
 
         assert_eq!(
             graph.sources,
@@ -143,7 +143,7 @@ mod globs {
             create_sandbox_with_config("project-graph/ids", Some(&workspace_config), None, None);
 
         let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-        let graph = generate_project_graph(&mut workspace).await.unwrap();
+        let graph = generate_project_graph(&mut workspace).unwrap();
 
         assert_eq!(
             graph.sources,
@@ -235,7 +235,7 @@ mod to_dot {
         );
 
         let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-        let mut graph = build_project_graph(&mut workspace).await.unwrap();
+        let mut graph = build_project_graph(&mut workspace).unwrap();
 
         graph.load("b").unwrap();
 

--- a/crates/core/runner/benches/runner_benchmark.rs
+++ b/crates/core/runner/benches/runner_benchmark.rs
@@ -47,7 +47,7 @@ pub fn runner_benchmark(c: &mut Criterion) {
     c.bench_function("runner", |b| {
         b.iter(|| async {
             let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-            let project_graph = generate_project_graph(&mut workspace).await.unwrap();
+            let project_graph = generate_project_graph(&mut workspace).unwrap();
             let dep_graph = generate_dep_graph(&workspace, &project_graph);
 
             black_box(

--- a/crates/core/runner/src/actions/run_target.rs
+++ b/crates/core/runner/src/actions/run_target.rs
@@ -51,14 +51,14 @@ pub struct TargetRunner<'a> {
 }
 
 impl<'a> TargetRunner<'a> {
-    pub async fn new(
+    pub fn new(
         emitter: &'a Emitter,
         workspace: &'a Workspace,
         project: &'a Project,
         task: &'a Task,
     ) -> Result<TargetRunner<'a>, MoonError> {
         Ok(TargetRunner {
-            cache: workspace.cache.cache_run_target_state(&task.target).await?,
+            cache: workspace.cache.cache_run_target_state(&task.target)?,
             emitter,
             project,
             stderr: Term::buffered_stderr(),
@@ -149,7 +149,7 @@ impl<'a> TargetRunner<'a> {
         }
 
         // Update the run state with the new hash
-        self.cache.save().await?;
+        self.cache.save()?;
 
         Ok(())
     }
@@ -327,8 +327,7 @@ impl<'a> TargetRunner<'a> {
         let runfile = self
             .workspace
             .cache
-            .create_runfile(&self.project.id, self.project)
-            .await?;
+            .create_runfile(&self.project.id, self.project)?;
 
         env_vars.insert(
             "MOON_PROJECT_RUNFILE".to_owned(),
@@ -424,8 +423,7 @@ impl<'a> TargetRunner<'a> {
         // Refresh the hash manifest
         self.workspace
             .cache
-            .create_hash_manifest(&hash, &(common_hasher, platform_hasher))
-            .await?;
+            .create_hash_manifest(&hash, &(common_hasher, platform_hasher))?;
 
         // Check if that hash exists in the cache
         if let EventFlow::Return(value) = self
@@ -585,20 +583,18 @@ impl<'a> TargetRunner<'a> {
         // Write the cache with the result and output
         self.cache.exit_code = output.status.code().unwrap_or(0);
         self.cache.last_run_time = time::now_millis();
-        self.cache.save().await?;
-        self.cache
-            .save_output_logs(
-                output_to_string(&output.stdout),
-                output_to_string(&output.stderr),
-            )
-            .await?;
+        self.cache.save()?;
+        self.cache.save_output_logs(
+            output_to_string(&output.stdout),
+            output_to_string(&output.stderr),
+        )?;
 
         Ok(attempts)
     }
 
-    pub async fn print_cache_item(&self) -> Result<(), MoonError> {
+    pub fn print_cache_item(&self) -> Result<(), MoonError> {
         let item = &self.cache;
-        let (stdout, stderr) = item.load_output_logs().await?;
+        let (stdout, stderr) = item.load_output_logs()?;
 
         self.print_output_with_style(&stdout, &stderr, item.exit_code != 0)?;
 
@@ -832,7 +828,7 @@ pub async fn run_target(
     let emitter = emitter.read().await;
     let project = project_graph.get(&project_id)?;
     let task = project.get_task(&task_id)?;
-    let mut runner = TargetRunner::new(&emitter, &workspace, project, task).await?;
+    let mut runner = TargetRunner::new(&emitter, &workspace, project, task)?;
 
     debug!(
         target: LOG_TARGET,
@@ -913,7 +909,7 @@ pub async fn run_target(
             }
 
             runner.print_checkpoint(Checkpoint::RunPassed, &comments)?;
-            runner.print_cache_item().await?;
+            runner.print_cache_item()?;
             runner.flush_output()?;
 
             return Ok(if matches!(cache_location, HydrateFrom::RemoteCache) {

--- a/crates/core/runner/src/actions/run_target.rs
+++ b/crates/core/runner/src/actions/run_target.rs
@@ -241,7 +241,7 @@ impl<'a> TargetRunner<'a> {
 
         let mut command = match task.platform {
             PlatformType::Node => {
-                node_actions::create_target_command(context, workspace, project, task).await?
+                node_actions::create_target_command(context, workspace, project, task)?
             }
             _ => system_actions::create_target_command(task, working_dir),
         };

--- a/crates/core/runner/src/actions/setup_toolchain.rs
+++ b/crates/core/runner/src/actions/setup_toolchain.rs
@@ -27,7 +27,7 @@ pub async fn setup_toolchain(
     );
 
     let mut workspace = workspace.write().await;
-    let mut cache = workspace.cache.cache_tool_state(runtime).await?;
+    let mut cache = workspace.cache.cache_tool_state(runtime)?;
     let toolchain_paths = workspace.toolchain.get_paths();
 
     // Install and setup the specific tool + version in the toolchain!
@@ -56,7 +56,7 @@ pub async fn setup_toolchain(
     // Update the cache with the timestamp
 
     cache.last_version_check_time = time::now_millis();
-    cache.save().await?;
+    cache.save()?;
 
     Ok(if installed > 0 {
         ActionStatus::Passed

--- a/crates/core/runner/src/runner.rs
+++ b/crates/core/runner/src/runner.rs
@@ -626,8 +626,7 @@ impl Runner {
 
             workspace
                 .cache
-                .create_json_report(name, RunReport::new(actions, &context, duration))
-                .await?;
+                .create_json_report(name, RunReport::new(actions, &context, duration))?;
         }
 
         Ok(())

--- a/crates/core/runner/src/subscribers/local_cache.rs
+++ b/crates/core/runner/src/subscribers/local_cache.rs
@@ -77,8 +77,7 @@ impl Subscriber for LocalCacheSubscriber {
             Event::RunnerFinished { .. } => {
                 workspace
                     .cache
-                    .clean_stale_cache(&workspace.config.runner.cache_lifetime)
-                    .await?;
+                    .clean_stale_cache(&workspace.config.runner.cache_lifetime)?;
             }
             _ => {}
         }

--- a/crates/core/runner/src/subscribers/local_cache.rs
+++ b/crates/core/runner/src/subscribers/local_cache.rs
@@ -46,9 +46,7 @@ impl Subscriber for LocalCacheSubscriber {
                 let archive_path = workspace.cache.get_hash_archive_path(hash);
 
                 if is_writable()
-                    && cache
-                        .archive_outputs(&archive_path, &project.root, &task.outputs)
-                        .await?
+                    && cache.archive_outputs(&archive_path, &project.root, &task.outputs)?
                 {
                     return Ok(EventFlow::Return(path::to_string(archive_path)?));
                 }
@@ -65,9 +63,7 @@ impl Subscriber for LocalCacheSubscriber {
                 let archive_path = workspace.cache.get_hash_archive_path(hash);
 
                 if is_readable()
-                    && cache
-                        .hydrate_outputs(&archive_path, &project.root, &task.outputs)
-                        .await?
+                    && cache.hydrate_outputs(&archive_path, &project.root, &task.outputs)?
                 {
                     return Ok(EventFlow::Return(path::to_string(archive_path)?));
                 }

--- a/crates/core/toolchain/src/toolchain.rs
+++ b/crates/core/toolchain/src/toolchain.rs
@@ -22,15 +22,14 @@ pub struct Toolchain {
 }
 
 impl Toolchain {
-    pub async fn load(config: &ToolchainConfig) -> Result<Toolchain, ToolchainError> {
+    pub fn load(config: &ToolchainConfig) -> Result<Toolchain, ToolchainError> {
         Toolchain::load_from(
             path::get_home_dir().ok_or(ToolchainError::MissingHomeDir)?,
             config,
         )
-        .await
     }
 
-    pub async fn load_from<P: AsRef<Path>>(
+    pub fn load_from<P: AsRef<Path>>(
         base_dir: P,
         config: &ToolchainConfig,
     ) -> Result<Toolchain, ToolchainError> {
@@ -42,7 +41,7 @@ impl Toolchain {
             color::path(&dir)
         );
 
-        fs::create_dir_all(&dir).await?;
+        fs::create_dir_all(&dir)?;
 
         let mut toolchain = Toolchain {
             config: config.to_owned(),

--- a/crates/core/toolchain/src/tools/yarn.rs
+++ b/crates/core/toolchain/src/tools/yarn.rs
@@ -181,7 +181,7 @@ impl DependencyManager<NodeTool> for YarnTool {
             return Ok(FxHashMap::default());
         };
 
-        Ok(yarn::load_lockfile_dependencies(lockfile_path).await?)
+        Ok(yarn::load_lockfile_dependencies(lockfile_path)?)
     }
 
     async fn install_dependencies(

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 moon_constants = { path = "../constants" }
 moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }
-# async-recursion = "1.0.0"
 cached = { workspace = true }
 chrono = { version = "0.4.23", features = ["serde"] }
 chrono-humanize = "0.2.2"
@@ -15,7 +14,6 @@ clean-path = "0.2.1"
 dirs = "4.0.0"
 dunce = "1.0.3"
 ec4rs = "1.0.1"
-# futures = "0.3.25"
 humantime = "2.1.0"
 json_comments = "0.2.1"
 lazy_static = "1.4.0"

--- a/crates/core/utils/Cargo.toml
+++ b/crates/core/utils/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 moon_constants = { path = "../constants" }
 moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }
-async-recursion = "1.0.0"
+# async-recursion = "1.0.0"
 cached = { workspace = true }
 chrono = { version = "0.4.23", features = ["serde"] }
 chrono-humanize = "0.2.2"
@@ -15,7 +15,7 @@ clean-path = "0.2.1"
 dirs = "4.0.0"
 dunce = "1.0.3"
 ec4rs = "1.0.1"
-futures = "0.3.25"
+# futures = "0.3.25"
 humantime = "2.1.0"
 json_comments = "0.2.1"
 lazy_static = "1.4.0"

--- a/crates/core/utils/src/fs.rs
+++ b/crates/core/utils/src/fs.rs
@@ -31,10 +31,7 @@ pub fn copy_dir_all<T: AsRef<Path> + Send>(
         let path = entry.path();
 
         if path.is_file() {
-            copy_file(
-                &path,
-                to_root.join(path.strip_prefix(from_root).unwrap()),
-            )?;
+            copy_file(&path, to_root.join(path.strip_prefix(from_root).unwrap()))?;
         } else if path.is_dir() {
             dirs.push(path);
         }

--- a/crates/core/utils/src/fs.rs
+++ b/crates/core/utils/src/fs.rs
@@ -1,27 +1,22 @@
-use async_recursion::async_recursion;
-use futures::future::try_join_all;
 use moon_error::{map_io_to_fs_error, MoonError};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
-use tokio::fs;
 
 #[inline]
-pub async fn copy_file<S: AsRef<Path>, D: AsRef<Path>>(from: S, to: D) -> Result<(), MoonError> {
+pub fn copy_file<S: AsRef<Path>, D: AsRef<Path>>(from: S, to: D) -> Result<(), MoonError> {
     let from = from.as_ref();
     let to = to.as_ref();
     let to_dir = to.parent().unwrap();
 
-    create_dir_all(to_dir).await?;
+    create_dir_all(to_dir)?;
 
-    fs::copy(from, to)
-        .await
-        .map_err(|e| map_io_to_fs_error(e, from.to_path_buf()))?;
+    fs::copy(from, to).map_err(|e| map_io_to_fs_error(e, from.to_path_buf()))?;
 
     Ok(())
 }
 
-#[async_recursion]
-pub async fn copy_dir_all<T: AsRef<Path> + Send>(
+pub fn copy_dir_all<T: AsRef<Path> + Send>(
     from_root: T,
     from: T,
     to_root: T,
@@ -29,42 +24,35 @@ pub async fn copy_dir_all<T: AsRef<Path> + Send>(
     let from_root = from_root.as_ref();
     let from = from.as_ref();
     let to_root = to_root.as_ref();
-    let entries = read_dir(from).await?;
-    let mut files = vec![];
+    let entries = read_dir(from)?;
     let mut dirs = vec![];
 
     for entry in entries {
         let path = entry.path();
 
         if path.is_file() {
-            files.push(copy_file(
+            copy_file(
                 path.to_owned(),
                 to_root.join(path.strip_prefix(from_root).unwrap()),
-            ));
-        } else {
+            )?;
+        } else if path.is_dir() {
             dirs.push(path);
         }
     }
 
-    // Copy files before dirs incase an error occurs
-    try_join_all(files).await?;
-
-    // Copy dirs in sequence for the same reason
     for dir in dirs {
-        copy_dir_all(from_root, &dir, to_root).await?;
+        copy_dir_all(from_root, &dir, to_root)?;
     }
 
     Ok(())
 }
 
 #[inline]
-pub async fn create_dir_all<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
+pub fn create_dir_all<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
     let path = path.as_ref();
 
     if !path.exists() {
-        fs::create_dir_all(&path)
-            .await
-            .map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
+        fs::create_dir_all(&path).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
     }
 
     Ok(())
@@ -130,41 +118,38 @@ pub fn get_editor_config_props<T: AsRef<Path>>(path: T) -> EditorConfigProps {
 }
 
 #[inline]
-pub async fn metadata<T: AsRef<Path>>(path: T) -> Result<std::fs::Metadata, MoonError> {
+pub fn metadata<T: AsRef<Path>>(path: T) -> Result<fs::Metadata, MoonError> {
     let path = path.as_ref();
 
-    fs::metadata(path)
-        .await
-        .map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))
+    fs::metadata(path).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))
 }
 
 #[inline]
-pub async fn read_dir<T: AsRef<Path>>(path: T) -> Result<Vec<fs::DirEntry>, MoonError> {
+pub fn read_dir<T: AsRef<Path>>(path: T) -> Result<Vec<fs::DirEntry>, MoonError> {
     let path = path.as_ref();
     let handle_error = |e| map_io_to_fs_error(e, path.to_path_buf());
 
-    let mut entries = fs::read_dir(path).await.map_err(handle_error)?;
+    let entries = fs::read_dir(path).map_err(handle_error)?;
     let mut results = vec![];
 
-    while let Some(entry) = entries.next_entry().await.map_err(handle_error)? {
-        results.push(entry);
+    for entry in entries {
+        match entry {
+            Ok(dir) => {
+                results.push(dir);
+            }
+            Err(e) => return Err(handle_error(e)),
+        }
     }
 
     Ok(results)
 }
 
-// Sync is almost 5x faster than async here!
 #[inline]
-pub fn read_dir_all<T: AsRef<Path> + Send>(path: T) -> Result<Vec<std::fs::DirEntry>, MoonError> {
-    let path = path.as_ref();
-    let handle_error = |e| map_io_to_fs_error(e, path.to_path_buf());
-
-    let entries = std::fs::read_dir(path).map_err(handle_error)?;
+pub fn read_dir_all<T: AsRef<Path> + Send>(path: T) -> Result<Vec<fs::DirEntry>, MoonError> {
+    let entries = read_dir(path)?;
     let mut results = vec![];
 
     for entry in entries {
-        let entry = entry?;
-
         if let Ok(file_type) = entry.file_type() {
             if file_type.is_dir() {
                 results.extend(read_dir_all(&entry.path())?);
@@ -178,49 +163,43 @@ pub fn read_dir_all<T: AsRef<Path> + Send>(path: T) -> Result<Vec<std::fs::DirEn
 }
 
 #[inline]
-pub async fn read<T: AsRef<Path>>(path: T) -> Result<String, MoonError> {
+pub fn read<T: AsRef<Path>>(path: T) -> Result<String, MoonError> {
     let path = path.as_ref();
-    let data = fs::read_to_string(path)
-        .await
-        .map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
+    let data = fs::read_to_string(path).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
 
     Ok(data)
 }
 
 #[inline]
-pub async fn remove<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
+pub fn remove<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
     let path = path.as_ref();
 
     if path.is_file() {
-        remove_file(path).await?;
+        remove_file(path)?;
     } else if path.is_dir() {
-        remove_dir_all(path).await?;
+        remove_dir_all(path)?;
     }
 
     Ok(())
 }
 
 #[inline]
-pub async fn remove_file<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
+pub fn remove_file<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
     let path = path.as_ref();
 
     if path.exists() {
-        fs::remove_file(&path)
-            .await
-            .map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
+        fs::remove_file(&path).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
     }
 
     Ok(())
 }
 
 #[inline]
-pub async fn remove_dir_all<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
+pub fn remove_dir_all<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
     let path = path.as_ref();
 
     if path.exists() {
-        fs::remove_dir_all(&path)
-            .await
-            .map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
+        fs::remove_dir_all(&path).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
     }
 
     Ok(())
@@ -228,7 +207,7 @@ pub async fn remove_dir_all<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
 
 pub type RemoveDirContentsResult = (usize, u64);
 
-pub async fn remove_dir_stale_contents<P: AsRef<Path>>(
+pub fn remove_dir_stale_contents<P: AsRef<Path>>(
     dir: P,
     duration: Duration,
 ) -> Result<RemoveDirContentsResult, MoonError> {
@@ -236,13 +215,13 @@ pub async fn remove_dir_stale_contents<P: AsRef<Path>>(
     let mut bytes_saved: u64 = 0;
     let threshold = SystemTime::now() - duration;
 
-    for entry in read_dir(dir.as_ref()).await? {
+    for entry in read_dir(dir.as_ref())? {
         let path = entry.path();
 
         if path.is_file() {
             let mut bytes = 0;
 
-            if let Ok(metadata) = entry.metadata().await {
+            if let Ok(metadata) = entry.metadata() {
                 bytes = metadata.len();
 
                 if let Ok(filetime) = metadata.accessed().or_else(|_| metadata.created()) {
@@ -256,7 +235,7 @@ pub async fn remove_dir_stale_contents<P: AsRef<Path>>(
                 }
             }
 
-            if remove_file(path).await.is_ok() {
+            if remove_file(path).is_ok() {
                 files_deleted += 1;
                 bytes_saved += bytes;
             }
@@ -267,23 +246,19 @@ pub async fn remove_dir_stale_contents<P: AsRef<Path>>(
 }
 
 #[inline]
-pub async fn rename<F: AsRef<Path>, T: AsRef<Path>>(from: F, to: T) -> Result<(), MoonError> {
+pub fn rename<F: AsRef<Path>, T: AsRef<Path>>(from: F, to: T) -> Result<(), MoonError> {
     let from = from.as_ref();
 
-    fs::rename(from, to.as_ref())
-        .await
-        .map_err(|e| map_io_to_fs_error(e, from.to_path_buf()))?;
+    fs::rename(from, to.as_ref()).map_err(|e| map_io_to_fs_error(e, from.to_path_buf()))?;
 
     Ok(())
 }
 
 #[inline]
-pub async fn write<T: AsRef<Path>>(path: T, data: impl AsRef<[u8]>) -> Result<(), MoonError> {
+pub fn write<T: AsRef<Path>>(path: T, data: impl AsRef<[u8]>) -> Result<(), MoonError> {
     let path = path.as_ref();
 
-    fs::write(path, data)
-        .await
-        .map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
+    fs::write(path, data).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
 
     Ok(())
 }
@@ -291,12 +266,12 @@ pub async fn write<T: AsRef<Path>>(path: T, data: impl AsRef<[u8]>) -> Result<()
 pub mod temp {
     use super::*;
     use moon_constants::CONFIG_DIRNAME;
-    use std::fs;
 
     pub fn get_dir() -> PathBuf {
         crate::get_workspace_root()
             .join(CONFIG_DIRNAME)
-            .join("cache/temp")
+            .join("cache")
+            .join("temp")
     }
 
     pub fn get_file(source: &str, ext: &str) -> PathBuf {
@@ -316,24 +291,24 @@ pub mod temp {
         if let Ok(metadata) = file.metadata() {
             if let Ok(filetime) = metadata.created() {
                 if filetime > threshold {
-                    fs::remove_file(file)?;
+                    remove_file(file)?;
 
                     return Ok(None);
                 }
             }
         }
 
-        Ok(Some(fs::read_to_string(file)?))
+        Ok(Some(super::read(file)?))
     }
 
     pub fn write<P: AsRef<Path>, D: AsRef<str>>(path: P, data: D) -> Result<(), MoonError> {
         let path = path.as_ref();
 
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
+            create_dir_all(parent)?;
         }
 
-        fs::write(path, data.as_ref())?;
+        super::write(path, data.as_ref())?;
 
         Ok(())
     }

--- a/crates/core/utils/src/fs.rs
+++ b/crates/core/utils/src/fs.rs
@@ -32,7 +32,7 @@ pub fn copy_dir_all<T: AsRef<Path> + Send>(
 
         if path.is_file() {
             copy_file(
-                path.to_owned(),
+                &path,
                 to_root.join(path.strip_prefix(from_root).unwrap()),
             )?;
         } else if path.is_dir() {
@@ -52,7 +52,7 @@ pub fn create_dir_all<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
     let path = path.as_ref();
 
     if !path.exists() {
-        fs::create_dir_all(&path).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
+        fs::create_dir_all(path).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
     }
 
     Ok(())
@@ -188,7 +188,7 @@ pub fn remove_file<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
     let path = path.as_ref();
 
     if path.exists() {
-        fs::remove_file(&path).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
+        fs::remove_file(path).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
     }
 
     Ok(())
@@ -199,7 +199,7 @@ pub fn remove_dir_all<T: AsRef<Path>>(path: T) -> Result<(), MoonError> {
     let path = path.as_ref();
 
     if path.exists() {
-        fs::remove_dir_all(&path).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
+        fs::remove_dir_all(path).map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
     }
 
     Ok(())

--- a/crates/core/workspace/Cargo.toml
+++ b/crates/core/workspace/Cargo.toml
@@ -16,4 +16,3 @@ moon_utils = { path = "../utils" }
 moon_vcs = { path = "../vcs" }
 reqwest = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }

--- a/crates/core/workspace/src/workspace.rs
+++ b/crates/core/workspace/src/workspace.rs
@@ -168,11 +168,11 @@ pub struct Workspace {
 impl Workspace {
     /// Create a new workspace instance starting from the current working directory.
     /// Will locate the workspace root and load available configuration files.
-    pub async fn load() -> Result<Workspace, WorkspaceError> {
-        Workspace::load_from(env::current_dir().unwrap()).await
+    pub fn load() -> Result<Workspace, WorkspaceError> {
+        Workspace::load_from(env::current_dir().unwrap())
     }
 
-    pub async fn load_from<P: AsRef<Path>>(working_dir: P) -> Result<Workspace, WorkspaceError> {
+    pub fn load_from<P: AsRef<Path>>(working_dir: P) -> Result<Workspace, WorkspaceError> {
         let working_dir = working_dir.as_ref();
         let Some(root_dir) = find_workspace_root(working_dir) else {
             return Err(WorkspaceError::MissingConfigDir);
@@ -191,8 +191,8 @@ impl Workspace {
         let projects_config = load_global_project_config(&root_dir)?;
 
         // Setup components
-        let cache = CacheEngine::load(&root_dir).await?;
-        let toolchain = Toolchain::load(&toolchain_config).await?;
+        let cache = CacheEngine::load(&root_dir)?;
+        let toolchain = Toolchain::load(&toolchain_config)?;
         let vcs = VcsLoader::load(&root_dir, &config)?;
 
         Ok(Workspace {

--- a/crates/node/lang/Cargo.toml
+++ b/crates/node/lang/Cargo.toml
@@ -22,4 +22,3 @@ yarn-lock-parser = "0.4.1"
 [dev-dependencies]
 moon_test_utils = { path = "../../core/test-utils" }
 reqwest = { workspace = true, features = ["blocking"] }
-tokio = { workspace = true }

--- a/crates/node/lang/src/yarn/mod.rs
+++ b/crates/node/lang/src/yarn/mod.rs
@@ -7,12 +7,10 @@ use std::path::PathBuf;
 use yarn_lock_parser::{parse_str, Entry};
 
 #[cached(result)]
-pub async fn load_lockfile_dependencies(
-    path: PathBuf,
-) -> Result<LockfileDependencyVersions, MoonError> {
+pub fn load_lockfile_dependencies(path: PathBuf) -> Result<LockfileDependencyVersions, MoonError> {
     let mut deps: LockfileDependencyVersions = FxHashMap::default();
 
-    let yarn_lock_text = fs::read(&path).await?;
+    let yarn_lock_text = fs::read(&path)?;
     let entries: Vec<Entry> = parse_str(&yarn_lock_text)
         .map_err(|e| MoonError::Generic(format!("Failed to parse lockfile: {}", e)))?;
 
@@ -35,7 +33,6 @@ mod tests {
     use moon_test_utils::{assert_fs::prelude::*, create_temp_dir, pretty_assertions::assert_eq};
     use moon_utils::string_vec;
 
-    #[tokio::test]
     async fn parses_lockfile() {
         let temp = create_temp_dir();
 
@@ -100,7 +97,7 @@ __metadata:
 "#.trim()).unwrap();
 
         assert_eq!(
-            load_lockfile_dependencies(temp.path().join("yarn.lock")).await.unwrap(),
+            load_lockfile_dependencies(temp.path().join("yarn.lock")).unwrap(),
             FxHashMap::from_iter([
                 (
                     "is-buffer".to_owned(),

--- a/crates/node/lang/src/yarn/mod.rs
+++ b/crates/node/lang/src/yarn/mod.rs
@@ -33,7 +33,8 @@ mod tests {
     use moon_test_utils::{assert_fs::prelude::*, create_temp_dir, pretty_assertions::assert_eq};
     use moon_utils::string_vec;
 
-    async fn parses_lockfile() {
+    #[test]
+    fn parses_lockfile() {
         let temp = create_temp_dir();
 
         temp.child("yarn.lock").write_str(r#"

--- a/crates/node/platform/src/actions/install_deps.rs
+++ b/crates/node/platform/src/actions/install_deps.rs
@@ -69,7 +69,7 @@ fn add_engines_constraint(node: &NodeTool, package_json: &mut PackageJson) -> bo
     false
 }
 
-async fn sync_workspace(workspace: &Workspace, node: &NodeTool) -> Result<(), MoonError> {
+fn sync_workspace(workspace: &Workspace, node: &NodeTool) -> Result<(), MoonError> {
     // Sync values to root `package.json`
     PackageJson::sync(&workspace.root, |package_json| {
         add_package_manager(node, package_json);
@@ -83,7 +83,7 @@ async fn sync_workspace(workspace: &Workspace, node: &NodeTool) -> Result<(), Mo
         let rc_name = version_manager.get_config_filename();
         let rc_path = workspace.root.join(&rc_name);
 
-        fs::write(&rc_path, &node.config.version).await?;
+        fs::write(&rc_path, &node.config.version)?;
 
         debug!(
             target: LOG_TARGET,
@@ -139,7 +139,7 @@ pub async fn install_deps(
             .any(|f| f.ends_with(&lock_filename) || f.ends_with(&manifest_filename));
 
         // When installing deps in the workspace root, also sync applicable settings
-        sync_workspace(&workspace, node).await?;
+        sync_workspace(&workspace, node)?;
     }
 
     // Install dependencies in the current project or workspace
@@ -147,13 +147,11 @@ pub async fn install_deps(
     let mut last_modified = 0;
     let mut cache = workspace
         .cache
-        .cache_deps_state(runtime, project.map(|p| p.id.as_ref()))
-        .await?;
+        .cache_deps_state(runtime, project.map(|p| p.id.as_ref()))?;
 
     if lock_filepath.exists() {
         last_modified = time::to_millis(
-            fs::metadata(&lock_filepath)
-                .await?
+            fs::metadata(&lock_filepath)?
                 .modified()
                 .map_err(|e| map_io_to_fs_error(e, lock_filepath.clone()))?,
         );
@@ -229,7 +227,7 @@ pub async fn install_deps(
 
         // Update the cache with the timestamp
         cache.last_install_time = time::now_millis();
-        cache.save().await?;
+        cache.save()?;
 
         return Ok(ActionStatus::Passed);
     }

--- a/crates/node/platform/src/actions/run_target.rs
+++ b/crates/node/platform/src/actions/run_target.rs
@@ -86,7 +86,7 @@ fn create_node_options(
 /// ~/.moon/tools/node/1.2.3/bin/node --inspect /path/to/node_modules/.bin/eslint
 ///     --cache --color --fix --ext .ts,.tsx,.js,.jsx
 #[track_caller]
-pub async fn create_target_command(
+pub fn create_target_command(
     context: &RunnerContext,
     workspace: &Workspace,
     project: &Project,

--- a/crates/node/platform/src/actions/sync_project.rs
+++ b/crates/node/platform/src/actions/sync_project.rs
@@ -20,7 +20,7 @@ const LOG_TARGET: &str = "moon:node-platform:sync-project";
 
 // Automatically create missing config files when we are syncing project references.
 #[track_caller]
-pub async fn create_missing_tsconfig(
+pub fn create_missing_tsconfig(
     project: &Project,
     typescript_config: &TypeScriptConfig,
     workspace_root: &Path,
@@ -266,7 +266,7 @@ pub async fn sync_project(
                 .join(&typescript_config.project_config_file_name)
                 .exists()
         {
-            create_missing_tsconfig(project, typescript_config, &workspace.root).await?;
+            create_missing_tsconfig(project, typescript_config, &workspace.root)?;
         }
 
         // Sync to the project's `tsconfig.json`

--- a/crates/node/platform/tests/project_aliases_test.rs
+++ b/crates/node/platform/tests/project_aliases_test.rs
@@ -20,7 +20,7 @@ async fn get_aliases_graph(node_config: NodeConfig) -> (ProjectGraph, Sandbox) {
     );
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
-    let graph = generate_project_graph(&mut workspace).await.unwrap();
+    let graph = generate_project_graph(&mut workspace).unwrap();
 
     (graph, sandbox)
 }

--- a/crates/node/platform/tests/sync_project_test.rs
+++ b/crates/node/platform/tests/sync_project_test.rs
@@ -8,8 +8,8 @@ use moon_utils::string_vec;
 mod missing_tsconfig {
     use super::*;
 
-    #[tokio::test]
-    async fn creates_tsconfig() {
+    #[test]
+    fn creates_tsconfig() {
         let (workspace_config, toolchain_config, projects_config) = get_node_fixture_configs();
         let sandbox = create_sandbox_with_config(
             "node",
@@ -30,9 +30,7 @@ mod missing_tsconfig {
 
         assert!(!tsconfig_path.exists());
 
-        create_missing_tsconfig(&project, &TypeScriptConfig::default(), sandbox.path())
-            .await
-            .unwrap();
+        create_missing_tsconfig(&project, &TypeScriptConfig::default(), sandbox.path()).unwrap();
 
         assert!(tsconfig_path.exists());
 
@@ -45,8 +43,8 @@ mod missing_tsconfig {
         assert_eq!(tsconfig.include, Some(string_vec!["**/*"]));
     }
 
-    #[tokio::test]
-    async fn creates_tsconfig_with_custom_settings() {
+    #[test]
+    fn creates_tsconfig_with_custom_settings() {
         let (workspace_config, toolchain_config, projects_config) = get_node_fixture_configs();
         let sandbox = create_sandbox_with_config(
             "node",
@@ -76,7 +74,6 @@ mod missing_tsconfig {
             },
             sandbox.path(),
         )
-        .await
         .unwrap();
 
         assert!(tsconfig_path.exists());
@@ -89,8 +86,8 @@ mod missing_tsconfig {
         assert_eq!(tsconfig.include, Some(string_vec!["**/*"]));
     }
 
-    #[tokio::test]
-    async fn doesnt_create_if_a_config_exists() {
+    #[test]
+    fn doesnt_create_if_a_config_exists() {
         let (workspace_config, toolchain_config, projects_config) = get_node_fixture_configs();
         let sandbox = create_sandbox_with_config(
             "node",
@@ -113,7 +110,6 @@ mod missing_tsconfig {
 
         let created =
             create_missing_tsconfig(&project, &TypeScriptConfig::default(), sandbox.path())
-                .await
                 .unwrap();
 
         assert!(!created);

--- a/crates/typescript/lang/Cargo.toml
+++ b/crates/typescript/lang/Cargo.toml
@@ -14,4 +14,3 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 
 [dev-dependencies]
 moon_test_utils = { path = "../../core/test-utils" }
-tokio = { workspace = true }

--- a/crates/typescript/lang/src/tsconfig.rs
+++ b/crates/typescript/lang/src/tsconfig.rs
@@ -66,7 +66,7 @@ pub struct TsConfigJson {
 }
 
 impl TsConfigJson {
-    pub async fn load_with_extends<T: AsRef<Path>>(path: T) -> Result<TsConfigJson, MoonError> {
+    pub fn load_with_extends<T: AsRef<Path>>(path: T) -> Result<TsConfigJson, MoonError> {
         let path = path.as_ref();
         let values = load_to_value(path, true)?;
 
@@ -891,8 +891,8 @@ mod test {
         assert_eq!(value.compiler_options.unwrap().remove_comments, Some(true));
     }
 
-    #[tokio::test]
-    async fn parse_basic_file() {
+    #[test]
+    fn parse_basic_file() {
         let path = get_fixtures_path("base/tsconfig-json");
         let config = TsConfigJson::read_with_name(path, "tsconfig.default.json")
             .unwrap()
@@ -909,10 +909,10 @@ mod test {
         assert_eq!(config.compiler_options.unwrap().strict, Some(true));
     }
 
-    #[tokio::test]
-    async fn parse_inheriting_file() {
+    #[test]
+    fn parse_inheriting_file() {
         let path = get_fixtures_path("base/tsconfig-json/tsconfig.inherits.json");
-        let config = TsConfigJson::load_with_extends(&path).await.unwrap();
+        let config = TsConfigJson::load_with_extends(&path).unwrap();
 
         assert_eq!(
             config
@@ -934,10 +934,10 @@ mod test {
         );
     }
 
-    #[tokio::test]
-    async fn parse_inheritance_chain() {
+    #[test]
+    fn parse_inheritance_chain() {
         let path = get_fixtures_path("base/tsconfig-json/a/tsconfig.json");
-        let config = TsConfigJson::load_with_extends(&path).await.unwrap();
+        let config = TsConfigJson::load_with_extends(&path).unwrap();
 
         assert_eq!(
             config


### PR DESCRIPTION
When I started building moon, I made all fs calls async as I was used to Node.js. However, in Rust, they work quite differently. Since OS fs calls are sync by default, Tokio fs is merely an async wrapper that _polls_ until complete. I'm not 100% positive, but I have a hunch this adds a non-trivial amount of processing cost.

This changes all fs calls to sync, which in turn converted a ton of async functions to sync. In theory, this should increase performance as we're no longer overloading the tokio runtime with a ton of useless async calls.