### PR TITLE
fix: Fix inaccurate run report action durations.

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,4 +1,4 @@
-# Trigger CI: 8
+# Trigger CI: 9
 
 $schema: '../website/static/schemas/workspace.json'
 

--- a/crates/core/action-pipeline/src/processor.rs
+++ b/crates/core/action-pipeline/src/processor.rs
@@ -27,6 +27,8 @@ pub async fn process_action(
     workspace: Arc<RwLock<Workspace>>,
     project_graph: Arc<RwLock<ProjectGraph>>,
 ) -> Result<Action, PipelineError> {
+    action.start();
+
     let node = action.node.take().unwrap();
     let log_action_label = color::muted_light(&action.label);
 
@@ -185,7 +187,7 @@ pub async fn process_action(
 
     match result {
         Ok(status) => {
-            action.done(status);
+            action.finish(status);
         }
         Err(error) => {
             action.fail(error.to_string());

--- a/crates/core/action/src/action.rs
+++ b/crates/core/action/src/action.rs
@@ -100,7 +100,7 @@ impl Action {
             label: node.label(),
             log_target: String::new(),
             node: Some(node),
-            start_time: Some(Instant::now()),
+            start_time: None,
             status: ActionStatus::Running,
         }
     }
@@ -109,7 +109,11 @@ impl Action {
         self.status = ActionStatus::FailedAndAbort;
     }
 
-    pub fn done(&mut self, status: ActionStatus) {
+    pub fn start(&mut self) {
+        self.start_time = Some(Instant::now());
+    }
+
+    pub fn finish(&mut self, status: ActionStatus) {
         self.finished_at = Some(now_timestamp());
         self.status = status;
 
@@ -120,7 +124,7 @@ impl Action {
 
     pub fn fail(&mut self, error: String) {
         self.error = Some(error);
-        self.done(ActionStatus::Failed);
+        self.finish(ActionStatus::Failed);
     }
 
     pub fn has_failed(&self) -> bool {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### 🐞 Fixes
 
 - Fixed an issue where the project graph cache was not always resetting based on changes.
+- Fixed an issue where run report action durations were innacurate.
 
 #### ⚙️ Internal
 


### PR DESCRIPTION
Noticed that durations were kind of off. For example, an attempt was 2 seconds but the overall action duration would be 15 seconds! 

What is happening for those other 13 minutes? I'm assuming this is Tokio jumping between the thread queue.

To remedy this, I'm deferring the start time until it actually starts, instead of time of creation.

