### PR TITLE
internal: Migrate to new artifacts endpoints.

### DIFF
--- a/crates/core/action-pipeline/src/subscribers/moonbase_cache.rs
+++ b/crates/core/action-pipeline/src/subscribers/moonbase_cache.rs
@@ -5,7 +5,7 @@ use moon_logger::{color, trace, warn};
 use moon_utils::async_trait;
 use moon_utils::fs;
 use moon_workspace::Workspace;
-use moonbase::{upload_artifact, ArtifactInput, MoonbaseError};
+use moonbase::{upload_artifact, ArtifactWriteInput, MoonbaseError};
 use rustc_hash::FxHashMap;
 use tokio::task::JoinHandle;
 
@@ -78,11 +78,11 @@ impl Subscriber for MoonbaseCacheSubscriber {
                         Err(_) => 0,
                     };
 
-                    // Created the database record
+                    // Create the database record
                     match moonbase
                         .write_artifact(
                             hash,
-                            ArtifactInput {
+                            ArtifactWriteInput {
                                 target: target.id.to_owned(),
                                 size: size as usize,
                             },
@@ -94,7 +94,7 @@ impl Subscriber for MoonbaseCacheSubscriber {
                             trace!(
                                 target: LOG_TARGET,
                                 "Uploading artifact {} ({} bytes) to remote cache",
-                                color::file(&hash),
+                                color::file(hash),
                                 if size == 0 {
                                     "unknown".to_owned()
                                 } else {
@@ -102,8 +102,8 @@ impl Subscriber for MoonbaseCacheSubscriber {
                                 }
                             );
 
-                            let auth_token = moonbase.auth_token.to_owned();
                             let hash = (*hash).to_owned();
+                            let auth_token = moonbase.auth_token.to_owned();
                             let archive_path = archive_path.to_owned();
 
                             // Run this in the background so we don't slow down the pipeline
@@ -135,7 +135,7 @@ impl Subscriber for MoonbaseCacheSubscriber {
                         trace!(
                             target: LOG_TARGET,
                             "Downloading artifact {} from remote cache",
-                            color::file(&hash),
+                            color::file(hash),
                         );
 
                         if let Err(error) = moonbase

--- a/crates/core/moonbase/src/api.rs
+++ b/crates/core/moonbase/src/api.rs
@@ -34,7 +34,18 @@ pub struct Artifact {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ArtifactInput {
+    pub target: String,
+    pub size: usize,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ArtifactResponse {
     pub artifact: Artifact,
     pub presigned_url: Option<String>,
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EmptyData {}

--- a/crates/core/moonbase/src/api.rs
+++ b/crates/core/moonbase/src/api.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SigninBody {
+pub struct SigninInput {
     pub organization_key: String,
     pub repository: String,
     pub repository_key: String,
@@ -34,9 +34,15 @@ pub struct Artifact {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ArtifactInput {
+pub struct ArtifactWriteInput {
     pub target: String,
     pub size: usize,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactCompleteInput {
+    pub success: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/core/moonbase/src/errors.rs
+++ b/crates/core/moonbase/src/errors.rs
@@ -3,22 +3,22 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum MoonbaseError {
-    #[error("Failed to check for artifact <symbol>{0}</symbol>. {1}")]
+    #[error("Failed to check for artifact <symbol>{0}</symbol>: {1}")]
     ArtifactCheckFailure(String, String),
 
-    #[error("Failed to download artifact <symbol>{0}</symbol>. {1}")]
+    #[error("Failed to download artifact <symbol>{0}</symbol>: {1}")]
     ArtifactDownloadFailure(String, String),
 
-    #[error("Failed to upload artifact <symbol>{0}</symbol>. {1}")]
+    #[error("Failed to upload artifact <symbol>{0}</symbol>: {1}")]
     ArtifactUploadFailure(String, String),
 
-    #[error("Failed to deserialize JSON response. {0}")]
+    #[error("Failed to deserialize JSON response: {0}")]
     JsonDeserializeFailure(String),
 
-    #[error("Failed to serialize JSON for request body. {0}")]
+    #[error("Failed to serialize JSON for request body: {0}")]
     JsonSerializeFailure(String),
 
-    #[error("Failed to send request to moonbase. {0}")]
+    #[error("Failed to send request to moonbase: {0}")]
     Http(#[from] reqwest::Error),
 
     #[error(transparent)]

--- a/crates/core/moonbase/src/lib.rs
+++ b/crates/core/moonbase/src/lib.rs
@@ -172,9 +172,10 @@ pub async fn upload_artifact(
     let file_stream = FramedRead::new(file, BytesCodec::new());
 
     let request = if let Some(url) = upload_url {
-        let client = reqwest::Client::new();
-        let file_body = Body::wrap_stream(file_stream);
-        client.put(url).header("Content-Length", file_length).body(file_body)
+        reqwest::Client::new()
+            .put(url)
+            .header("Content-Length", file_length)
+            .body(Body::wrap_stream(file_stream))
     } else {
         reqwest::Client::new()
             .post(endpoint(format!("artifacts/{}/upload", hash)))

--- a/crates/core/moonbase/src/lib.rs
+++ b/crates/core/moonbase/src/lib.rs
@@ -5,7 +5,7 @@ mod errors;
 use common::{endpoint, get_request, post_request, Response};
 use moon_error::map_io_to_fs_error;
 use moon_logger::{color, debug, warn};
-use reqwest::{multipart, Body, StatusCode};
+use reqwest::{Body};
 use std::io;
 use std::path::{Path, PathBuf};
 use tokio::fs;
@@ -174,12 +174,7 @@ pub async fn upload_artifact(
     let request = if let Some(url) = upload_url {
         let client = reqwest::Client::new();
         let file_body = Body::wrap_stream(file_stream);
-        let some_file = multipart::Part::stream_with_length(file_body, file_length)
-            .file_name(hash.clone())
-            .mime_str("text/plain")?;
-
-        let form = multipart::Form::new().part("file", some_file);
-        client.put(url).multipart(form)
+        client.put(url).header("Content-Length", file_length).body(file_body)
     } else {
         reqwest::Client::new()
             .post(endpoint(format!("artifacts/{}/upload", hash)))

--- a/crates/core/moonbase/src/lib.rs
+++ b/crates/core/moonbase/src/lib.rs
@@ -4,8 +4,7 @@ mod errors;
 
 use common::{get_host, get_request, parse_response, post_request, Response};
 use moon_error::map_io_to_fs_error;
-use moon_logger::{color, debug, trace, warn};
-use reqwest::multipart::{Form, Part};
+use moon_logger::{color, debug, warn};
 use reqwest::Body;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -76,7 +75,7 @@ impl Moonbase {
         }
     }
 
-    pub async fn get_artifact(
+    pub async fn read_artifact(
         &self,
         hash: &str,
     ) -> Result<Option<(Artifact, Option<String>)>, MoonbaseError> {
@@ -97,6 +96,26 @@ impl Moonbase {
                     ))
                 }
             }
+        }
+    }
+
+    pub async fn write_artifact(
+        &self,
+        hash: &str,
+        input: ArtifactInput,
+    ) -> Result<(Artifact, Option<String>), MoonbaseError> {
+        let response =
+            post_request(format!("artifacts/{}", hash), input, Some(&self.auth_token)).await?;
+
+        match response {
+            Response::Success(ArtifactResponse {
+                artifact,
+                presigned_url,
+            }) => Ok((artifact, presigned_url)),
+            Response::Failure { message, .. } => Err(MoonbaseError::ArtifactUploadFailure(
+                hash.to_string(),
+                message,
+            )),
         }
     }
 
@@ -146,59 +165,49 @@ impl Moonbase {
 pub async fn upload_artifact(
     auth_token: String,
     hash: String,
-    target_id: String,
     path: PathBuf,
     upload_url: Option<String>,
-) -> Result<Artifact, MoonbaseError> {
+) -> Result<(), MoonbaseError> {
     let file = fs::File::open(&path)
         .await
         .map_err(|e| map_io_to_fs_error(e, path.to_path_buf()))?;
-    let file_name = match path.file_name() {
-        Some(name) => name.to_string_lossy().to_string(),
-        None => format!("{}.tar.gz", hash),
-    };
-    let file_size = match file.metadata().await {
-        Ok(meta) => meta.len(),
-        Err(_) => 0,
-    };
     let file_stream = FramedRead::new(file, BytesCodec::new());
 
-    let form = Form::new().text("target", target_id.to_owned()).part(
-        "file",
-        Part::stream(Body::wrap_stream(file_stream))
-            .file_name(file_name.clone())
-            .mime_str("application/gzip")?,
-    );
-
+    // Upload to cloud storage
     let request = if let Some(url) = upload_url {
-        reqwest::Client::new().post(url).multipart(form)
+        reqwest::Client::new()
+            .post(url)
+            .body(Body::wrap_stream(file_stream))
     } else {
         reqwest::Client::new()
             .post(format!("{}/artifacts/{}/upload", get_host(), hash))
-            .multipart(form)
-            .bearer_auth(auth_token)
+            .body(Body::wrap_stream(file_stream))
+            .bearer_auth(&auth_token)
             .header("Accept", "application/json")
     };
 
-    trace!(
-        target: LOG_TARGET,
-        "Uploading artifact {} ({} bytes) to remote cache",
-        color::file(&file_name),
-        if file_size == 0 {
-            "unknown".to_owned()
-        } else {
-            file_size.to_string()
-        }
-    );
+    request.send().await?;
 
-    let response = request.send().await?;
-    let data: Response<ArtifactResponse> = parse_response(response.text().await?)?;
+    // Does an upload return a response???
+    // let response = request.send().await?;
+    // let data: Response<ArtifactResponse> = parse_response(response.text().await?)?;
 
-    match data {
-        Response::Success(ArtifactResponse { artifact, .. }) => Ok(artifact),
-        Response::Failure { message, .. } => Err(MoonbaseError::ArtifactUploadFailure(
-            hash.to_string(),
-            message,
-        )),
-    }
+    // match data {
+    //     Response::Success(_) => Ok(artifact),
+    //     Response::Failure { message, .. } => Err(MoonbaseError::ArtifactUploadFailure(
+    //         hash.to_string(),
+    //         message,
+    //     )),
+    // }
+
+    // Once the upload to cloud storage is complete, we need to mark the upload
+    // as completed on our end!
+    let _: Response<EmptyData> = post_request(
+        format!("artifacts/{}/complete", hash),
+        EmptyData {},
+        Some(&auth_token),
+    )
+    .await?;
+
+    Ok(())
 }


### PR DESCRIPTION
We'll be utilizing presigned URLs entirely for this.