### PR TITLE
new: Support multiple `--status` options.

### DIFF
--- a/.yarn/versions/95a4fdd8.yml
+++ b/.yarn/versions/95a4fdd8.yml
@@ -8,3 +8,9 @@ releases:
   '@moonrepo/core-macos-x64': minor
   '@moonrepo/core-windows-x64-msvc': minor
   '@moonrepo/visualizer': minor
+  '@moonrepo/types': patch
+
+declined:
+  - '@moonrepo/runtime'
+  - '@moonrepo/report'
+  - 'website'

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -118,13 +118,8 @@ pub enum QueryCommands {
         #[arg(long, help = "Gather files from you local state instead of upstream")]
         local: bool,
 
-        #[arg(
-            value_enum,
-            long,
-            help = "Filter files based on a touched status",
-            default_value_t
-        )]
-        status: TouchedStatus,
+        #[arg(value_enum, long, help = "Filter files based on a touched status")]
+        status: Vec<TouchedStatus>,
     },
 }
 
@@ -372,9 +367,8 @@ pub enum Commands {
             help = "Filter affected files based on a touched status",
             help_heading = HEADING_AFFECTED,
             requires = "affected-args",
-            default_value_t
         )]
-        status: TouchedStatus,
+        status: Vec<TouchedStatus>,
 
         #[arg(
             long,

--- a/crates/cli/src/commands/ci.rs
+++ b/crates/cli/src/commands/ci.rs
@@ -1,4 +1,3 @@
-use crate::enums::TouchedStatus;
 use crate::helpers::AnyError;
 use crate::queries::touched_files::{query_touched_files, QueryTouchedFilesOptions};
 use itertools::Itertools;
