### PR TITLE
fix: Fix child processes not being killed.

### DIFF
--- a/crates/core/utils/src/process.rs
+++ b/crates/core/utils/src/process.rs
@@ -359,6 +359,10 @@ impl Command {
             command.current_dir(cwd);
         }
 
+        // Avoid zombie processes, especially for long-running
+        // or never ending tasks!
+        command.kill_on_drop(true);
+
         command.envs(&self.env);
         command
     }

--- a/crates/core/utils/src/process.rs
+++ b/crates/core/utils/src/process.rs
@@ -360,7 +360,7 @@ impl Command {
         }
 
         // Avoid zombie processes, especially for long-running
-        // or never ending tasks!
+        // or never-ending tasks!
         command.kill_on_drop(true);
 
         command.envs(&self.env);

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 - Fixed an issue where `~/.moon` is deleted, but local caching isn't aware of it missing and fails
   to run a target.
+- Fixed an issue where long-running processes would not exit even after moon has exited.
 
 ## 0.21.4
 


### PR DESCRIPTION
I've noticed that local tasks (web servers) would keep running after moon has exited via ctrl+c, so this attempts to fix that by killing the process when it's dropped out of scope.