### PR TITLE
new: Add `versionConstraint` setting to `.moon/workspace.yml`.

### DIFF
--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_default.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_default.snap
@@ -1,10 +1,13 @@
 ---
 source: crates/cli/src/commands/init/mod.rs
-assertion_line: 221
-expression: render_template(&context).unwrap()
+assertion_line: 238
+expression: render_workspace_template(&context).unwrap()
 ---
 # https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
+
+# Require a specific version of moon while running commands, otherwise fail.
+# versionConstraint: '>=0.0.0'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: './shared/workspace.yml'

--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_git_vcs.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_git_vcs.snap
@@ -1,10 +1,13 @@
 ---
 source: crates/cli/src/commands/init/mod.rs
-assertion_line: 246
-expression: render_template(&context).unwrap()
+assertion_line: 263
+expression: render_workspace_template(&context).unwrap()
 ---
 # https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
+
+# Require a specific version of moon while running commands, otherwise fail.
+# versionConstraint: '>=0.0.0'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: './shared/workspace.yml'

--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_glob_list.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_glob_list.snap
@@ -1,10 +1,13 @@
 ---
 source: crates/cli/src/commands/init/mod.rs
-assertion_line: 166
-expression: render_template(context).unwrap()
+assertion_line: 246
+expression: render_workspace_template(&context).unwrap()
 ---
 # https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
+
+# Require a specific version of moon while running commands, otherwise fail.
+# versionConstraint: '>=0.0.0'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: './shared/workspace.yml'

--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_projects_map.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_projects_map.snap
@@ -1,10 +1,13 @@
 ---
 source: crates/cli/src/commands/init/mod.rs
-assertion_line: 237
-expression: render_template(&context).unwrap()
+assertion_line: 254
+expression: render_workspace_template(&context).unwrap()
 ---
 # https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
+
+# Require a specific version of moon while running commands, otherwise fail.
+# versionConstraint: '>=0.0.0'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: './shared/workspace.yml'

--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_svn_vcs.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_svn_vcs.snap
@@ -1,10 +1,13 @@
 ---
 source: crates/cli/src/commands/init/mod.rs
-assertion_line: 255
-expression: render_template(&context).unwrap()
+assertion_line: 272
+expression: render_workspace_template(&context).unwrap()
 ---
 # https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
+
+# Require a specific version of moon while running commands, otherwise fail.
+# versionConstraint: '>=0.0.0'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: './shared/workspace.yml'

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -63,6 +63,8 @@ fn setup_logging(level: &LogLevel, log_file: Option<PathBuf>) {
     } else {
         debug!(target: "moon", "Running moon v{}", version);
     }