@@ -55,9 +54,8 @@ async fn gather_touched_files(
             default_branch: true,
             base: options.base.clone().unwrap_or_default(),
             head: options.head.clone().unwrap_or_default(),
-            local: false,
             log: true,
-            status: TouchedStatus::All,
+            ..QueryTouchedFilesOptions::default()
         },
     )
     .await?;

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -75,7 +75,11 @@ pub async fn run_target(
         let targets_list = map_list(target_ids, |id| color::target(id));
 
         if options.affected {
-            let status_list = map_list(&options.status, |s| color::symbol(s.to_string()));
+            let status_list = if options.status.is_empty() {
+                color::symbol(TouchedStatus::All.to_string())
+            } else {
+                map_list(&options.status, |s| color::symbol(s.to_string()))
+            };
 
             println!(
                 "Target(s) {} not affected by touched files (using status {})",

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -16,7 +16,7 @@ use std::string::ToString;
 pub struct RunOptions {
     pub affected: bool,
     pub dependents: bool,
-    pub status: TouchedStatus,
+    pub status: Vec<TouchedStatus>,
     pub passthrough: Vec<String>,
     pub profile: Option<ProfileType>,
     pub report: bool,
@@ -49,7 +49,7 @@ pub async fn run_target(
             &workspace,
             &mut QueryTouchedFilesOptions {
                 local: is_local(&options),
-                status: options.status,
+                status: options.status.clone(),
                 ..QueryTouchedFilesOptions::default()
             },
         )
@@ -75,15 +75,12 @@ pub async fn run_target(
         let targets_list = map_list(target_ids, |id| color::target(id));
 
         if options.affected {
-            if matches!(options.status, TouchedStatus::All) {
-                println!("Target(s) {} not affected by touched files", targets_list);
-            } else {
-                println!(
-                    "Target(s) {} not affected by touched files (using status {})",
-                    targets_list,
-                    color::symbol(&options.status.to_string())
-                );
-            }
+            let status_list = map_list(&options.status, |s| color::symbol(s.to_string()));
+
+            println!(
+                "Target(s) {} not affected by touched files (using status {})",
+                targets_list, status_list
+            );
         } else {
             println!("No tasks found for target(s) {}", targets_list);
         }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -192,7 +192,7 @@ pub async fn run_cli() {
                     head: head.clone().unwrap_or_default(),
                     local: *local,
                     log: false,
-                    status: *status,
+                    status: status.clone(),
                 })
                 .await
             }
@@ -213,7 +213,7 @@ pub async fn run_cli() {
                 RunOptions {
                     affected: *affected,
                     dependents: *dependents,
-                    status: *status,
+                    status: status.clone(),
                     passthrough: passthrough.clone(),
                     profile: profile.clone(),
                     report: *report,

--- a/crates/cli/src/queries/touched_files.rs
+++ b/crates/cli/src/queries/touched_files.rs
@@ -79,15 +79,21 @@ pub async fn query_touched_files(
     let mut touched_files_to_log = vec![];
     let mut touched_files = FxHashSet::default();
 
-    debug!(
-        target: LOG_TARGET,
-        "Filtering based on touched status \"{}\"",
-        map_list(&options.status, |f| color::symbol(f.to_string()))
-    );
-
     if options.status.is_empty() {
+        debug!(
+            target: LOG_TARGET,
+            "Filtering based on touched status \"{}\"",
+            color::symbol(TouchedStatus::All.to_string())
+        );
+
         touched_files.extend(&touched_files_map.all);
     } else {
+        debug!(
+            target: LOG_TARGET,
+            "Filtering based on touched status \"{}\"",
+            map_list(&options.status, |f| color::symbol(f.to_string()))
+        );
+
         for status in &options.status {
             touched_files.extend(match status {
                 TouchedStatus::Added => &touched_files_map.added,

--- a/crates/cli/tests/query_test.rs
+++ b/crates/cli/tests/query_test.rs
@@ -275,7 +275,37 @@ mod touched_files {
 
         assert_eq!(json.options.base, "master".to_string());
         assert_eq!(json.options.head, "branch".to_string());
-        assert_eq!(json.options.status, TouchedStatus::Deleted);
+        assert_eq!(json.options.status, vec![TouchedStatus::Deleted]);
         assert!(!json.options.local);
+    }
+
+    #[test]
+    fn can_supply_multi_status() {
+        let (workspace_config, toolchain_config, projects_config) = get_cases_fixture_configs();
+
+        let sandbox = create_sandbox_with_config(
+            "cases",
+            Some(&workspace_config),
+            Some(&toolchain_config),
+            Some(&projects_config),
+        );
+        sandbox.enable_git();
+
+        let assert = sandbox.run_moon(|cmd| {
+            cmd.arg("query").arg("touched-files").args([
+                "--status", "deleted", "--status", "added", "--status", "modified",
+            ]);
+        });
+
+        let json: QueryTouchedFilesResult = serde_json::from_str(&assert.output()).unwrap();
+
+        assert_eq!(
+            json.options.status,
+            vec![
+                TouchedStatus::Deleted,
+                TouchedStatus::Added,
+                TouchedStatus::Modified
+            ]
+        );
     }
 }

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -1073,10 +1073,33 @@ mod affected {
 
         let output = assert.output();
 
-        assert!(
-            predicate::str::contains("Target(s) files:noop not affected by touched files")
-                .eval(&output)
-        );
+        assert!(predicate::str::contains(
+            "Target(s) files:noop not affected by touched files (using status all)"
+        )
+        .eval(&output));
+    }
+
+    #[test]
+    fn doesnt_run_if_not_affected_by_multi_status() {
+        let sandbox = cases_sandbox();
+        sandbox.enable_git();
+
+        let assert = sandbox.run_moon(|cmd| {
+            cmd.arg("run")
+                .arg("files:noop")
+                .arg("--affected")
+                .arg("--status")
+                .arg("untracked")
+                .arg("--status")
+                .arg("deleted");
+        });
+
+        let output = assert.output();
+
+        assert!(predicate::str::contains(
+            "Target(s) files:noop not affected by touched files (using status untracked, deleted)"
+        )
+        .eval(&output));
     }
 
     #[test]
@@ -1093,6 +1116,57 @@ mod affected {
         let output = assert.output();
 
         assert!(predicate::str::contains("Tasks: 1 completed").eval(&output));
+    }
+
+    #[test]
+    fn runs_if_affected_by_multi_status() {
+        let sandbox = cases_sandbox();
+        sandbox.enable_git();
+
+        // Test modified
+        sandbox.create_file("files/file.txt", "modified");
+
+        let assert = sandbox.run_moon(|cmd| {
+            cmd.arg("run")
+                .arg("files:affected")
+                .arg("-u")
+                .arg("--affected")
+                .arg("--status")
+                .arg("modified");
+        });
+
+        assert!(predicate::str::contains("\n./file.txt\n").eval(&assert.output()));
+
+        // Then test added
+        sandbox.create_file("files/other.txt", "added");
+        sandbox.run_git(|cmd| {
+            cmd.args(["add", "files/other.txt"]);
+        });
+
+        let assert = sandbox.run_moon(|cmd| {
+            cmd.arg("run")
+                .arg("files:affected")
+                .arg("-u")
+                .arg("--affected")
+                .arg("--status")
+                .arg("added");
+        });
+
+        assert!(predicate::str::contains("\n./other.txt\n").eval(&assert.output()));
+
+        // Then test both
+        let assert = sandbox.run_moon(|cmd| {
+            cmd.arg("run")
+                .arg("files:affected")
+                .arg("-u")
+                .arg("--affected")
+                .arg("--status")
+                .arg("modified")
+                .arg("--status")
+                .arg("added");
+        });
+
+        assert!(predicate::str::contains("\n./file.txt,./other.txt\n").eval(&assert.output()));
     }
 
     #[test]

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -1135,7 +1135,11 @@ mod affected {
                 .arg("modified");
         });
 
-        assert!(predicate::str::contains("\n./file.txt\n").eval(&assert.output()));
+        if cfg!(windows) {
+            assert!(predicate::str::contains("\n.\\file.txt\n").eval(&assert.output()));
+        } else {
+            assert!(predicate::str::contains("\n./file.txt\n").eval(&assert.output()));
+        }
 
         // Then test added
         sandbox.create_file("files/other.txt", "added");
@@ -1152,7 +1156,11 @@ mod affected {
                 .arg("added");
         });
 
-        assert!(predicate::str::contains("\n./other.txt\n").eval(&assert.output()));
+        if cfg!(windows) {
+            assert!(predicate::str::contains("\n.\\other.txt\n").eval(&assert.output()));
+        } else {
+            assert!(predicate::str::contains("\n./other.txt\n").eval(&assert.output()));
+        }
 
         // Then test both
         let assert = sandbox.run_moon(|cmd| {
@@ -1166,7 +1174,11 @@ mod affected {
                 .arg("added");
         });
 
-        assert!(predicate::str::contains("\n./file.txt,./other.txt\n").eval(&assert.output()));
+        if cfg!(windows) {
+            assert!(predicate::str::contains("\n.\\file.txt,.\\other.txt\n").eval(&assert.output()));
+        } else {
+            assert!(predicate::str::contains("\n./file.txt,./other.txt\n").eval(&assert.output()));
+        }
     }
 
     #[test]

--- a/crates/core/task/src/task_options.rs
+++ b/crates/core/task/src/task_options.rs
@@ -5,6 +5,7 @@ use moon_config::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum TaskOptionAffectedFiles {
     Args,
     Env,

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -17,8 +17,9 @@
 - Added `--updateCache` (`-u`) to `moon check` and `moon run` that force updates the cache and
   bypasses any existing cache.
 - Added a new cache level, `read-write`, that can be passed to `--cache` or `MOON_CACHE`. This is
-  now the default level, while `write` is a write-only level.
-- Added `args` and `env` as valid values for the `options.affectedFiles` task option.
+  now the default level, while `write` is now a write-only level.
+- Added `args` and `env` as valid values for the `affectedFiles` task option.
+- Updated `moon run` and `moon query touched-files` to support a list of `--status` options.
 
 ##### Toolchain
 

--- a/packages/types/src/project-config.ts
+++ b/packages/types/src/project-config.ts
@@ -14,7 +14,7 @@ export type TaskMergeStrategy = 'append' | 'prepend' | 'replace';
 export type TaskOutputStyle = 'buffer-only-failure' | 'buffer' | 'hash' | 'none' | 'stream';
 
 export interface TaskOptionsConfig {
-	affectedFiles: boolean | null;
+	affectedFiles: boolean | 'args' | 'env' | null;
 	cache: boolean | null;
 	envFile: boolean | string | null;
 	mergeArgs: TaskMergeStrategy | null;

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -16,7 +16,7 @@ export interface FileGroup {
 }
 
 export interface TaskOptions {
-	affectedFiles: boolean;
+	affectedFiles: 'args' | 'both' | 'env';
 	cache: boolean;
 	envFile: string | null;
 	mergeArgs: TaskMergeStrategy;

--- a/tests/fixtures/cases/files/affected.js
+++ b/tests/fixtures/cases/files/affected.js
@@ -1,0 +1,1 @@
+console.log(process.env.MOON_AFFECTED_FILES);

--- a/tests/fixtures/cases/files/moon.yml
+++ b/tests/fixtures/cases/files/moon.yml
@@ -1,3 +1,8 @@
 tasks:
   noop:
     command: noop
+  affected:
+    command: node ./affected.js
+    options:
+      affectedFiles: true
+    platform: node

--- a/website/blog/2022-12-16_v0.21.mdx
+++ b/website/blog/2022-12-16_v0.21.mdx
@@ -30,3 +30,34 @@ reading any existing cache items, but will force update the cache base on the la
 ```shell
 $ moon run app:build --updateCache
 ```
+
+## New multi-status affected filtering
+
+We support running tasks based on affected files using the
+[`moon run --affected`](../docs/commands/run) command, which is great for reducing the amount of
+tasks being ran, and for applying code quality tooling like git hooks. However, you were only able
+to apply a single status filter, like "deleted" or "modified", which was non-ideal... but no more!
+
+You can now apply multiple statuses by passing the `--status` option multiple times.
+
+```shell
+$ moon run :lint --affected --status modified --status added
+```
+
+This pairs nicely with the recent
+[`affectedFiles` task option](../docs/config/project#affectedfiles) changes!
+
+## Other changes
+
+View the
+[official release](https://github.com/moonrepo/moon/releases/tag/%40moonrepo%2Fcli%400.21.0) for a
+full list of changes.
+
+- Rewritten project and dependency graphs for improved performance.
+- Added args and env var variants to the `affectedFiles` task option.
+
+## What's next?
+
+Expect the following in the v0.21 release!
+
+- Scope tasks defined in `.moon/project.yml` to a project language or type.

--- a/website/docs/commands/query/touched-files.mdx
+++ b/website/docs/commands/query/touched-files.mdx
@@ -47,5 +47,5 @@ This will return a list of absolute file paths with the following stsructure:
   [`vcs.defaultBranch`](../../config/workspace#defaultbranch).
 - `--head <rev>` - Current branch, commit, or revision to compare with. Defaults to `HEAD`.
 - `--local` - Gather files from you local state instead of upstream.
-- `--status <type>` - Filter files based on a touched status.
+- `--status <type>` - Filter files based on a touched status. Can be passed multiple times.
   - Types: `all` (default), `added`, `deleted`, `modified`, `staged`, `unstaged`, `untracked`

--- a/website/docs/commands/run.mdx
+++ b/website/docs/commands/run.mdx
@@ -37,7 +37,7 @@ $ moon run :lint
 #### Affected
 
 - `--affected` - Only run target if affected by changed files, _otherwise_ will always run.
-- `--status <type>` - Filter affected based on a change status.
+- `--status <type>` - Filter affected based on a change status. Can be passed multiple times.
   - Types: `all` (default), `added`, `deleted`, `modified`, `staged`, `unstaged`, `untracked`
 - `--upstream` - Determine affected against upstream by comparing `HEAD` against a base revision
   (default branch), _otherwise_ uses local changes.

--- a/website/docs/run-task.mdx
+++ b/website/docs/run-task.mdx
@@ -77,6 +77,12 @@ We can take this a step further by filtering down affected files based on a chan
 $ moon run app:typecheck --affected --status deleted
 ```
 
+Multiple status can be provided by passing the `--status` option multiple times.
+
+```shell
+$ moon run app:typecheck --affected --status deleted --status modified
+```
+
 ## Passing arguments to the underlying command
 
 If you'd like to pass arbitrary arguments to the underlying task command, in addition to the already


### PR DESCRIPTION
This expands upon our affected detection by allowing multiple statuses to be used.