### PR TITLE
new: Use presigned URLs for remote caching.

### DIFF
--- a/crates/core/moonbase/src/api.rs
+++ b/crates/core/moonbase/src/api.rs
@@ -36,4 +36,5 @@ pub struct Artifact {
 #[serde(rename_all = "camelCase")]
 pub struct ArtifactResponse {
     pub artifact: Artifact,
+    pub presigned_url: Option<String>,
 }

--- a/crates/core/moonbase/src/lib.rs
+++ b/crates/core/moonbase/src/lib.rs
@@ -106,16 +106,16 @@ impl Moonbase {
         dest_path: &Path,
         download_url: &Option<String>,
     ) -> Result<(), MoonbaseError> {
-        let response = reqwest::Client::new()
-            .get(if let Some(url) = download_url {
-                url.to_owned()
-            } else {
-                format!("{}/artifacts/{}/download", get_host(), hash)
-            })
-            .bearer_auth(&self.auth_token)
-            .header("Accept", "application/json")
-            .send()
-            .await?;
+        let response = if let Some(url) = download_url {
+            reqwest::Client::new().get(url)
+        } else {
+            reqwest::Client::new()
+                .get(format!("{}/artifacts/{}/download", get_host(), hash))
+                .bearer_auth(&self.auth_token)
+                .header("Accept", "application/json")
+        };
+
+        let response = response.send().await?;
         let status = response.status();
 
         if status.is_success() {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
   now the default level, while `write` is now a write-only level.
 - Added `--minimal` to `moon init` for quick scaffolding and prototyping.
 - Updated the system platform to include the operating system and architecture when hashing.
+- Updated remote caching to use presigned URLs when available.
 
 ##### Graphs
 


### PR DESCRIPTION
We will start using these on the backend.