### PR TITLE
breaking: Remove `--report` option.

### DIFF
--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -293,9 +293,6 @@ pub enum Commands {
         #[clap(group = "projects")]
         all: bool,
 
-        #[arg(long, help = "Generate a run report for the current actions")]
-        report: bool,
-
         #[arg(
             long,
             short = 'u',
@@ -356,9 +353,6 @@ pub enum Commands {
             help_heading = HEADING_DEBUGGING,
         )]
         profile: Option<ProfileType>,
-
-        #[arg(long, help = "Generate a run report for the current actions")]
-        report: bool,
 
         // Affected
         #[arg(

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -8,7 +8,6 @@ use std::env;
 pub struct CheckOptions {
     pub all: bool,
     pub concurrency: Option<usize>,
-    pub report: bool,
     pub update_cache: bool,
 }
 
@@ -56,7 +55,6 @@ pub async fn check(project_ids: &Vec<String>, options: CheckOptions) -> Result<(
         &targets,
         RunOptions {
             concurrency: options.concurrency,
-            report: options.report,
             update_cache: options.update_cache,
             ..RunOptions::default()
         },

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -21,7 +21,6 @@ pub struct RunOptions {
     pub passthrough: Vec<String>,
     pub profile: Option<ProfileType>,
     pub remote: bool,
-    pub report: bool,
     pub update_cache: bool,
 }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -102,7 +102,6 @@ pub async fn run_cli() {
         Commands::Check {
             ids,
             all,
-            report,
             update_cache,
         } => {
             check(
@@ -110,7 +109,6 @@ pub async fn run_cli() {
                 CheckOptions {
                     all: *all,
                     concurrency: args.concurrency,
-                    report: *report,
                     update_cache: *update_cache,
                 },
             )
@@ -229,7 +227,6 @@ pub async fn run_cli() {
             passthrough,
             profile,
             remote,
-            report,
         } => {
             run(
                 targets,
@@ -241,7 +238,6 @@ pub async fn run_cli() {
                     passthrough: passthrough.clone(),
                     profile: profile.clone(),
                     remote: *remote,
-                    report: *report,
                     update_cache: *update_cache,
                 },
             )

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@
 #### 💥 Breaking
 
 - Renamed the `--upstream` option to `--remote`.
+- Removed the `--report` option from `moon check` and `moon run` commands. Reports are now always
+  created.
 
 #### 🚀 Updates
 

--- a/website/blog/2023-01-17_v0.22.mdx
+++ b/website/blog/2023-01-17_v0.22.mdx
@@ -61,6 +61,8 @@ full list of changes.
 - Renamed the `--upstream` option to `--remote`.
 - Updated the [`project` fields](/docs/config/project#project) in `moon.yml` to be optional,
   excluding `description`.
+- Removed the `--report` option from `moon check` and `moon run` commands. Reports are now always
+  created.
 
 ## What's next?
 

--- a/website/docs/commands/check.mdx
+++ b/website/docs/commands/check.mdx
@@ -33,6 +33,4 @@ $ moon check --all
 ### Options
 
 - `--all` - Run check for all projects in the workspace.
-- `--report` - Generate a report of the ran actions. Report is written to
-  `.moon/cache/runReport.json`.
 - `-u`, `--updateCache` - Bypass cache and force update any existing items.

--- a/website/docs/commands/run.mdx
+++ b/website/docs/commands/run.mdx
@@ -30,8 +30,6 @@ $ moon run :lint
 - `--dependents` - Run downstream dependent targets (of the same task name) as well.
 - `--profile <type>` - Record and [generate a profile](../guides/profile) for ran tasks.
   - Types: `cpu`, `heap`
-- `--report` - Generate a report of the ran actions. Report is written to
-  `.moon/cache/runReport.json`.
 - `-u`, `--updateCache` - Bypass cache and force update any existing items.
 
 #### Affected

--- a/website/docs/editors/vscode.mdx
+++ b/website/docs/editors/vscode.mdx
@@ -56,8 +56,7 @@ icon, or using the command palette.
 ### Last run
 
 Information about the last ran target will be displayed in a beautiful table with detailed stats.
-Only tasks ran from the [projects view](#projects), or with `--report` on the command line will be
-displayed here.
+Only tasks ran from the [projects view](#projects) or on the command line will be displayed here.
 
 This table displays all actions that were ran alongside the running primary target(s). They are
 ordered topologically via the dependency graph.


### PR DESCRIPTION
The report is now always created and this change was made in the previous pipeline PR. This PR merely removes the CLI option.