### PR TITLE
new: Use `pnpm dedupe` when it's available.

### DIFF
--- a/crates/node/tool/src/pnpm_tool.rs
+++ b/crates/node/tool/src/pnpm_tool.rs
@@ -5,7 +5,7 @@ use moon_node_lang::{pnpm, LockfileDependencyVersions, PNPM};
 use moon_terminal::{print_checkpoint, Checkpoint};
 use moon_tool::{get_path_env_var, DependencyManager, Tool, ToolError};
 use moon_utils::process::Command;
-use moon_utils::{fs, is_ci};
+use moon_utils::{fs, is_ci, semver};
 use proto_core::{
     async_trait, Describable, Executable, Installable, Proto, Resolvable, Shimable,
     Tool as ProtoTool,
@@ -108,11 +108,21 @@ impl DependencyManager<NodeTool> for PnpmTool {
         &self,
         node: &NodeTool,
         working_dir: &Path,
-        _log: bool,
+        log: bool,
     ) -> Result<(), ToolError> {
         if working_dir.join(self.get_lock_filename()).exists() {
-            node.exec_package("pnpm-deduplicate", &["pnpm-deduplicate"], working_dir)
-                .await?;
+            // https://github.com/pnpm/pnpm/releases/tag/v7.26.0
+            if semver::satisfies_range(&self.config.version, ">=7.26.0") {
+                self.create_command(node)?
+                    .arg("dedupe")
+                    .cwd(working_dir)
+                    .log_running_command(log)
+                    .exec_capture_output()
+                    .await?;
+            } else {
+                node.exec_package("pnpm-deduplicate", &["pnpm-deduplicate"], working_dir)
+                    .await?;
+            }
         }
 
         Ok(())

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Now supports `.moon/tasks/<language>.yml` and `.moon/tasks/<language>-<type>.yml` configuration
     files.
 - Updated to no longer cache the project graph when there's no VCS root.
+- Updated pnpm to use the new `pnpm dedupe` command when the version is >= 7.26.0.
 
 #### 🐞 Fixes
 

--- a/website/blog/2023-01-30_v0.23.mdx
+++ b/website/blog/2023-01-30_v0.23.mdx
@@ -207,3 +207,18 @@ implicitInputs:
 
 </TabItem>
 </Tabs>
+
+## Other changes
+
+View the
+[official release](https://github.com/moonrepo/moon/releases/tag/%40moonrepo%2Fcli%400.23.0) for a
+full list of changes.
+
+- Updated to no longer cache the project graph when there's no VCS root.
+- Updated pnpm to use the new `pnpm dedupe` command when the version is >= 7.26.0.
+
+## What's next?
+
+Expect the following in the v0.24 release!
+
+- ???


### PR DESCRIPTION
This was recently added: https://github.com/pnpm/pnpm/releases/tag/v7.26.0