### PR TITLE
new: Make `project` fields optional.

### DIFF
--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -51,9 +51,18 @@ pub async fn project(id: &str, json: bool) -> Result<(), AnyError> {
     if let Some(meta) = &config.project {
         term.render_entry("Name", &meta.name)?;
         term.render_entry("Description", &meta.description)?;
-        term.render_entry("Owner", &meta.owner)?;
-        term.render_entry_list("Maintainers", &meta.maintainers)?;
-        term.render_entry("Channel", &meta.channel)?;
+
+        if let Some(owner) = &meta.owner {
+            term.render_entry("Owner", owner)?;
+        }
+
+        if let Some(maintainers) = &meta.maintainers {
+            term.render_entry_list("Maintainers", maintainers)?;
+        }
+
+        if let Some(channel) = &meta.channel {
+            term.render_entry("Channel", channel)?;
+        }
     }
 
     let mut deps = vec![];

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -49,7 +49,10 @@ pub async fn project(id: &str, json: bool) -> Result<(), AnyError> {
     term.render_entry("Type", term.format(&project.type_of))?;
 
     if let Some(meta) = &config.project {
-        term.render_entry("Name", &meta.name)?;
+        if let Some(name) = &meta.name {
+            term.render_entry("Name", name)?;
+        }
+
         term.render_entry("Description", &meta.description)?;
 
         if let Some(owner) = &meta.owner {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -90,7 +90,7 @@ pub async fn run_cli() {
         } => {
             ci(CiOptions {
                 base: base.clone(),
-                concurrency: args.concurrency.clone(),
+                concurrency: args.concurrency,
                 head: head.clone(),
                 job: *job,
                 job_total: *job_total,
@@ -107,7 +107,7 @@ pub async fn run_cli() {
                 ids,
                 CheckOptions {
                     all: *all,
-                    concurrency: args.concurrency.clone(),
+                    concurrency: args.concurrency,
                     report: *report,
                     update_cache: *update_cache,
                 },
@@ -233,7 +233,7 @@ pub async fn run_cli() {
                 targets,
                 RunOptions {
                     affected: *affected,
-                    concurrency: args.concurrency.clone(),
+                    concurrency: args.concurrency,
                     dependents: *dependents,
                     status: status.clone(),
                     passthrough: passthrough.clone(),

--- a/crates/cli/tests/snapshots/run_test__configs__bubbles_up_invalid_project_config.snap
+++ b/crates/cli/tests/snapshots/run_test__configs__bubbles_up_invalid_project_config.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/cli/tests/run_test.rs
-assertion_line: 174
-expression: "standardize_separators(get_path_safe_output(&assert,\n        &PathBuf::from(\"./fake/path\")))"
+assertion_line: 173
+expression: assert.output_standardized()
 ---
 
  ERROR 
 
 Failed to validate base/moon.yml configuration file.
 
-  ▪ missing field `name` for key "project.project" in base/moon.yml YAML Extended file
+  ▪ missing field `description` for key "project.project" in base/moon.yml YAML Extended file
 
 
 

--- a/crates/core/config/src/project/local_config.rs
+++ b/crates/core/config/src/project/local_config.rs
@@ -79,7 +79,7 @@ pub enum ProjectType {
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct ProjectMetadataConfig {
-    pub name: String,
+    pub name: Option<String>,
 
     pub description: String,
 

--- a/crates/core/config/src/project/local_config.rs
+++ b/crates/core/config/src/project/local_config.rs
@@ -83,12 +83,12 @@ pub struct ProjectMetadataConfig {
 
     pub description: String,
 
-    pub owner: String,
+    pub owner: Option<String>,
 
-    pub maintainers: Vec<String>,
+    pub maintainers: Option<Vec<String>>,
 
     #[validate(custom = "validate_channel")]
-    pub channel: String,
+    pub channel: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]

--- a/crates/core/project/tests/project_test.rs
+++ b/crates/core/project/tests/project_test.rs
@@ -141,11 +141,11 @@ fn advanced_config() {
             id: "advanced".into(),
             config: ProjectConfig {
                 project: Some(ProjectMetadataConfig {
-                    name: "Advanced".into(),
+                    name: Some("Advanced".into()),
                     description: "Advanced example.".into(),
-                    owner: "Batman".into(),
-                    maintainers: string_vec!["Bruce Wayne"],
-                    channel: "#batcave".into(),
+                    owner: Some("Batman".into()),
+                    maintainers: Some(string_vec!["Bruce Wayne"]),
+                    channel: Some("#batcave".into()),
                 }),
                 type_of: ProjectType::Application,
                 language: ProjectLanguage::TypeScript,

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
   This is much more accurate than before, which only relied on lockfile modified timestamps.
 - Added global `--concurrency` option to all `moon` commands, allowing the thread count to be
   customized.
+- Updated the `project` fields in `moon.yml` to be optional, excluding `description`.
 
 ## 0.21.4
 

--- a/website/blog/2023-01-17_v0.22.mdx
+++ b/website/blog/2023-01-17_v0.22.mdx
@@ -56,7 +56,7 @@ View the
 [official release](https://github.com/moonrepo/moon/releases/tag/%40moonrepo%2Fcli%400.22.0) for a
 full list of changes.
 
-- ???
+- Updated the `project` fields in `moon.yml` to be optional, excluding `description`.
 
 ## What's next?
 

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -86,8 +86,7 @@ language: 'javascript'
 
 <HeadingApiLink to="/api/types/interface/ProjectConfig#project" />
 
-The `project` setting defines metadata about the project itself. Although this setting is optional,
-when defined, all fields within it _must_ be defined as well.
+The `project` setting defines metadata about the project itself.
 
 ```yaml title="moon.yml"
 project:
@@ -108,7 +107,7 @@ organize all projects. Feel free to build your own tooling around these settings
 
 The Slack, Discord, Teams, IRC, etc channel name (with leading #) in which to discuss the project.
 
-### `description`
+### `description`<RequiredLabel />
 
 <HeadingApiLink to="/api/types/interface/ProjectMetadataConfig#description" />
 


### PR DESCRIPTION
Fixes https://github.com/moonrepo/moon/issues/524

Made them all optional except `description`, as that seems the most important.