### PR TITLE
fix: Fix config files unexpectedly changing new lines.

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -54,7 +54,7 @@ run_task = { name = ["clean-test", "run-tests"] }
 
 [tasks.run-tests-with-coverage]
 command = "cargo"
-args = ["llvm-cov", "nextest", "--config-file", "./.cargo/nextest.toml"]
+args = ["llvm-cov", "nextest", "--workspace", "--config-file", "./.cargo/nextest.toml"]
 
 [tasks.test-coverage]
 run_task = { name = ["clean-test", "run-tests-with-coverage"] }

--- a/crates/cli/tests/run_system_test.rs
+++ b/crates/cli/tests/run_system_test.rs
@@ -194,7 +194,6 @@ mod unix {
     mod caching {
         use super::*;
         use moon_cache::RunTargetState;
-        use std::fs;
 
         #[test]
         fn uses_cache_on_subsequent_runs() {

--- a/crates/cli/tests/snapshots/run_node_test__engines__adds_engines_constraint.snap
+++ b/crates/cli/tests/snapshots/run_node_test__engines__adds_engines_constraint.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/cli/tests/run_node_test.rs
-assertion_line: 439
+assertion_line: 446
 expression: "read_to_string(sandbox.path().join(\"package.json\")).unwrap()"
 ---
 {
@@ -13,9 +13,9 @@ expression: "read_to_string(sandbox.path().join(\"package.json\")).unwrap()"
     "swc",
     "version-override"
   ],
+  "packageManager": "npm@8.19.2",
   "engines": {
     "node": "18.0.0"
-  },
-  "packageManager": "npm@8.19.2"
+  }
 }
 

--- a/crates/node/lang/src/package.rs
+++ b/crates/node/lang/src/package.rs
@@ -519,7 +519,7 @@ fn write_preserved_json(path: &Path, package: &PackageJson) -> Result<(), MoonEr
                     root.remove(field);
                 }
             }
-            _ => panic!(),
+            _ => {}
         };
     }
 
@@ -534,8 +534,9 @@ mod test {
     use moon_test_utils::{assert_fs::prelude::*, create_temp_dir};
 
     #[test]
-    fn preserves_order_when_de_to_ser() {
-        let json = r#"{"name": "hello", "description": "world", "private": true}"#;
+    fn preserves_when_saving() {
+        let json =
+            "{\n  \"name\": \"hello\",\n  \"description\": \"world\",\n  \"private\": true\n}\n";
 
         let dir = create_temp_dir();
         let file = dir.child("package.json");
@@ -543,9 +544,12 @@ mod test {
 
         let mut package = PackageJson::read(dir.path()).unwrap().unwrap();
 
+        // Trigger dirty
+        package.dirty.push("unknown".into());
+
         package.save().unwrap();
 
-        assert_eq!(json::read_to_string(file.path()).unwrap(), json,);
+        assert_eq!(json::read_to_string(file.path()).unwrap(), json);
     }
 
     mod add_dependency {

--- a/crates/typescript/lang/src/tsconfig.rs
+++ b/crates/typescript/lang/src/tsconfig.rs
@@ -765,7 +765,7 @@ fn write_preserved_json(path: &Path, tsconfig: &TsConfigJson) -> Result<(), Moon
                     }
                 }
             }
-            _ => panic!(),
+            _ => {}
         }
     }
 
@@ -777,8 +777,26 @@ fn write_preserved_json(path: &Path, tsconfig: &TsConfigJson) -> Result<(), Moon
 #[cfg(test)]
 mod test {
     use super::*;
-    use moon_test_utils::get_fixtures_path;
+    use moon_test_utils::{assert_fs::prelude::*, create_temp_dir, get_fixtures_path};
     use moon_utils::string_vec;
+
+    #[test]
+    fn preserves_when_saving() {
+        let json = "{\n  \"compilerOptions\": {},\n  \"files\": [\n    \"**/*\"\n  ]\n}\n";
+
+        let dir = create_temp_dir();
+        let file = dir.child("tsconfig.json");
+        file.write_str(json).unwrap();
+
+        let mut package = TsConfigJson::read(dir.path()).unwrap().unwrap();
+
+        // Trigger dirty
+        package.dirty.push("unknown".into());
+
+        package.save().unwrap();
+
+        assert_eq!(json::read_to_string(file.path()).unwrap(), json);
+    }
 
     #[test]
     fn serializes_special_fields() {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -29,8 +29,7 @@
 #### 🐞 Fixes
 
 - Fixed an issue where "installing yarn" would constantly show.
-- Fixed an issue on Windows where `package.json` and `tsconfig.json` would be modified and linefeeds
-  would change.
+- Fixed an issue on Windows where `package.json` and `tsconfig.json` would change newlines unexpectedly when saving.
 
 ## 0.20.3
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -29,6 +29,8 @@
 #### 🐞 Fixes
 
 - Fixed an issue where "installing yarn" would constantly show.
+- Fixed an issue on Windows where `package.json` and `tsconfig.json` would be modified and linefeeds
+  would change.
 
 ## 0.20.3
 


### PR DESCRIPTION
I noticed on Windows that running a task would modify a bunch of package.json/tsconfig.json files, but it wouldn't change it's contents, but would change the newline character.

To combat this, I'm improving the dirty check logic, and improving the test cases.