### PR TITLE
breaking: Move `implicitDeps` and `implicitInputs`.

### DIFF
--- a/.moon/tasks.yml
+++ b/.moon/tasks.yml
@@ -1,5 +1,8 @@
 $schema: '../website/static/schemas/tasks.json'
 
+implicitDeps:
+  - '^:build'
+
 fileGroups:
   configs:
     - '*.{js,json}'

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -18,8 +18,6 @@ runner:
     - ':lint'
     - ':test'
     - ':typecheck'
-  implicitDeps:
-    - '^:build'
   logRunningCommand: true
 
 vcs:

--- a/crates/cli/tests/migrate_test.rs
+++ b/crates/cli/tests/migrate_test.rs
@@ -100,6 +100,7 @@ mod from_package_json {
 mod from_turborepo {
     use super::*;
     use moon_cli::commands::migrate::{TurboJson, TurboTask};
+    use moon_config::InheritedTasksConfig;
     use rustc_hash::FxHashMap;
 
     #[test]
@@ -139,18 +140,11 @@ mod from_turborepo {
 
         assert.success();
 
-        let config = WorkspaceConfig::load(sandbox.path().join(".moon/workspace.yml")).unwrap();
+        let config = InheritedTasksConfig::load(sandbox.path().join(".moon/tasks.yml")).unwrap();
 
         assert_eq!(
-            config.runner.implicit_inputs,
-            string_vec![
-                "package.json",
-                "/.moon/*.yml",
-                "package.json",
-                "*.json",
-                "$FOO",
-                "$BAR"
-            ]
+            config.implicit_inputs,
+            string_vec!["package.json", "*.json", "$FOO", "$BAR", "/.moon/*.yml"]
         );
     }
 

--- a/crates/cli/tests/run_system_test.rs
+++ b/crates/cli/tests/run_system_test.rs
@@ -15,6 +15,7 @@ fn system_sandbox() -> Sandbox {
     };
 
     let tasks_config = InheritedTasksConfig {
+        // Avoid defaults in hashes or snapshots
         implicit_inputs: string_vec![],
         ..InheritedTasksConfig::default()
     };

--- a/crates/cli/tests/run_system_test.rs
+++ b/crates/cli/tests/run_system_test.rs
@@ -1,4 +1,4 @@
-use moon_config::{RunnerConfig, WorkspaceConfig, WorkspaceProjects};
+use moon_config::{InheritedTasksConfig, WorkspaceConfig, WorkspaceProjects};
 use moon_test_utils::{
     assert_snapshot, create_sandbox_with_config, predicates::prelude::*, Sandbox,
 };
@@ -11,15 +11,16 @@ fn system_sandbox() -> Sandbox {
             ("unix".to_owned(), "unix".to_owned()),
             ("windows".to_owned(), "windows".to_owned()),
         ])),
-        runner: RunnerConfig {
-            // Avoid these in hashes or snapshots
-            implicit_inputs: string_vec![],
-            ..RunnerConfig::default()
-        },
         ..WorkspaceConfig::default()
     };
 
-    let sandbox = create_sandbox_with_config("system", Some(&workspace_config), None, None);
+    let tasks_config = InheritedTasksConfig {
+        implicit_inputs: string_vec![],
+        ..InheritedTasksConfig::default()
+    };
+
+    let sandbox =
+        create_sandbox_with_config("system", Some(&workspace_config), None, Some(&tasks_config));
 
     sandbox.enable_git();
     sandbox

--- a/crates/core/config/src/workspace/runner.rs
+++ b/crates/core/config/src/workspace/runner.rs
@@ -98,41 +98,4 @@ cacheLifetime: 'bad unit'
         });
     }
 
-    #[test]
-    #[should_panic(expected = "Must be a valid target format")]
-    fn invalid_dep_target() {
-        figment::Jail::expect_with(|jail| {
-            jail.create_file(
-                CONFIG_FILENAME,
-                r#"
-implicitDeps:
-  - '%:task'
-"#,
-            )?;
-
-            load_jailed_config()?;
-
-            Ok(())
-        });
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "Must be a valid ID (accepts A-Z, a-z, 0-9, - (dashes), _ (underscores), /, and must start with a letter)"
-    )]
-    fn invalid_dep_target_no_scope() {
-        figment::Jail::expect_with(|jail| {
-            jail.create_file(
-                CONFIG_FILENAME,
-                r#"
-implicitDeps:
-  - 'foo bar'
-"#,
-            )?;
-
-            load_jailed_config()?;
-
-            Ok(())
-        });
-    }
 }

