### PR TITLE
fix: Fix `runFromWorkspaceRoot` for node modules.

### DIFF
--- a/.yarn/versions/cfd8ae71.yml
+++ b/.yarn/versions/cfd8ae71.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/cli/tests/run_node_test.rs
+++ b/crates/cli/tests/run_node_test.rs
@@ -307,6 +307,17 @@ fn runs_from_workspace_root() {
 }
 
 #[test]
+fn runs_npm_bin_from_workspace_root() {
+    let sandbox = node_sandbox();
+
+    let assert = sandbox.run_moon(|cmd| {
+        cmd.arg("run").arg("node:runFromWorkspaceBin");
+    });
+
+    assert_snapshot!(assert.output());
+}
+
+#[test]
 fn retries_on_failure_till_count() {
     let sandbox = node_sandbox();
 

--- a/crates/cli/tests/snapshots/run_node_test__runs_npm_bin_from_workspace_root.snap
+++ b/crates/cli/tests/snapshots/run_node_test__runs_npm_bin_from_workspace_root.snap
@@ -1,0 +1,16 @@
+---
+source: crates/cli/tests/run_node_test.rs
+assertion_line: 317
+expression: assert.output()
+---
+▪▪▪▪ npm install
+▪▪▪▪ node:runFromWorkspaceBin
+Checking formatting...
+All matched files use Prettier code style!
+▪▪▪▪ node:runFromWorkspaceBin (100ms)
+
+Tasks: 1 completed
+ Time: 100ms
+
+
+

--- a/crates/core/runner/src/actions/run_target.rs
+++ b/crates/core/runner/src/actions/run_target.rs
@@ -243,7 +243,7 @@ impl<'a> TargetRunner<'a> {
 
         let mut command = match task.platform {
             PlatformType::Node => {
-                node_actions::create_target_command(context, workspace, project, task)?
+                node_actions::create_target_command(context, workspace, project, task, working_dir)?
             }
             _ => system_actions::create_target_command(task, working_dir),
         };

--- a/crates/node/platform/src/actions/run_target.rs
+++ b/crates/node/platform/src/actions/run_target.rs
@@ -16,6 +16,7 @@ use moon_utils::process::Command;
 use moon_utils::{path, string_vec};
 use moon_workspace::{Workspace, WorkspaceError};
 use rustc_hash::FxHashMap;
+use std::path::Path;
 
 const LOG_TARGET: &str = "moon:node-platform:run-target";
 
@@ -92,6 +93,7 @@ pub fn create_target_command(
     workspace: &Workspace,
     project: &Project,
     task: &Task,
+    working_dir: &Path,
 ) -> Result<Command, WorkspaceError> {
     let mut node = workspace.toolchain.node.get::<NodeTool>()?;
 
@@ -128,7 +130,7 @@ pub fn create_target_command(
                 BinFile::Script(bin_path) => {
                     args.extend(create_node_options(context, workspace, task)?);
                     args.push(path::to_string(
-                        path::relative_from(bin_path, &project.root).unwrap(),
+                        path::relative_from(bin_path, working_dir).unwrap(),
                     )?);
                 }
             };

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where `runFromWorkspaceRoot` wasn't working correctly for node module binaries.
+
 ## 0.21.3
 
 #### 🚀 Updates

--- a/tests/fixtures/node/base/moon.yml
+++ b/tests/fixtures/node/base/moon.yml
@@ -56,6 +56,10 @@ tasks:
     args: ./base/cwd.js
     options:
       runFromWorkspaceRoot: true
+  runFromWorkspaceBin:
+    command: prettier --check '*.json'
+    options:
+      runFromWorkspaceRoot: true
   retryCount:
     command: node
     args: ./processExitNonZero.js

--- a/tests/fixtures/node/base/package.json
+++ b/tests/fixtures/node/base/package.json
@@ -1,4 +1,7 @@
 {
   "name": "test-node-base",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "dependencies": {
+    "prettier": "2.7.0"
+  }
 }


### PR DESCRIPTION
When we run a task, we resolve npm binaries to a relative path from the project directory. But when running in the workspace root, these relative paths are now wrong. This updates the relative logic to use the working dir instead of the project root.