### PR TITLE
internal: Make `node.version` optional and decouple crates.

### DIFF
--- a/.yarn/versions/f656d236.yml
+++ b/.yarn/versions/f656d236.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": minor
+  "@moonrepo/core-linux-arm64-gnu": minor
+  "@moonrepo/core-linux-arm64-musl": minor
+  "@moonrepo/core-linux-x64-gnu": minor
+  "@moonrepo/core-linux-x64-musl": minor
+  "@moonrepo/core-macos-arm64": minor
+  "@moonrepo/core-macos-x64": minor
+  "@moonrepo/core-windows-x64-msvc": minor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,7 +1781,6 @@ dependencies = [
  "figment",
  "moon_constants",
  "moon_error",
- "moon_node_lang",
  "moon_test_utils",
  "moon_utils",
  "reqwest",

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -11,13 +11,15 @@ pub async fn setup() -> Result<(), AnyError> {
     let project_graph = generate_project_graph(&mut workspace)?;
     let mut dep_builder = build_dep_graph(&workspace, &project_graph);
 
-    if let Some(node) = &workspace.toolchain.config.node {
-        let runtime = Runtime::Node(Version(node.version.to_owned(), false));
+    if let Some(node_config) = &workspace.toolchain.config.node {
+        if let Some(node_version) = &node_config.version {
+            let runtime = Runtime::Node(Version(node_version.to_owned(), false));
 
-        if is_test_env() {
-            dep_builder.setup_tool(&runtime);
-        } else {
-            dep_builder.install_workspace_deps(&runtime);
+            if is_test_env() {
+                dep_builder.setup_tool(&runtime);
+            } else {
+                dep_builder.install_workspace_deps(&runtime);
+            }
         }
     }
 

--- a/crates/core/config/Cargo.toml
+++ b/crates/core/config/Cargo.toml
@@ -15,7 +15,6 @@ crate-type = ["rlib"]
 [dependencies]
 moon_constants = { path = "../constants" }
 moon_error = { path = "../error" }
-moon_node_lang = { path = "../../node/lang" }
 moon_utils = { path = "../utils" }
 figment = { version = "0.10.8", features = ["test", "yaml"] }
 reqwest = { workspace = true, features = ["blocking", "native-tls-vendored"] }

--- a/crates/core/config/src/toolchain/config.rs
+++ b/crates/core/config/src/toolchain/config.rs
@@ -52,7 +52,7 @@ impl ToolchainConfig {
         if let Some(node_config) = &mut config.node {
             // Versions from env vars should take precedence
             if let Ok(node_version) = env::var("MOON_NODE_VERSION") {
-                node_config.version = node_version;
+                node_config.version = Some(node_version);
             }
 
             if let Ok(npm_version) = env::var("MOON_NPM_VERSION") {

--- a/crates/core/config/src/toolchain/node.rs
+++ b/crates/core/config/src/toolchain/node.rs
@@ -166,7 +166,7 @@ pub struct NodeConfig {
     pub sync_version_manager_config: Option<NodeVersionManager>,
 
     #[validate(custom = "validate_node_version")]
-    pub version: String,
+    pub version: Option<String>,
 
     #[validate]
     pub yarn: Option<YarnConfig>,
@@ -186,7 +186,7 @@ impl Default for NodeConfig {
             pnpm: None,
             sync_project_workspace_dependencies: true,
             sync_version_manager_config: None,
-            version: default_node_version(),
+            version: Some(default_node_version()),
             yarn: None,
         }
     }
@@ -195,7 +195,7 @@ impl Default for NodeConfig {
 impl NodeConfig {
     pub fn with_project_override(&self, version: &str) -> Self {
         let mut config = self.clone();
-        config.version = version.to_owned();
+        config.version = Some(version.to_owned());
 
         // These settings should not be ran in a project, only the root
         config.add_engines_constraint = false;

--- a/crates/core/config/src/toolchain/node.rs
+++ b/crates/core/config/src/toolchain/node.rs
@@ -1,24 +1,23 @@
 use crate::validators::validate_semver_version;
-use moon_node_lang::{NODE, NODENV, NPM, NVM, PNPM, YARN};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::env;
 use validator::{Validate, ValidationError};
 
 pub fn default_node_version() -> String {
-    env::var("MOON_NODE_VERSION").unwrap_or_else(|_| NODE.default_version.to_string())
+    env::var("MOON_NODE_VERSION").unwrap_or_else(|_| "18.12.0".to_string())
 }
 
 pub fn default_npm_version() -> String {
-    env::var("MOON_NPM_VERSION").unwrap_or_else(|_| NPM.default_version.to_string())
+    env::var("MOON_NPM_VERSION").unwrap_or_else(|_| "8.19.2".to_string())
 }
 
 pub fn default_pnpm_version() -> String {
-    env::var("MOON_PNPM_VERSION").unwrap_or_else(|_| PNPM.default_version.to_string())
+    env::var("MOON_PNPM_VERSION").unwrap_or_else(|_| "7.18.2".to_string())
 }
 
 pub fn default_yarn_version() -> String {
-    env::var("MOON_YARN_VERSION").unwrap_or_else(|_| YARN.default_version.to_string())
+    env::var("MOON_YARN_VERSION").unwrap_or_else(|_| "3.3.0".to_string())
 }
 
 fn validate_node_version(value: &str) -> Result<(), ValidationError> {
@@ -89,15 +88,6 @@ pub enum NodePackageManager {
 pub enum NodeVersionManager {
     Nodenv,
     Nvm,
-}
-
-impl NodeVersionManager {
-    pub fn get_config_filename(&self) -> String {
-        match self {
-            NodeVersionManager::Nodenv => String::from(NODENV.version_file),
-            NodeVersionManager::Nvm => String::from(NVM.version_file),
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize, Validate)]

--- a/crates/core/config/tests/toolchain_test.rs
+++ b/crates/core/config/tests/toolchain_test.rs
@@ -50,7 +50,7 @@ mod extends {
             config,
             ToolchainConfig {
                 node: Some(NodeConfig {
-                    version: "4.5.6".into(),
+                    version: Some("4.5.6".into()),
                     add_engines_constraint: true,
                     dedupe_on_lockfile_change: false,
                     package_manager: NodePackageManager::Yarn,
@@ -191,7 +191,10 @@ node:
             assert!(!config.typescript.unwrap().sync_project_references);
 
             // Ensure we can override the extended config
-            assert_eq!(config.node.as_ref().unwrap().version, "18.0.0".to_owned());
+            assert_eq!(
+                config.node.as_ref().unwrap().version.as_ref().unwrap(),
+                "18.0.0"
+            );
             assert_eq!(
                 config.node.as_ref().unwrap().npm.version,
                 "8.0.0".to_owned()
@@ -228,7 +231,10 @@ node:
             assert!(!config.typescript.unwrap().sync_project_references);
 
             // Ensure we can override the extended config
-            assert_eq!(config.node.as_ref().unwrap().version, "18.0.0".to_owned());
+            assert_eq!(
+                config.node.as_ref().unwrap().version.as_ref().unwrap(),
+                "18.0.0"
+            );
             assert_eq!(
                 config.node.as_ref().unwrap().npm.version,
                 "8.0.0".to_owned()
@@ -408,7 +414,7 @@ node:
 
             let config = super::load_jailed_config(jail.directory())?;
 
-            assert_eq!(config.node.unwrap().version, String::from("4.5.6"));
+            assert_eq!(config.node.unwrap().version.unwrap(), String::from("4.5.6"));
 
             Ok(())
         });

--- a/crates/core/dep-graph/tests/dep_graph_test.rs
+++ b/crates/core/dep-graph/tests/dep_graph_test.rs
@@ -30,7 +30,7 @@ async fn create_project_graph() -> (Workspace, ProjectGraph, Sandbox) {
     };
     let toolchain_config = ToolchainConfig {
         node: Some(NodeConfig {
-            version: "16.0.0".into(),
+            version: Some("16.0.0".into()),
             dedupe_on_lockfile_change: false,
             ..NodeConfig::default()
         }),
@@ -82,7 +82,7 @@ async fn create_tasks_project_graph() -> (Workspace, ProjectGraph, Sandbox) {
     };
     let toolchain_config = ToolchainConfig {
         node: Some(NodeConfig {
-            version: "16.0.0".into(),
+            version: Some("16.0.0".into()),
             ..NodeConfig::default()
         }),
         ..ToolchainConfig::default()

--- a/crates/core/lang/src/lib.rs
+++ b/crates/core/lang/src/lib.rs
@@ -11,8 +11,6 @@ type StaticStringList = &'static [StaticString];
 pub struct Language {
     pub binary: StaticString,
 
-    pub default_version: StaticString,
-
     pub file_exts: StaticStringList,
 
     pub vendor_bins_dir: Option<StaticString>,
@@ -24,8 +22,6 @@ pub struct DependencyManager {
     pub binary: StaticString,
 
     pub config_files: StaticStringList,
-
-    pub default_version: StaticString,
 
     pub lockfile: StaticString,
 

--- a/crates/core/moon/src/lib.rs
+++ b/crates/core/moon/src/lib.rs
@@ -16,10 +16,12 @@ pub fn register_platforms(workspace: &mut Workspace) -> Result<(), WorkspaceErro
     if let Some(node_config) = workspace.toolchain.config.node.clone() {
         workspace.register_platform(Box::new(NodePlatform::new(&node_config, &workspace.root)));
 
-        workspace
-            .toolchain
-            .node
-            .register(Box::new(NodeTool::new(&node_config, &paths)?), true);
+        if node_config.version.is_some() {
+            workspace
+                .toolchain
+                .node
+                .register(Box::new(NodeTool::new(&node_config, &paths)?), true);
+        }
     }
 
     // Should be last since it's the last resort
@@ -65,11 +67,13 @@ pub async fn load_workspace_with_toolchain() -> Result<Workspace, WorkspaceError
         match platform {
             PlatformType::Node => {
                 if let Some(node_config) = &workspace.toolchain.config.node {
-                    workspace
-                        .toolchain
-                        .node
-                        .setup(&node_config.version, &mut last_versions)
-                        .await?;
+                    if let Some(node_version) = &node_config.version {
+                        workspace
+                            .toolchain
+                            .node
+                            .setup(node_version, &mut last_versions)
+                            .await?;
+                    }
                 }
             }
             PlatformType::System | PlatformType::Unknown => {}

--- a/crates/core/test-utils/src/configs.rs
+++ b/crates/core/test-utils/src/configs.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 pub fn get_default_toolchain() -> ToolchainConfig {
     ToolchainConfig {
         node: Some(NodeConfig {
-            version: "18.0.0".into(),
+            version: Some("18.0.0".into()),
             add_engines_constraint: false,
             dedupe_on_lockfile_change: false,
             infer_tasks_from_scripts: false,
@@ -123,7 +123,7 @@ pub fn get_project_graph_aliases_fixture_configs(
 
     let toolchain_config = ToolchainConfig {
         node: Some(NodeConfig {
-            version: "18.0.0".into(),
+            version: Some("18.0.0".into()),
             add_engines_constraint: false,
             alias_package_names: Some(NodeProjectAliasFormat::NameAndScope),
             dedupe_on_lockfile_change: false,

--- a/crates/deno/lang/src/lib.rs
+++ b/crates/deno/lang/src/lib.rs
@@ -2,7 +2,6 @@ use moon_lang::{Language, VersionManager};
 
 pub const DENO: Language = Language {
     binary: "deno",
-    default_version: "1.29.1",
     file_exts: &["js", "jsx", "ts", "tsx"],
     vendor_bins_dir: None,
     vendor_dir: Some("vendor"),

--- a/crates/go/lang/src/lib.rs
+++ b/crates/go/lang/src/lib.rs
@@ -2,7 +2,6 @@ use moon_lang::{DependencyManager, Language, VersionManager};
 
 pub const GO: Language = Language {
     binary: "go",
-    default_version: "1.19.4",
     file_exts: &["go"],
     vendor_bins_dir: None,
     vendor_dir: Some("vendor"),
@@ -13,7 +12,6 @@ pub const GO: Language = Language {
 pub const GOMOD: DependencyManager = DependencyManager {
     binary: "go mod",
     config_files: &[],
-    default_version: "1.19.4",
     lockfile: "go.sum",
     manifest: "go.mod",
 };

--- a/crates/node/lang/src/lib.rs
+++ b/crates/node/lang/src/lib.rs
@@ -11,7 +11,6 @@ use moon_lang::{DependencyManager, Language, VersionManager};
 
 pub const NODE: Language = Language {
     binary: "node",
-    default_version: "18.12.0",
     file_exts: &["js", "cjs", "mjs"],
     vendor_bins_dir: Some("node_modules/.bin"),
     vendor_dir: Some("node_modules"),
@@ -22,7 +21,6 @@ pub const NODE: Language = Language {
 pub const NPM: DependencyManager = DependencyManager {
     binary: "npm",
     config_files: &[".npmrc"],
-    default_version: "8.19.2",
     lockfile: "package-lock.json",
     manifest: "package.json",
 };
@@ -30,7 +28,6 @@ pub const NPM: DependencyManager = DependencyManager {
 pub const PNPM: DependencyManager = DependencyManager {
     binary: "pnpm",
     config_files: &[".npmrc", ".pnpmfile.cjs", "pnpm-workspace.yaml"],
-    default_version: "7.18.2",
     lockfile: "pnpm-lock.yaml",
     manifest: "package.json",
 };
@@ -38,7 +35,6 @@ pub const PNPM: DependencyManager = DependencyManager {
 pub const YARN: DependencyManager = DependencyManager {
     binary: "yarn",
     config_files: &[".yarn", ".yarnrc", ".yarnrc.yml"],
-    default_version: "3.3.0",
     lockfile: "yarn.lock",
     manifest: "package.json",
 };

--- a/crates/node/platform/src/actions/install_deps.rs
+++ b/crates/node/platform/src/actions/install_deps.rs
@@ -1,10 +1,10 @@
 use moon_action::{Action, ActionStatus};
-use moon_config::NodePackageManager;
+use moon_config::{NodePackageManager, NodeVersionManager};
 use moon_error::map_io_to_fs_error;
 use moon_error::MoonError;
 use moon_lang::has_vendor_installed_dependencies;
 use moon_logger::{color, debug, warn};
-use moon_node_lang::{PackageJson, NODE, NPM};
+use moon_node_lang::{PackageJson, NODE, NODENV, NPM, NVM};
 use moon_node_tool::NodeTool;
 use moon_platform::Runtime;
 use moon_project::Project;
@@ -80,7 +80,11 @@ fn sync_workspace(workspace: &Workspace, node: &NodeTool) -> Result<(), MoonErro
 
     // Create nvm/nodenv version file
     if let Some(version_manager) = &node.config.sync_version_manager_config {
-        let rc_name = version_manager.get_config_filename();
+        let rc_name = match version_manager {
+            NodeVersionManager::Nodenv => NODENV.version_file.to_string(),
+            NodeVersionManager::Nvm => NVM.version_file.to_string(),
+        };
+
         let rc_path = workspace.root.join(&rc_name);
 
         fs::write(rc_path, &node.config.version)?;

--- a/crates/node/platform/src/actions/install_deps.rs
+++ b/crates/node/platform/src/actions/install_deps.rs
@@ -56,14 +56,16 @@ fn add_package_manager(node: &NodeTool, package_json: &mut PackageJson) -> bool 
 
 /// Add `engines` constraint to root `package.json`.
 fn add_engines_constraint(node: &NodeTool, package_json: &mut PackageJson) -> bool {
-    if node.config.add_engines_constraint && package_json.add_engine("node", &node.config.version) {
-        debug!(
-            target: LOG_TARGET,
-            "Adding engines version constraint to root {}",
-            color::file(NPM.manifest)
-        );
+    if let Some(node_version) = &node.config.version {
+        if node.config.add_engines_constraint && package_json.add_engine("node", node_version) {
+            debug!(
+                target: LOG_TARGET,
+                "Adding engines version constraint to root {}",
+                color::file(NPM.manifest)
+            );
 
-        return true;
+            return true;
+        }
     }
 
     false
@@ -85,15 +87,17 @@ fn sync_workspace(workspace: &Workspace, node: &NodeTool) -> Result<(), MoonErro
             NodeVersionManager::Nvm => NVM.version_file.to_string(),
         };
 
-        let rc_path = workspace.root.join(&rc_name);
+        if let Some(node_version) = &node.config.version {
+            let rc_path = workspace.root.join(&rc_name);
 
-        fs::write(rc_path, &node.config.version)?;
+            fs::write(rc_path, node_version)?;
 
-        debug!(
-            target: LOG_TARGET,
-            "Syncing Node.js version to root {}",
-            color::file(&rc_name)
-        );
+            debug!(
+                target: LOG_TARGET,
+                "Syncing Node.js version to root {}",
+                color::file(&rc_name)
+            );
+        }
     }
 
     Ok(())

--- a/crates/node/platform/src/hasher.rs
+++ b/crates/node/platform/src/hasher.rs
@@ -24,10 +24,10 @@ pub struct NodeTargetHasher {
 }
 
 impl NodeTargetHasher {
-    pub fn new(node_version: String) -> Self {
+    pub fn new(node_version: Option<String>) -> Self {
         NodeTargetHasher {
-            node_version,
-            version: String::from("1"),
+            node_version: node_version.unwrap_or_else(|| "unknown".into()),
+            version: "1".into(),
             ..NodeTargetHasher::default()
         }
     }
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn returns_default_hash() {
-        let hasher = NodeTargetHasher::new(String::from("0.0.0"));
+        let hasher = NodeTargetHasher::new(Some("0.0.0".into()));
 
         assert_eq!(
             to_hash_only(&hasher),
@@ -117,15 +117,15 @@ mod tests {
 
     #[test]
     fn returns_same_hash_if_called_again() {
-        let hasher = NodeTargetHasher::new(String::from("0.0.0"));
+        let hasher = NodeTargetHasher::new(Some("0.0.0".into()));
 
         assert_eq!(to_hash_only(&hasher), to_hash_only(&hasher));
     }
 
     #[test]
     fn returns_different_hash_for_diff_contents() {
-        let hasher1 = NodeTargetHasher::new(String::from("0.0.0"));
-        let hasher2 = NodeTargetHasher::new(String::from("1.0.0"));
+        let hasher1 = NodeTargetHasher::new(Some("0.0.0".into()));
+        let hasher2 = NodeTargetHasher::new(Some("1.0.0".into()));
 
         assert_ne!(to_hash_only(&hasher1), to_hash_only(&hasher2));
     }
@@ -140,10 +140,10 @@ mod tests {
             let mut package1 = PackageJson::default();
             package1.add_dependency("react", "17.0.0", true);
 
-            let mut hasher1 = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher1 = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher1.hash_package_json(&package1, &resolved_deps);
 
-            let mut hasher2 = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher2 = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher2.hash_package_json(&package1, &resolved_deps);
             hasher2.hash_package_json(&package1, &resolved_deps);
 
@@ -160,11 +160,11 @@ mod tests {
             let mut package2 = PackageJson::default();
             package2.add_dependency("react-dom", "17.0.0", true);
 
-            let mut hasher1 = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher1 = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher1.hash_package_json(&package2, &resolved_deps);
             hasher1.hash_package_json(&package1, &resolved_deps);
 
-            let mut hasher2 = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher2 = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher2.hash_package_json(&package1, &resolved_deps);
             hasher2.hash_package_json(&package2, &resolved_deps);
 
@@ -181,7 +181,7 @@ mod tests {
             let mut package2 = PackageJson::default();
             package2.add_dependency("react", "18.0.0", true);
 
-            let mut hasher1 = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher1 = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher1.hash_package_json(&package1, &resolved_deps);
 
             let hash1 = to_hash_only(&hasher1);
@@ -204,21 +204,21 @@ mod tests {
             let mut package = PackageJson::default();
             package.add_dependency("moment", "10.0.0", true);
 
-            let mut hasher1 = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher1 = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher1.hash_package_json(&package, &resolved_deps);
             let hash1 = to_hash_only(&hasher1);
 
             package.dev_dependencies =
                 Some(BTreeMap::from([("eslint".to_owned(), "8.0.0".to_owned())]));
 
-            let mut hasher2 = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher2 = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher2.hash_package_json(&package, &resolved_deps);
             let hash2 = to_hash_only(&hasher2);
 
             package.peer_dependencies =
                 Some(BTreeMap::from([("react".to_owned(), "18.0.0".to_owned())]));
 
-            let mut hasher3 = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher3 = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher3.hash_package_json(&package, &resolved_deps);
             let hash3 = to_hash_only(&hasher3);
 
@@ -236,7 +236,7 @@ mod tests {
             package.add_dependency("prettier", "^2.0.0", true);
             package.add_dependency("rollup", "^2.0.0", true);
 
-            let mut hasher = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher.hash_package_json(&package, &resolved_deps);
 
             assert_eq!(
@@ -258,7 +258,7 @@ mod tests {
             let mut package = PackageJson::default();
             package.add_dependency("prettier", "^2.0.0", true);
 
-            let mut hasher = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher.hash_package_json(&package, &resolved_deps);
 
             assert_eq!(
@@ -287,7 +287,7 @@ mod tests {
 
             tsconfig.compiler_options.as_mut().unwrap().module = Some(Module::Es2022);
 
-            let mut hasher1 = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher1 = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher1.hash_tsconfig_json(&tsconfig);
             let hash1 = to_hash_only(&hasher1);
 
@@ -297,13 +297,13 @@ mod tests {
                 .unwrap()
                 .module_resolution = Some(ModuleResolution::NodeNext);
 
-            let mut hasher2 = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher2 = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher2.hash_tsconfig_json(&tsconfig);
             let hash2 = to_hash_only(&hasher2);
 
             tsconfig.compiler_options.as_mut().unwrap().target = Some(Target::Es2019);
 
-            let mut hasher3 = NodeTargetHasher::new(String::from("0.0.0"));
+            let mut hasher3 = NodeTargetHasher::new(Some("0.0.0".into()));
             hasher3.hash_tsconfig_json(&tsconfig);
             let hash3 = to_hash_only(&hasher3);
 

--- a/crates/node/platform/src/platform.rs
+++ b/crates/node/platform/src/platform.rs
@@ -50,10 +50,11 @@ impl Platform for NodePlatform {
             }
         }
 
-        Some(Runtime::Node(Version(
-            self.config.version.to_owned(),
-            false,
-        )))
+        if let Some(node_version) = &self.config.version {
+            return Some(Runtime::Node(Version(node_version.to_owned(), false)));
+        }
+
+        None
     }
 
     fn is_project_in_dependency_workspace(&self, project: &Project) -> Result<bool, MoonError> {

--- a/crates/php/lang/src/lib.rs
+++ b/crates/php/lang/src/lib.rs
@@ -2,7 +2,6 @@ use moon_lang::{DependencyManager, Language, VersionManager};
 
 pub const PHP: Language = Language {
     binary: "php",
-    default_version: "8.2.0",
     file_exts: &["php"],
     vendor_bins_dir: Some("vendor/bin"),
     vendor_dir: Some("vendor"),
@@ -13,7 +12,6 @@ pub const PHP: Language = Language {
 pub const COMPOSER: DependencyManager = DependencyManager {
     binary: "composer",
     config_files: &[],
-    default_version: "2.4.4",
     lockfile: "composer.lock",
     manifest: "composer.json",
 };

--- a/crates/python/lang/src/lib.rs
+++ b/crates/python/lang/src/lib.rs
@@ -2,7 +2,6 @@ use moon_lang::{DependencyManager, Language, VersionManager};
 
 pub const PYTHON: Language = Language {
     binary: "python",
-    default_version: "3.11.1",
     file_exts: &["py", "pyc", "pyo", "pyd"],
     vendor_bins_dir: None,
     vendor_dir: None,
@@ -13,7 +12,6 @@ pub const PYTHON: Language = Language {
 pub const PIP: DependencyManager = DependencyManager {
     binary: "pip",
     config_files: &["constraints.txt"],
-    default_version: "22.3.1",
     lockfile: ".pylock.toml", // https://peps.python.org/pep-0665/
     manifest: "requirements.txt",
 };
@@ -21,7 +19,6 @@ pub const PIP: DependencyManager = DependencyManager {
 pub const PIPENV: DependencyManager = DependencyManager {
     binary: "pipenv",
     config_files: &[],
-    default_version: "2022.11.30",
     lockfile: "Pipfile.lock",
     manifest: "Pipfile",
 };

--- a/crates/ruby/lang/src/lib.rs
+++ b/crates/ruby/lang/src/lib.rs
@@ -2,7 +2,6 @@ use moon_lang::{DependencyManager, Language, VersionManager};
 
 pub const RUBY: Language = Language {
     binary: "ruby",
-    default_version: "3.1.3",
     file_exts: &["rb"],
     vendor_bins_dir: None,
     vendor_dir: Some("vendor"),
@@ -13,7 +12,6 @@ pub const RUBY: Language = Language {
 pub const BUNDLER: DependencyManager = DependencyManager {
     binary: "bundle",
     config_files: &[".bundle/config"],
-    default_version: "2.3.0",
     lockfile: "Gemfile.lock",
     manifest: "Gemfile",
 };

--- a/crates/rust/lang/src/lib.rs
+++ b/crates/rust/lang/src/lib.rs
@@ -2,7 +2,6 @@ use moon_lang::{DependencyManager, Language, VersionManager};
 
 pub const RUST: Language = Language {
     binary: "rustc",
-    default_version: "1.66.0",
     file_exts: &["rs", "rlib"],
     vendor_bins_dir: None,
     vendor_dir: None,
@@ -13,7 +12,6 @@ pub const RUST: Language = Language {
 pub const CARGO: DependencyManager = DependencyManager {
     binary: "cargo",
     config_files: &[".cargo/config.toml"],
-    default_version: "1.66.0",
     lockfile: "Cargo.lock",
     manifest: "Cargo.toml",
 };

--- a/crates/typescript/lang/src/lib.rs
+++ b/crates/typescript/lang/src/lib.rs
@@ -5,7 +5,6 @@ pub use tsconfig::TsConfigJson;
 
 pub const TYPESCRIPT: Language = Language {
     binary: "tsc",
-    default_version: "4.8.4",
     file_exts: &["ts", "tsx", "cts", "mts", "d.ts", "d.cts", "d.mts"],
     vendor_bins_dir: None,
     vendor_dir: Some("node_modules/@types"),

--- a/website/static/schemas/toolchain.json
+++ b/website/static/schemas/toolchain.json
@@ -121,7 +121,10 @@
         },
         "version": {
           "default": "18.12.0",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "yarn": {
           "default": null,


### PR DESCRIPTION
Going forward, the `node` setting will enable the platform, while `node.version` will enable the toolchain. We need to support both scenarios.

This also decouples `node_lang` from `config`, as config is a super crate.