--- a/crates/core/config/src/workspace/runner.rs
+++ b/crates/core/config/src/workspace/runner.rs
@@ -97,5 +97,4 @@ cacheLifetime: 'bad unit'
             Ok(())
         });
     }
-
 }

--- a/crates/core/config/src/workspace/runner.rs
+++ b/crates/core/config/src/workspace/runner.rs
@@ -1,26 +1,11 @@
 use crate::{
     errors::create_validation_error,
-    validators::{is_default, is_default_true, validate_id, validate_target},
+    validators::{is_default, is_default_true, validate_target},
 };
-use moon_utils::{string_vec, time};
+use moon_utils::time;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationError};
-
-fn validate_deps(list: &[String]) -> Result<(), ValidationError> {
-    for (index, item) in list.iter().enumerate() {
-        let key = format!("implicitDeps[{}]", index);
-
-        // When no target scope, it's assumed to be a self scope
-        if item.contains(':') {
-            validate_target(key, item)?;
-        } else {
-            validate_id(key, item)?;
-        }
-    }
-
-    Ok(())
-}
 
 fn validate_cache_lifetime(value: &str) -> Result<(), ValidationError> {
     if let Err(e) = time::parse_duration(value) {
@@ -54,13 +39,6 @@ pub struct RunnerConfig {
     #[validate(custom = "validate_cache_lifetime")]
     pub cache_lifetime: String,
 
-    #[serde(skip_serializing_if = "is_default")]
-    #[validate(custom = "validate_deps")]
-    pub implicit_deps: Vec<String>,
-
-    #[serde(skip_serializing_if = "is_default")]
-    pub implicit_inputs: Vec<String>,
-
     #[serde(skip_serializing_if = "is_default_true")]
     pub inherit_colors_for_piped_tasks: bool,
 
@@ -73,13 +51,6 @@ impl Default for RunnerConfig {
         RunnerConfig {
             cache_lifetime: "7 days".to_owned(),
             archivable_targets: vec![],
-            implicit_deps: vec![],
-            implicit_inputs: string_vec![
-                // When a project changes
-                "package.json",
-                // When root config changes
-                "/.moon/*.yml",
-            ],
             inherit_colors_for_piped_tasks: true,
             log_running_command: false,
         }

--- a/crates/core/config/tests/global_tasks_test.rs
+++ b/crates/core/config/tests/global_tasks_test.rs
@@ -46,6 +46,44 @@ fileGroups:
     });
 }
 
+#[test]
+#[should_panic(expected = "Must be a valid target format")]
+fn invalid_dep_target() {
+    figment::Jail::expect_with(|jail| {
+        jail.create_file(
+            CONFIG_TASKS_FILENAME,
+            r#"
+implicitDeps:
+  - '%:task'
+"#,
+        )?;
+
+        load_jailed_config(jail.directory())?;
+
+        Ok(())
+    });
+}
+
+#[test]
+#[should_panic(
+    expected = "Must be a valid ID (accepts A-Z, a-z, 0-9, - (dashes), _ (underscores), /, and must start with a letter)"
+)]
+fn invalid_dep_target_no_scope() {
+    figment::Jail::expect_with(|jail| {
+        jail.create_file(
+            CONFIG_TASKS_FILENAME,
+            r#"
+implicitDeps:
+  - 'foo bar'
+"#,
+        )?;
+
+        load_jailed_config(jail.directory())?;
+
+        Ok(())
+    });
+}
+
 mod extends {
     use super::*;
     use moon_config::{TaskConfig, TaskOptionsConfig};
@@ -61,8 +99,8 @@ mod extends {
             config,
             InheritedTasksConfig {
                 file_groups: FxHashMap::from_iter([
-                    ("sources".to_owned(), string_vec!["sources/**/*"]), // NOT src/**/*
                     ("tests".to_owned(), string_vec!["tests/**/*"]),
+                    ("sources".to_owned(), string_vec!["sources/**/*"]), // NOT src/**/*
                 ]),
                 tasks: BTreeMap::from([
                     (

--- a/crates/core/config/tests/global_tasks_test.rs
+++ b/crates/core/config/tests/global_tasks_test.rs
@@ -38,6 +38,7 @@ fileGroups:
                     String::from("sources"),
                     string_vec!["src/**/*"]
                 )]),
+                implicit_inputs: string_vec!["/.moon/*.yml"],
                 ..InheritedTasksConfig::default()
             }
         );
@@ -102,6 +103,7 @@ mod extends {
                     ("tests".to_owned(), string_vec!["tests/**/*"]),
                     ("sources".to_owned(), string_vec!["sources/**/*"]), // NOT src/**/*
                 ]),