+
+    env::set_var("MOON_VERSION", version);
 }
 
 fn setup_caching(mode: &CacheMode) {
@@ -78,8 +80,6 @@ pub async fn run_cli() {
     setup_colors(args.color);
     setup_logging(&args.log, args.log_file);
     setup_caching(&args.cache);
-
-    env::set_var("MOON_VERSION", env!("CARGO_PKG_VERSION"));
 
     // Match and run subcommand
     let result = match &args.command {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -79,6 +79,8 @@ pub async fn run_cli() {
     setup_logging(&args.log, args.log_file);
     setup_caching(&args.cache);
 
+    env::set_var("MOON_VERSION", env!("CARGO_PKG_VERSION"));
+
     // Match and run subcommand
     let result = match &args.command {
         Commands::Bin { tool } => bin(tool).await,

--- a/crates/cli/tests/misc_test.rs
+++ b/crates/cli/tests/misc_test.rs
@@ -1,0 +1,18 @@
+use moon_test_utils::{assert_snapshot, create_sandbox_with_config, get_cases_fixture_configs};
+
+#[test]
+fn fails_on_version_constraint() {
+    let (mut workspace_config, _, _) = get_cases_fixture_configs();
+
+    workspace_config.version_constraint = Some(">=1000.0.0".into());
+
+    let sandbox = create_sandbox_with_config("cases", Some(&workspace_config), None, None);
+
+    let assert = sandbox.run_moon(|cmd| {
+        cmd.arg("sync");
+    });
+
+    assert_snapshot!(assert.output());
+
+    assert.failure();
+}

--- a/crates/cli/tests/snapshots/misc_test__fails_on_version_constraint.snap
+++ b/crates/cli/tests/snapshots/misc_test__fails_on_version_constraint.snap
@@ -1,0 +1,12 @@
+---
+source: crates/cli/tests/misc_test.rs
+assertion_line: 16
+expression: assert.output()
+---
+
+ ERROR 
+
+Invalid moon version, unable to proceed. Found 0.21.4, expected >=1000.0.0.
+
+
+

--- a/crates/core/config/src/validators.rs
+++ b/crates/core/config/src/validators.rs
@@ -1,6 +1,6 @@
 use crate::errors::create_validation_error;
 use moon_utils::regex::{matches_id, matches_target};
-use moon_utils::semver::Version;
+use moon_utils::semver::{Version, VersionReq};
 use std::path::Path;
 use validator::{validate_url as validate_base_url, ValidationError};
 
@@ -14,6 +14,21 @@ pub fn validate_semver_version<K: AsRef<str>, V: AsRef<str>>(
             "invalid_semver",
             key.as_ref(),
             "Must be a valid semantic version",
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn validate_semver_requirement<K: AsRef<str>, V: AsRef<str>>(
+    key: K,
+    value: V,
+) -> Result<(), ValidationError> {
+    if VersionReq::parse(value.as_ref()).is_err() {
+        return Err(create_validation_error(
+            "invalid_semver_req",
+            key.as_ref(),
+            "Must be a valid semantic version requirement or range",
         ));
     }
 

--- a/crates/core/config/src/workspace/config.rs
+++ b/crates/core/config/src/workspace/config.rs
@@ -3,7 +3,9 @@
 use crate::errors::map_validation_errors_to_figment_errors;
 use crate::helpers::gather_extended_sources;
 use crate::types::{FileGlob, FilePath};
-use crate::validators::{validate_child_relative_path, validate_extends, validate_id};
+use crate::validators::{
+    validate_child_relative_path, validate_extends, validate_id, validate_semver_requirement,
+};
 use crate::workspace::generator::GeneratorConfig;
 use crate::workspace::hasher::HasherConfig;
 use crate::workspace::notifier::NotifierConfig;
@@ -42,6 +44,12 @@ fn validate_projects(projects: &WorkspaceProjects) -> Result<(), ValidationError
             }
         }
     }
+
+    Ok(())
+}
+
+fn validate_version_constraint(value: &str) -> Result<(), ValidationError> {
+    validate_semver_requirement("versionConstraint", value)?;
 
     Ok(())
 }
@@ -92,6 +100,10 @@ pub struct WorkspaceConfig {
 
     #[validate]
     pub vcs: VcsConfig,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(custom = "validate_version_constraint")]
+    pub version_constraint: Option<String>,
 
     /// JSON schema URI.
     #[serde(skip, rename = "$schema")]

--- a/crates/core/config/templates/workspace.yml
+++ b/crates/core/config/templates/workspace.yml
@@ -1,6 +1,9 @@
 # https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
+# Require a specific version of moon while running commands, otherwise fail.
+# versionConstraint: '>=0.0.0'
+
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: './shared/workspace.yml'
 

--- a/crates/core/config/tests/workspace_test.rs
+++ b/crates/core/config/tests/workspace_test.rs
@@ -34,6 +34,7 @@ fn loads_defaults() {
                 notifier: NotifierConfig::default(),
                 projects: WorkspaceProjects::default(),
                 vcs: VcsConfig::default(),
+                version_constraint: None,
                 schema: String::new(),
             }
         );
@@ -471,6 +472,39 @@ mod generator {
             jail.create_file(
                 super::CONFIG_WORKSPACE_FILENAME,
                 "generator:\n  templates: ['../templates']",
+            )?;
+
+            super::load_jailed_config(jail.directory())?;
+
+            Ok(())
+        });
+    }
+}
+
+mod version_constraint {
+    #[test]
+    #[should_panic(
+        expected = "invalid type: found unsigned int `123`, expected a string for key \"workspace.versionConstraint\""
+    )]
+    fn invalid_type() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(super::CONFIG_WORKSPACE_FILENAME, "versionConstraint: 123")?;
+
+            super::load_jailed_config(jail.directory())?;
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Must be a valid semantic version requirement or range for key \"workspace.versionConstraint\""
+    )]
+    fn invalid_req() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                super::CONFIG_WORKSPACE_FILENAME,
+                "versionConstraint: '@1.0.0'",
             )?;
 
             super::load_jailed_config(jail.directory())?;

