### PR TITLE
fix: Fix issues around the Node.js tool not being configured.

### DIFF
--- a/crates/core/action-pipeline/src/actions/run_target.rs
+++ b/crates/core/action-pipeline/src/actions/run_target.rs
@@ -68,7 +68,7 @@ pub async fn run_target(
     if should_cache {
         let mut context = context.write().await;
 
-        if let Some(cache_location) = runner.is_cached(&mut context).await? {
+        if let Some(cache_location) = runner.is_cached(&mut context, runtime).await? {
             return Ok(runner.hydrate(cache_location).await?);
         }
     }

--- a/crates/core/platform-runtime/src/version.rs
+++ b/crates/core/platform-runtime/src/version.rs
@@ -14,6 +14,10 @@ impl Version {
         Version(version.to_owned(), true)
     }
 
+    pub fn is_latest(&self) -> bool {
+        self.0 == "latest"
+    }
+
     pub fn is_override(&self) -> bool {
         self.1
     }

--- a/crates/core/platform/src/platform.rs
+++ b/crates/core/platform/src/platform.rs
@@ -151,6 +151,7 @@ pub trait Platform: Debug + Send + Sync {
     async fn hash_run_target(
         &self,
         project: &Project,
+        runtime: &Runtime,
         hashset: &mut HashSet,
         hasher_config: &HasherConfig,
     ) -> Result<(), ToolError> {

--- a/crates/core/runner/src/runner.rs
+++ b/crates/core/runner/src/runner.rs
@@ -428,6 +428,7 @@ impl<'a> Runner<'a> {
     pub async fn is_cached(
         &mut self,
         context: &mut ActionContext,
+        runtime: &Runtime,
     ) -> Result<Option<HydrateFrom>, RunnerError> {
         let mut hashset = HashSet::default();
 
@@ -436,7 +437,12 @@ impl<'a> Runner<'a> {
         self.workspace
             .platforms
             .get(self.task.platform)?
-            .hash_run_target(self.project, &mut hashset, &self.workspace.config.hasher)
+            .hash_run_target(
+                self.project,
+                runtime,
+                &mut hashset,
+                &self.workspace.config.hasher,
+            )
             .await?;
 
         let hash = hashset.generate();

--- a/crates/node/platform/src/actions/run_target.rs
+++ b/crates/node/platform/src/actions/run_target.rs
@@ -1,6 +1,8 @@
 use crate::target_hasher::NodeTargetHasher;
 use moon_action_context::{ActionContext, ProfileType};
-use moon_config::{HasherConfig, HasherOptimization, NodePackageManager, TypeScriptConfig};
+use moon_config::{
+    HasherConfig, HasherOptimization, NodeConfig, NodePackageManager, TypeScriptConfig,
+};
 use moon_error::MoonError;
 use moon_logger::{color, trace};
 use moon_node_lang::{
@@ -21,7 +23,7 @@ use std::path::Path;
 const LOG_TARGET: &str = "moon:node-platform:run-target";
 
 fn create_node_options(
-    node: &NodeTool,
+    node_config: &NodeConfig,
     context: &ActionContext,
     task: &Task,
 ) -> Result<Vec<String>, MoonError> {
@@ -31,7 +33,7 @@ fn create_node_options(
         &task.target.id,
     ];
 
-    options.extend(node.config.bin_exec_args.to_owned());
+    options.extend(node_config.bin_exec_args.to_owned());
 
     if let Some(profile) = &context.profile {
         let prof_dir = get_cache_dir()
@@ -77,6 +79,38 @@ fn create_node_options(
     Ok(options)
 }
 
+fn find_package_bin(starting_dir: &Path, bin_name: &str) -> Result<node::BinFile, ToolError> {
+    match node::find_package_bin(starting_dir, bin_name)? {
+        Some(bin) => Ok(bin),
+        None => Err(ToolError::MissingBinary(bin_name.to_owned())),
+    }
+}
+
+fn prepare_target_command(
+    command: &mut Command,
+    context: &ActionContext,
+    task: &Task,
+    node_config: &NodeConfig,
+) -> Result<(), ToolError> {
+    command.args(&task.args).envs(&task.env);
+
+    // This functionality mimics what pnpm's "node_modules/.bin" binaries do
+    if matches!(node_config.package_manager, NodePackageManager::Pnpm) {
+        command.env(
+            "NODE_PATH",
+            node::extend_node_path(path::to_string(
+                context
+                    .workspace_root
+                    .join("node_modules")
+                    .join(".pnpm")
+                    .join("node_modules"),
+            )?),
+        );
+    }
+
+    Ok(())
+}
+
 /// Runs a task command through our toolchain's installed Node.js instance.
 /// We accomplish this by executing the Node.js binary as a child process,
 /// while passing a file path to a package's node module binary (this is the file
@@ -99,7 +133,7 @@ pub fn create_target_command(
 
     match task.command.as_str() {
         "node" | "nodejs" => {
-            args.extend(create_node_options(node, context, task)?);
+            args.extend(create_node_options(&node.config, context, task)?);
         }
         "npx" => {
             command = Command::new(node.get_npx_path()?);
@@ -114,14 +148,14 @@ pub fn create_target_command(
             command = node.get_yarn()?.create_command(node)?;
         }
         bin => {
-            match node.find_package_bin(&project.root, bin)? {
+            match find_package_bin(&project.root, bin)? {
                 // Rust, Go
                 BinFile::Binary(bin_path) => {
                     command = Command::new(bin_path);
                 }
                 // JavaScript
                 BinFile::Script(bin_path) => {
-                    args.extend(create_node_options(node, context, task)?);
+                    args.extend(create_node_options(&node.config, context, task)?);
                     args.push(path::to_string(
                         path::relative_from(bin_path, working_dir).unwrap(),
                     )?);
@@ -132,39 +166,71 @@ pub fn create_target_command(
 
     command
         .args(&args)
-        .args(&task.args)
-        .envs(&task.env)
         .env("PATH", get_path_env_var(&node.tool.get_install_dir()?));
 
-    // This functionality mimics what pnpm's "node_modules/.bin" binaries do
-    if matches!(node.config.package_manager, NodePackageManager::Pnpm) {
-        command.env(
-            "NODE_PATH",
-            node::extend_node_path(path::to_string(
-                context
-                    .workspace_root
-                    .join("node_modules")
-                    .join(".pnpm")
-                    .join("node_modules"),
-            )?),
-        );
-    }
+    prepare_target_command(&mut command, context, task, &node.config)?;
+
+    Ok(command)
+}
+
+// This is like the function above, but is for situations where the tool
+// has not been configured, and should default to the global "node" found
+// in the user's shell.
+pub fn create_target_command_without_tool(
+    node_config: &NodeConfig,
+    context: &ActionContext,
+    project: &Project,
+    task: &Task,
+    working_dir: &Path,
+) -> Result<Command, ToolError> {
+    let mut command = Command::new("node");
+    let mut args = vec![];
+
+    match task.command.as_str() {
+        "node" | "nodejs" => {
+            args.extend(create_node_options(node_config, context, task)?);
+        }
+        "npx" | "npm" | "pnpm" | "yarn" | "yarnpkg" => {
+            command = Command::new(&task.command);
+        }
+        bin => {
+            match find_package_bin(&project.root, bin)? {
+                // Rust, Go
+                BinFile::Binary(bin_path) => {
+                    command = Command::new(bin_path);
+                }
+                // JavaScript
+                BinFile::Script(bin_path) => {
+                    args.extend(create_node_options(node_config, context, task)?);
+                    args.push(path::to_string(
+                        path::relative_from(bin_path, working_dir).unwrap(),
+                    )?);
+                }
+            };
+        }
+    };
+
+    command.args(&args);
+
+    prepare_target_command(&mut command, context, task, node_config)?;
 
     Ok(command)
 }
 
 pub async fn create_target_hasher(
-    node: &NodeTool,
+    node: Option<&NodeTool>,
     project: &Project,
     workspace_root: &Path,
     hasher_config: &HasherConfig,
     typescript_config: &Option<TypeScriptConfig>,
 ) -> Result<NodeTargetHasher, ToolError> {
-    let mut hasher = NodeTargetHasher::new(node.config.version.clone());
+    let mut hasher =
+        NodeTargetHasher::new(node.map(|n| n.config.version.clone()).unwrap_or_default());
 
     let resolved_dependencies =
-        if matches!(hasher_config.optimization, HasherOptimization::Accuracy) {
-            node.get_package_manager()
+        if matches!(hasher_config.optimization, HasherOptimization::Accuracy) && node.is_some() {
+            node.unwrap()
+                .get_package_manager()
                 .get_resolved_dependencies(&project.root)
                 .await?
         } else {

--- a/crates/node/tool/src/node_tool.rs
+++ b/crates/node/tool/src/node_tool.rs
@@ -73,17 +73,6 @@ impl NodeTool {
         Ok(())
     }
 
-    pub fn find_package_bin(
-        &self,
-        starting_dir: &Path,
-        bin_name: &str,
-    ) -> Result<node::BinFile, ToolError> {
-        match node::find_package_bin(starting_dir, bin_name)? {
-            Some(bin) => Ok(bin),
-            None => Err(ToolError::MissingBinary(bin_name.to_owned())),
-        }
-    }
-
     /// Return the `npm` package manager.
     pub fn get_npm(&self) -> Result<&NpmTool, ToolError> {
         match &self.npm {

--- a/crates/node/tool/src/npm_tool.rs
+++ b/crates/node/tool/src/npm_tool.rs
@@ -67,7 +67,7 @@ impl Tool for NpmTool {
         }
 
         print_checkpoint(
-            format!("installing node v{}", self.config.version),
+            format!("installing npm v{}", self.config.version),
             Checkpoint::Setup,
         );
 

--- a/crates/system/platform/src/platform.rs
+++ b/crates/system/platform/src/platform.rs
@@ -52,6 +52,7 @@ impl Platform for SystemPlatform {
     async fn hash_run_target(
         &self,
         _project: &Project,
+        _runtime: &Runtime,
         hashset: &mut HashSet,
         _hasher_config: &HasherConfig,
     ) -> Result<(), ToolError> {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fixed a recursion issue when attempting to install dependencies and a post-install script would
   trigger the process again.
+- Fixed an issue where a task may be hashed with the incorrect Node.js version.
+- Fixed an issue when running Node.js tasks and the toolchain has not been configured.
 
 #### 0.23.1
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
   trigger the process again.
 - Fixed an issue where a task may be hashed with the incorrect Node.js version.
 - Fixed an issue when running Node.js tasks and the toolchain has not been configured.
+- Fixed a typo when installing npm dependencies: `node install` -> `npm install`
 
 #### 0.23.1
 


### PR DESCRIPTION
Technically the tool is optional, and is optional when the `version` field in `toolchain.yml` is not set, or is set to null. When this happens, we should default to the global "node" found in the user's shell.