+                implicit_inputs: string_vec!["/.moon/*.yml"],
                 tasks: BTreeMap::from([
                     (
                         "lint".to_owned(),

--- a/crates/core/config/tests/global_tasks_test.rs
+++ b/crates/core/config/tests/global_tasks_test.rs
@@ -34,13 +34,11 @@ fileGroups:
         assert_eq!(
             config,
             InheritedTasksConfig {
-                extends: None,
                 file_groups: FxHashMap::from_iter([(
                     String::from("sources"),
                     string_vec!["src/**/*"]
                 )]),
-                tasks: BTreeMap::new(),
-                schema: String::new(),
+                ..InheritedTasksConfig::default()
             }
         );
 

--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -245,9 +245,9 @@ impl<'ws> ProjectGraphBuilder<'ws> {
         project: &mut Project,
         task: &mut Task,
     ) -> Result<(), ProjectGraphError> {
-        if !self.workspace.config.runner.implicit_deps.is_empty() {
+        if !self.workspace.tasks_config.implicit_deps.is_empty() {
             task.deps.extend(Task::create_dep_targets(
-                &self.workspace.config.runner.implicit_deps,
+                &self.workspace.tasks_config.implicit_deps,
             )?);
         }
 
@@ -345,9 +345,9 @@ impl<'ws> ProjectGraphBuilder<'ws> {
         project: &mut Project,
         task: &mut Task,
     ) -> Result<(), ProjectGraphError> {
-        if !self.workspace.config.runner.implicit_inputs.is_empty() {
+        if !self.workspace.tasks_config.implicit_inputs.is_empty() {
             task.inputs
-                .extend(self.workspace.config.runner.implicit_inputs.clone());
+                .extend(self.workspace.tasks_config.implicit_inputs.clone());
         }
 
         if task.inputs.is_empty() {

--- a/crates/core/project-graph/tests/projects_test.rs
+++ b/crates/core/project-graph/tests/projects_test.rs
@@ -619,9 +619,8 @@ mod task_expansion {
 
         #[tokio::test]
         async fn inherits_implicit_deps() {
-            let (_sandbox, project_graph) = tasks_sandbox_with_config(|workspace_config, _| {
-                workspace_config.runner.implicit_deps =
-                    string_vec!["build", "~:build", "project:task",]
+            let (_sandbox, project_graph) = tasks_sandbox_with_config(|_, tasks_config| {
+                tasks_config.implicit_deps = string_vec!["build", "~:build", "project:task",]
             })
             .await;
 
@@ -665,8 +664,8 @@ mod task_expansion {
 
         #[tokio::test]
         async fn resolves_implicit_deps_parent_depends_on() {
-            let (_sandbox, project_graph) = tasks_sandbox_with_config(|workspace_config, _| {
-                workspace_config.runner.implicit_deps = string_vec!["^:build"]
+            let (_sandbox, project_graph) = tasks_sandbox_with_config(|_, tasks_config| {
+                tasks_config.implicit_deps = string_vec!["^:build"]
             })
             .await;
 
@@ -686,8 +685,8 @@ mod task_expansion {
 
         #[tokio::test]
         async fn avoids_implicit_deps_matching_target() {
-            let (_sandbox, project_graph) = tasks_sandbox_with_config(|workspace_config, _| {
-                workspace_config.runner.implicit_deps = string_vec!["basic:build"]
+            let (_sandbox, project_graph) = tasks_sandbox_with_config(|_, tasks_config| {
+                tasks_config.implicit_deps = string_vec!["basic:build"]
             })
             .await;
 
@@ -893,9 +892,8 @@ mod task_expansion {
 
         #[tokio::test]
         async fn inherits_implicit_inputs() {
-            let (_sandbox, project_graph) = tasks_sandbox_with_config(|workspace_config, _| {
-                workspace_config.runner.implicit_inputs =
-                    string_vec!["package.json", "/.moon/workspace.yml"]
+            let (_sandbox, project_graph) = tasks_sandbox_with_config(|_, tasks_config| {
+                tasks_config.implicit_inputs = string_vec!["package.json", "/.moon/workspace.yml"]
             })
             .await;
 
@@ -922,8 +920,8 @@ mod task_expansion {
 
         #[tokio::test]
         async fn inherits_implicit_inputs_env_vars() {
-            let (_sandbox, project_graph) = tasks_sandbox_with_config(|workspace_config, _| {
-                workspace_config.runner.implicit_inputs = string_vec!["$FOO", "$BAR"]
+            let (_sandbox, project_graph) = tasks_sandbox_with_config(|_, tasks_config| {
+                tasks_config.implicit_inputs = string_vec!["$FOO", "$BAR"]
             })
             .await;
 

--- a/crates/core/project-graph/tests/projects_test.rs
+++ b/crates/core/project-graph/tests/projects_test.rs
@@ -191,10 +191,7 @@ mod task_inheritance {
             assert_eq!(task.command, "newcmd".to_string());
             assert_eq!(task.args, string_vec!["--b"]);
             assert_eq!(task.env, FxHashMap::from_iter([("KEY".into(), "b".into())]));
-            assert_eq!(
-                task.inputs,
-                string_vec!["b.*", "package.json", "/.moon/*.yml",]
-            );
+            assert_eq!(task.inputs, string_vec!["b.*", "/.moon/*.yml",]);
             assert_eq!(task.outputs, string_vec!["b.ts"]);
         }
 
@@ -219,10 +216,7 @@ mod task_inheritance {
                     ("KEY".to_owned(), "b".to_owned()),
                 ])
             );
-            assert_eq!(
-                task.inputs,
-                string_vec!["a.*", "b.*", "package.json", "/.moon/*.yml",]
-            );
+            assert_eq!(task.inputs, string_vec!["a.*", "b.*", "/.moon/*.yml",]);
             assert_eq!(task.outputs, string_vec!["a.ts", "b.ts"]);
         }
 
@@ -247,10 +241,7 @@ mod task_inheritance {
                     ("KEY".to_owned(), "a".to_owned()),
                 ])
             );
-            assert_eq!(
-                task.inputs,
-                string_vec!["b.*", "a.*", "package.json", "/.moon/*.yml",]
-            );
+            assert_eq!(task.inputs, string_vec!["b.*", "a.*", "/.moon/*.yml",]);
             assert_eq!(task.outputs, string_vec!["b.ts", "a.ts"]);
         }
 
@@ -272,10 +263,7 @@ mod task_inheritance {
                 task.env,
                 FxHashMap::from_iter([("KEY".to_owned(), "b".to_owned()),])
             );
-            assert_eq!(
-                task.inputs,
-                string_vec!["b.*", "package.json", "/.moon/*.yml",]
-            );
+            assert_eq!(task.inputs, string_vec!["b.*", "/.moon/*.yml",]);
             assert_eq!(task.outputs, string_vec!["a.ts", "b.ts"]);
         }
     }
@@ -889,11 +877,12 @@ mod task_expansion {
 
     mod expand_inputs {
         use super::*;
+        use moon_test_utils::pretty_assertions::assert_eq;
 
         #[tokio::test]
         async fn inherits_implicit_inputs() {
             let (_sandbox, project_graph) = tasks_sandbox_with_config(|_, tasks_config| {
-                tasks_config.implicit_inputs = string_vec!["package.json", "/.moon/workspace.yml"]
+                tasks_config.implicit_inputs = string_vec!["package.json"];
             })
             .await;
 
@@ -904,7 +893,7 @@ mod task_expansion {
                     .get_task("a")
                     .unwrap()
                     .inputs,
-                string_vec!["a.ts", "package.json", "/.moon/workspace.yml"]
+                string_vec!["a.ts", "package.json", "/.moon/*.yml"]
             );
 
             assert_eq!(
@@ -914,7 +903,7 @@ mod task_expansion {
                     .get_task("c")
                     .unwrap()
                     .inputs,
-                string_vec!["**/*", "package.json", "/.moon/workspace.yml"]
+                string_vec!["**/*", "package.json", "/.moon/*.yml"]
             );
         }
 
@@ -967,7 +956,6 @@ mod task_expansion {
             let b: FxHashSet<PathBuf> = FxHashSet::from_iter(
                 vec![
                     sandbox.path().join("package.json"),
-                    project.root.join("package.json"),
                     project.root.join("file.ts"),
                     project.root.join("dir"),
                     project.root.join("dir/subdir"),

--- a/crates/core/project/tests/project_test.rs
+++ b/crates/core/project/tests/project_test.rs
@@ -7,7 +7,6 @@ use moon_task::FileGroup;
 use moon_test_utils::get_fixtures_root;
 use moon_utils::string_vec;
 use rustc_hash::FxHashMap;
-use std::collections::BTreeMap;
 
 fn mock_file_groups() -> FxHashMap<String, FileGroup> {
     FxHashMap::from_iter([(
@@ -18,10 +17,8 @@ fn mock_file_groups() -> FxHashMap<String, FileGroup> {
 
 fn mock_tasks_config() -> InheritedTasksConfig {
     InheritedTasksConfig {
-        extends: None,
         file_groups: FxHashMap::from_iter([("sources".into(), string_vec!["src/**/*"])]),
-        tasks: BTreeMap::new(),
-        schema: String::new(),
+        ..InheritedTasksConfig::default()
     }
 }
 

--- a/packages/types/src/project-config.ts
+++ b/packages/types/src/project-config.ts
@@ -92,5 +92,7 @@ export interface ProjectConfig {
 export interface InheritedTasksConfig {
 	extends: string | null;
 	fileGroups: Record<string, string[]>;
+	implicitDeps: string[];
+	implicitInputs: string[];
 	tasks: Record<string, TaskConfig>;
 }

--- a/packages/types/src/workspace-config.ts
+++ b/packages/types/src/workspace-config.ts
@@ -13,8 +13,6 @@ export interface NotifierConfig {
 export interface RunnerConfig {
 	archivableTargets: string[];
 	cacheLifetime: string;
-	implicitDeps: string[];
-	implicitInputs: string[];
 	inheritColorsForPipedTasks: boolean;
 	logRunningCommand: boolean;
 }

--- a/scripts/release/buildPackages.sh
+++ b/scripts/release/buildPackages.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-# Change the working directory so that we avoid the CLI postinstall checks!
-cd scripts
+args="--addFiles --addExports --declaration --declarationConfig tsconfig.build.json"
 
-# Build all packages with moon itself, so that the order is resolved correctly
-npm install -g pnpm
-pnpm --package @moonrepo/cli@0.21.0 dlx moon run types:build visualizer:build
-pnpm --package @moonrepo/cli@0.21.0 dlx moon run report:build runtime:build visualizer:build
+export NODE_ENV=production
 
-# Note: yarn/npm/npx did not work here, but pnpm does!
+# Build types first since everything depends on it
+yarn packemon build --filter @moonrepo/types $args
+
+# Then just build everything
+yarn packemon build $args

--- a/scripts/release/buildPackages.sh
+++ b/scripts/release/buildPackages.sh
@@ -5,7 +5,7 @@ cd scripts
 
 # Build all packages with moon itself, so that the order is resolved correctly
 npm install -g pnpm
-pnpm --package @moonrepo/cli@0.22.0 dlx moon run types:build visualizer:build
-pnpm --package @moonrepo/cli@0.22.0 dlx moon run report:build runtime:build visualizer:build
+pnpm --package @moonrepo/cli@0.21.0 dlx moon run types:build visualizer:build
+pnpm --package @moonrepo/cli@0.21.0 dlx moon run report:build runtime:build visualizer:build
 
 # Note: yarn/npm/npx did not work here, but pnpm does!

--- a/scripts/release/buildPackages.sh
+++ b/scripts/release/buildPackages.sh
@@ -5,6 +5,7 @@ cd scripts
 
 # Build all packages with moon itself, so that the order is resolved correctly
 npm install -g pnpm
-pnpm --package @moonrepo/cli@0.20.3 dlx moon run report:build runtime:build types:build visualizer:build
+pnpm --package @moonrepo/cli@0.22.0 dlx moon run types:build visualizer:build
+pnpm --package @moonrepo/cli@0.22.0 dlx moon run report:build runtime:build visualizer:build
 
 # Note: yarn/npm/npx did not work here, but pnpm does!

--- a/website/docs/commands/migrate/from-turborepo.mdx
+++ b/website/docs/commands/migrate/from-turborepo.mdx
@@ -9,7 +9,7 @@ This process will convert the root `turbo.json` file to moon applicable configur
 - Migrates `pipeline` global tasks to [`.moon/tasks.yml`](../../config/tasks#tasks) and project
   scoped tasks to [`moon.yml`](../../config/project#tasks).
 - Migrates `globalDependencies` and `globalEnv` to
-  [`.moon/workspace.yml`](../../config/workspace#implicitinputs) (via `runner.implicitInputs`).
+  [`.moon/tasks.yml`](../../config/tasks#implicitinputs) (via `implicitInputs`).
 
 ```shell
 $ moon migrate from-turborepo

--- a/website/docs/config/tasks.mdx
+++ b/website/docs/config/tasks.mdx
@@ -65,6 +65,36 @@ fileGroups:
 > File paths and globs used within a file group are relative from the inherited project's root, and
 > not the workspace.
 
+### `implicitDeps`<VersionLabel version="0.23" />
+
+<HeadingApiLink to="/api/types/interface/InheritedTasksConfig#implicitDeps" />
+
+Defines task [`deps`](./project#deps) that are implicitly inherited by _all_ tasks within the
+workspace. This is extremely useful for pre-building projects that are used extensively throughout
+the repo, or always building project dependencies. Defaults to an empty list.
+
+```yaml title=".moon/tasks.yml" {1-2}
+implicitDeps:
+  - '^:build'
+```
+
+### `implicitInputs`<VersionLabel version="0.23" />
+
+<HeadingApiLink to="/api/types/interface/InheritedTasksConfig#implicitInputs" />
+
+Defines task [`inputs`](./project#inputs) that are implicitly inherited by _all_ tasks within the
+workspace. This is extremely useful for the "changes to these files should always trigger a task"
+scenario.
+
+Like `inputs`, file paths/globs defined here are relative from the inheriting project.
+[Project and workspace relative file patterns](../concepts/file-pattern#project-relative) are
+supported and encouraged.
+
+```yaml title=".moon/workspace.yml" {1-2}
+implicitInputs:
+  - 'package.json'
+```
+
 ## `tasks`
 
 <HeadingApiLink to="/api/types/interface/InheritedTasksConfig#tasks" />

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -188,45 +188,6 @@ runner:
 > This setting primarily exists for [remote caching](../guides/remote-cache) as it will create and
 > persist tar archives located in `.moon/cache/outputs`.
 
-### `implicitDeps`<VersionLabel version="0.16" />
-
-<HeadingApiLink to="/api/types/interface/RunnerConfig#implicitDeps" />
-
-Defines task [`deps`](./project#deps) that are implicitly inherited by _all_ tasks within the
-workspace. This is extremely useful for pre-building projects that are used extensively throughout
-the repo, or always building project dependencies. Defaults to an empty list.
-
-```yaml title=".moon/workspace.yml" {2-5}
-runner:
-  implicitDeps:
-    - '^:build'
-```
-
-### `implicitInputs`<VersionLabel version="0.9" />
-
-<HeadingApiLink to="/api/types/interface/RunnerConfig#implicitInputs" />
-
-Defines task [`inputs`](./project#inputs) that are implicitly inherited by _all_ tasks within the
-workspace. This is extremely useful for the "changes to these files should always trigger a task"
-scenario.
-
-Like `inputs`, file paths/globs defined here are relative from the inheriting project.
-[Project and workspace relative file patterns](../concepts/file-pattern#project-relative) are
-supported and encouraged.
-
-```yaml title=".moon/workspace.yml" {2-5}
-runner:
-  implicitInputs:
-    - 'package.json'
-    - '/.moon/tasks.yml'
-    - '/.moon/toolchain.yml'
-    - '/.moon/workspace.yml'
-```
-
-> When not defined, this setting defaults to the list in the example above. When this setting _is
-> defined_, that list will be overwritten, so be sure to explicitly define them if you would like to
-> retain that functionality.
-
 ### `inheritColorsForPipedTasks`<VersionLabel version="0.3" />
 
 <HeadingApiLink to="/api/types/interface/RunnerConfig#inheritColorsForPipedTasks" />

--- a/website/static/schemas/tasks.json
+++ b/website/static/schemas/tasks.json
@@ -19,6 +19,18 @@
         }
       }
     },
+    "implicitDeps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "implicitInputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "tasks": {
       "type": "object",
       "additionalProperties": {

--- a/website/static/schemas/workspace.json
+++ b/website/static/schemas/workspace.json
@@ -89,24 +89,6 @@
           "default": "7 days",
           "type": "string"
         },
-        "implicitDeps": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "implicitInputs": {
-          "default": [
-            "package.json",
-            "/.moon/tasks.yml",
-            "/.moon/toolchain.yml",
-            "/.moon/workspace.yml"
-          ],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "inheritColorsForPipedTasks": {
           "type": "boolean"
         },


### PR DESCRIPTION
These settings make much more sense in the new `.moon/tasks.yml` config file then they do in the runner config. Especially with the new inheritance coming in the next version.