### PR TITLE
new: Add `--minimal` option to `moon init`.

### DIFF
--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -140,6 +140,9 @@ pub enum Commands {
         #[arg(long, help = "Overwrite existing configurations")]
         force: bool,
 
+        #[arg(long, help = "Initialize with minimal configuration and prompts")]
+        minimal: bool,
+
         #[arg(long, help = "Skip prompts and use default values")]
         yes: bool,
 

--- a/crates/cli/src/commands/init/mod.rs
+++ b/crates/cli/src/commands/init/mod.rs
@@ -197,10 +197,12 @@ pub async fn init(
         render_workspace_template(&context)?,
     )?;
 
-    fs::write(
-        moon_dir.join(CONFIG_GLOBAL_PROJECT_FILENAME),
-        Tera::one_off(load_global_project_config_template(), &context, false)?,
-    )?;
+    if !options.minimal {
+        fs::write(
+            moon_dir.join(CONFIG_GLOBAL_PROJECT_FILENAME),
+            Tera::one_off(load_global_project_config_template(), &context, false)?,
+        )?;
+    }
 
     // Append to ignore file
     let mut file = OpenOptions::new()

--- a/crates/cli/src/commands/init/mod.rs
+++ b/crates/cli/src/commands/init/mod.rs
@@ -53,6 +53,7 @@ fn create_default_context() -> Context {
 
 pub struct InitOptions {
     pub force: bool,
+    pub minimal: bool,
     pub yes: bool,
 }
 

--- a/crates/cli/src/commands/init/node.rs
+++ b/crates/cli/src/commands/init/node.rs
@@ -196,7 +196,7 @@ pub async fn init_node(
         detect_projects(dest_dir, options, parent_context, theme)?;
     }
 
-    let alias_names = if options.yes {
+    let alias_names = if options.yes || options.minimal {
         false
     } else {
         Confirm::with_theme(theme)
@@ -207,7 +207,7 @@ pub async fn init_node(
             .interact()?
     };
 
-    let infer_tasks = if options.yes {
+    let infer_tasks = if options.yes || options.minimal {
         false
     } else {
         Confirm::with_theme(theme)
@@ -226,6 +226,7 @@ pub async fn init_node(
     context.insert("package_manager_version", &package_manager.1);
     context.insert("alias_names", &alias_names);
     context.insert("infer_tasks", &infer_tasks);
+    context.insert("minimal", &options.minimal);
 
     Ok(render_template(context)?)
 }

--- a/crates/cli/src/commands/init/node.rs
+++ b/crates/cli/src/commands/init/node.rs
@@ -250,6 +250,20 @@ mod tests {
     }
 
     #[test]
+    fn renders_minimal() {
+        let mut context = Context::new();
+        context.insert("node_version", &"16.0.0");
+        context.insert("node_version_manager", &"");
+        context.insert("package_manager", &"npm");
+        context.insert("package_manager_version", &"8.0.0");
+        context.insert("alias_names", &false);
+        context.insert("infer_tasks", &false);
+        context.insert("minimal", &true);
+
+        assert_snapshot!(render_template(context).unwrap());
+    }
+
+    #[test]
     fn renders_nvm() {
         let mut context = Context::new();
         context.insert("node_version", &"18.1.0");

--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__node__tests__renders_minimal.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__node__tests__renders_minimal.snap
@@ -1,0 +1,11 @@
+---
+source: crates/cli/src/commands/init/node.rs
+assertion_line: 263
+expression: render_template(context).unwrap()
+---
+node:
+  version: '16.0.0'
+  packageManager: 'npm'
+  npm:
+    version: '8.0.0'
+

--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__typescript__tests__renders_minimal.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__typescript__tests__renders_minimal.snap
@@ -1,0 +1,8 @@
+---
+source: crates/cli/src/commands/init/typescript.rs
+assertion_line: 84
+expression: render_template(context).unwrap()
+---
+typescript:
+  syncProjectReferences: false
+

--- a/crates/cli/src/commands/init/typescript.rs
+++ b/crates/cli/src/commands/init/typescript.rs
@@ -28,6 +28,7 @@ pub async fn init_typescript(
         }
     } else {
         options.yes
+            || options.minimal
             || Confirm::with_theme(theme)
                 .with_prompt("Use project references?")
                 .interact()?
@@ -36,7 +37,7 @@ pub async fn init_typescript(
     let mut route_cache = false;
     let mut sync_paths = false;
 
-    if project_refs {
+    if project_refs && !options.minimal {
         route_cache = options.yes
             || Confirm::with_theme(theme)
                 .with_prompt("Route declaration output to moons cache?")
@@ -52,6 +53,7 @@ pub async fn init_typescript(
     context.insert("project_refs", &project_refs);
     context.insert("route_cache", &route_cache);
     context.insert("sync_paths", &sync_paths);
+    context.insert("minimal", &options.minimal);
 
     Ok(render_template(context)?)
 }

--- a/crates/cli/src/commands/init/typescript.rs
+++ b/crates/cli/src/commands/init/typescript.rs
@@ -74,6 +74,17 @@ mod tests {
     }
 
     #[test]
+    fn renders_minimal() {
+        let mut context = Context::new();
+        context.insert("project_refs", &false);
+        context.insert("route_cache", &false);
+        context.insert("sync_paths", &false);
+        context.insert("minimal", &true);
+
+        assert_snapshot!(render_template(context).unwrap());
+    }
+
+    #[test]
     fn renders_project_refs() {
         let mut context = Context::new();
         context.insert("project_refs", &true);

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -131,6 +131,7 @@ pub async fn run_cli() {
         Commands::Init {
             dest,
             force,
+            minimal,
             tool,
             yes,
         } => {
@@ -139,6 +140,7 @@ pub async fn run_cli() {
                 tool.as_ref(),
                 InitOptions {
                     force: *force,
+                    minimal: *minimal,
                     yes: *yes,
                 },
             )

--- a/crates/cli/tests/init_node_test.rs
+++ b/crates/cli/tests/init_node_test.rs
@@ -1,8 +1,21 @@
-use moon_test_utils::{create_sandbox, predicates::prelude::*};
+use moon_test_utils::{assert_snapshot, create_sandbox, predicates::prelude::*};
 use std::fs;
 
 mod init_node {
     use super::*;
+
+    #[test]
+    fn minimal() {
+        let sandbox = create_sandbox("init-sandbox");
+        let root = sandbox.path().to_path_buf();
+        let config = root.join(".moon").join("toolchain.yml");
+
+        sandbox.run_moon(|cmd| {
+            cmd.arg("init").arg("--yes").arg("--minimal").arg(root);
+        });
+
+        assert_snapshot!(fs::read_to_string(config).unwrap());
+    }
 
     #[test]
     fn infers_version_from_nvm() {

--- a/crates/cli/tests/init_test.rs
+++ b/crates/cli/tests/init_test.rs
@@ -28,6 +28,21 @@ fn creates_files_in_dest() {
 }
 
 #[test]
+fn doesnt_create_project_config_when_minimal() {
+    let sandbox = create_sandbox("init-sandbox");
+    let root = sandbox.path().to_path_buf();
+    let project_config = root.join(".moon").join(CONFIG_GLOBAL_PROJECT_FILENAME);
+
+    assert!(!project_config.exists());
+
+    sandbox.run_moon(|cmd| {
+        cmd.arg("init").arg("--yes").arg("--minimal").arg(root);
+    });
+
+    assert!(!project_config.exists());
+}
+
+#[test]
 fn creates_workspace_config_from_template() {
     let sandbox = create_sandbox("init-sandbox");
     let root = sandbox.path().to_path_buf();

--- a/crates/cli/tests/snapshots/init_node_test__init_node__minimal.snap
+++ b/crates/cli/tests/snapshots/init_node_test__init_node__minimal.snap
@@ -1,0 +1,19 @@
+---
+source: crates/cli/tests/init_node_test.rs
+assertion_line: 17
+expression: "fs::read_to_string(config).unwrap()"
+---
+# https://moonrepo.dev/docs/config/toolchain
+$schema: 'https://moonrepo.dev/schemas/toolchain.json'
+
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/toolchain.yml'
+
+node:
+  version: '18.12.0'
+  packageManager: 'npm'
+  npm:
+    version: '8.19.2'
+
+typescript:
+  syncProjectReferences: true

--- a/crates/core/config/templates/toolchain_node.yml
+++ b/crates/core/config/templates/toolchain_node.yml
@@ -1,4 +1,4 @@
-{%- if minimal %}
+{%- if minimal -%}
 
 node:
   version: '{{ node_version }}'
@@ -6,7 +6,7 @@ node:
   {{ package_manager }}:
     version: '{{ package_manager_version }}'
 
-{%- else %}
+{%- else -%}
 
 # Configures Node.js within the toolchain. moon manages its own version of Node.js
 # instead of relying on a version found on the host machine. This ensures deterministic

--- a/crates/core/config/templates/toolchain_node.yml
+++ b/crates/core/config/templates/toolchain_node.yml
@@ -1,3 +1,13 @@
+{%- if minimal %}
+
+node:
+  version: '{{ node_version }}'
+  packageManager: '{{ package_manager }}'
+  {{ package_manager }}:
+    version: '{{ package_manager_version }}'
+
+{%- else %}
+
 # Configures Node.js within the toolchain. moon manages its own version of Node.js
 # instead of relying on a version found on the host machine. This ensures deterministic
 # and reproducible builds across any machine.
@@ -45,4 +55,6 @@ node:
   syncVersionManagerConfig: 'nodenv'
 {%- else %}
   # syncVersionManagerConfig: 'nvm'
+{%- endif %}
+
 {%- endif %}

--- a/crates/core/config/templates/toolchain_typescript.yml
+++ b/crates/core/config/templates/toolchain_typescript.yml
@@ -1,3 +1,10 @@
+{%- if minimal %}
+
+typescript:
+  syncProjectReferences: {{ project_refs }}
+
+{%- else %}
+
 # Configures how moon integrates with TypeScript.
 typescript:
   # When `syncProjectReferences` is enabled and a dependent project reference
@@ -25,3 +32,5 @@ typescript:
   # Sync a project's project references as import aliases to the `paths`
   # compiler option in each applicable project.
   syncProjectReferencesToPaths: {{ project_refs and sync_paths }}
+
+{%- endif %}

--- a/crates/core/config/templates/toolchain_typescript.yml
+++ b/crates/core/config/templates/toolchain_typescript.yml
@@ -1,9 +1,9 @@
-{%- if minimal %}
+{%- if minimal -%}
 
 typescript:
   syncProjectReferences: {{ project_refs }}
 
-{%- else %}
+{%- else -%}
 
 # Configures how moon integrates with TypeScript.
 typescript:

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Added `--updateCache` (`-u`) to `moon check` and `moon run` that force updates the cache and
   bypasses any existing cache.
+- Added `--minimal` to `moon init` for quick scaffolding and prototyping.
 - Added a new cache level, `read-write`, that can be passed to `--cache` or `MOON_CACHE`. This is
   now the default level, while `write` is now a write-only level.
 - Added `args` and `env` as valid values for the `affectedFiles` task option.

--- a/website/blog/2022-12-16_v0.21.mdx
+++ b/website/blog/2022-12-16_v0.21.mdx
@@ -55,6 +55,7 @@ full list of changes.
 
 - Rewritten project and dependency graphs for improved performance.
 - Added args and env var variants to the `affectedFiles` task option.
+- Added `--minimal` to `moon init` for quick scaffolding and prototyping.
 
 ## What's next?
 

--- a/website/docs/setup-workspace.mdx
+++ b/website/docs/setup-workspace.mdx
@@ -35,6 +35,13 @@ When executed, the following operations will be applied.
 - Infers languages and dependency managers to register in the toolchain.
 - Infers the version control system from the environment.
 
+:::info
+
+If you're investigating moon, or merely want to prototype, you can use `moon init --minimal` to
+quickly initialize and create minimal configuration files.
+
+:::
+
 ## Configuring a version control system
 
 moon requires a version control system (VCS) to be present for functionality like file diffing,


### PR DESCRIPTION
Provides a simple way to test moon without having to go through all the configuration and "overhead".