### PR TITLE
internal: Change artifact upload endpoint.

### DIFF
--- a/crates/core/runner/src/subscribers/moonbase_cache.rs
+++ b/crates/core/runner/src/subscribers/moonbase_cache.rs
@@ -80,7 +80,7 @@ impl Subscriber for MoonbaseCacheSubscriber {
                     // while waiting for very large archives to upload.
                     self.requests.push(tokio::spawn(async move {
                         if let Err(error) =
-                            upload_artifact(auth_token, hash, target, archive_path).await
+                            upload_artifact(auth_token, hash, target, archive_path, None).await
                         {
                             handle_error(error);
                         }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - We now include the version and file path of the moon binary being executed in the logs for
   debugging purposes.
+- Updated remote caching to use a new upload endpoint.
 
 ## 0.21.1
 


### PR DESCRIPTION
We're making some changes to the upstream remote caching API, so this change future proofs us.