### PR TITLE
internal: Pass CI information to versions endpoint.

### DIFF
--- a/.yarn/versions/1b36b2c6.yml
+++ b/.yarn/versions/1b36b2c6.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch


### PR DESCRIPTION
We need to differentiate local vs CI runs.