--- a/crates/core/workspace/src/errors.rs
+++ b/crates/core/workspace/src/errors.rs
@@ -43,6 +43,9 @@ pub enum WorkspaceError {
     )]
     InvalidGlobalProjectConfigFile(String),
 
+    #[error("Invalid moon version, unable to proceed. Found {0}, expected {1}.")]
+    InvalidMoonVersion(String, String),
+
     #[error(transparent)]
     Moon(#[from] MoonError),
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,13 +4,24 @@
 
 #### 🚀 Updates
 
-- We've refactored the pipeline to use a new thread pool strategy so that we have more control over
-  concurrency. This also paves the way for future output reporters.
 - We've improved our smart hashing for other use cases besides task running. The first improvement
   is that we now hash dependencies to determine whether to run a dependency install, or to skip!
   This is much more accurate than before, which only relied on lockfile modified timestamps.
+
+##### Config
+
+- Added a `versionConstraint` setting to `.moon/workspace.yml` that enforces a requirement on the
+  running moon binary.
+
+##### Pipeline
+
+- We've refactored the pipeline to use a new thread pool strategy so that we have more control over
+  concurrency. This also paves the way for future output reporters.
 - Added global `--concurrency` option to all `moon` commands, allowing the thread count to be
   customized.
+
+##### Projects
+
 - Updated the `project` fields in `moon.yml` to be optional, excluding `description`.
 
 ## 0.21.4

--- a/packages/types/src/workspace-config.ts
+++ b/packages/types/src/workspace-config.ts
@@ -36,4 +36,5 @@ export interface WorkspaceConfig {
 		| { globs: string[]; sources: Record<string, string> };
 	runner: RunnerConfig;
 	vcs: VcsConfig;
+	versionConstraint: string | null;
 }

--- a/tests/fixtures/node/base/envVarsMoon.js
+++ b/tests/fixtures/node/base/envVarsMoon.js
@@ -1,5 +1,5 @@
 Object.entries(process.env).forEach(([key, value]) => {
-	if (key.startsWith('MOON_') && !key.startsWith('MOON_TEST')) {
+	if (key.startsWith('MOON_') && !key.startsWith('MOON_TEST') && key !== 'MOON_VERSION') {
 		console.log(`${key}=${value.replace(/\\/g, '/')}`);
 	}
 });

--- a/tests/fixtures/system/unix/envVarsMoon.sh
+++ b/tests/fixtures/system/unix/envVarsMoon.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 for var in "${!MOON_@}"; do
-	if [[ "$var" != *"MOON_TEST"* ]];then
+	if [[ "$var" != *"MOON_TEST"* && "$var" != *"MOON_VERSION"* ]];then
 		echo "$var=${!var}"
 	fi
 done

--- a/website/blog/2023-01-17_v0.22.mdx
+++ b/website/blog/2023-01-17_v0.22.mdx
@@ -56,7 +56,10 @@ View the
 [official release](https://github.com/moonrepo/moon/releases/tag/%40moonrepo%2Fcli%400.22.0) for a
 full list of changes.
 
-- Updated the `project` fields in `moon.yml` to be optional, excluding `description`.
+- Added a [`versionConstraint` setting](/docs/config/workspace#versionconstraint) in
+  `.moon/workspace.yml` that enforces a requirement on the running moon binary.
+- Updated the [`project` fields](/docs/config/project#project) in `moon.yml` to be optional,
+  excluding `description`.
 
 ## What's next?
 

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -297,3 +297,15 @@ vcs:
     - 'origin'
     - 'upstream'
 ```
+
+## `versionConstraint`<VersionLabel version="0.22" />
+
+<HeadingApiLink to="/api/types/interface/WorkspaceConfig#versionConstraint" />
+
+Defines a semantic version requirement for the currently running moon binary. This provides a
+mechanism for enforcing that the globally installed moon on every developers machine is using an
+applicable version.
+
+```yaml title=".moon/workspace.yml" {1}
+versionConstraint: '>=0.20.0'
+```


### PR DESCRIPTION
Allows consumers to enforce a specific moon version.