### PR TITLE
internal: Require a subscription for remote caching.

### DIFF
--- a/.yarn/versions/22ae79cb.yml
+++ b/.yarn/versions/22ae79cb.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/core/action-pipeline/src/pipeline.rs
+++ b/crates/core/action-pipeline/src/pipeline.rs
@@ -383,10 +383,14 @@ async fn create_emitter(workspace: Arc<RwLock<Workspace>>) -> Emitter {
             }
         }
 
-        if local_workspace.session.is_some() {
-            emitter
-                .subscribers
-                .push(Arc::new(RwLock::new(MoonbaseCacheSubscriber::new())));
+        if let Some(session) = &local_workspace.session {
+            if session.remote_caching_enabled {
+                emitter
+                    .subscribers
+                    .push(Arc::new(RwLock::new(MoonbaseCacheSubscriber::new())));
+            } else {
+                MoonbaseCacheSubscriber::not_enabled();
+            }
         }
     }
 

--- a/crates/core/action-pipeline/src/subscribers/moonbase_cache.rs
+++ b/crates/core/action-pipeline/src/subscribers/moonbase_cache.rs
@@ -29,6 +29,10 @@ impl MoonbaseCacheSubscriber {
             requests: vec![],
         }
     }
+
+    pub fn not_enabled() {
+        warn!(target: LOG_TARGET, "A moonbase session exists, but no subscription exists for remote caching. Will not enable remote caching!");
+    }
 }
 
 #[async_trait]

--- a/crates/core/moonbase/src/api.rs
+++ b/crates/core/moonbase/src/api.rs
@@ -13,6 +13,7 @@ pub struct SigninInput {
 #[serde(rename_all = "camelCase")]
 pub struct SigninResponse {
     pub organization_id: i32,
+    pub remote_caching: bool,
     pub repository_id: i32,
     pub token: String,
 }

--- a/crates/core/moonbase/src/lib.rs
+++ b/crates/core/moonbase/src/lib.rs
@@ -23,12 +23,14 @@ pub struct Moonbase {
     #[allow(dead_code)]
     pub organization_id: i32,
 
+    pub remote_caching_enabled: bool,
+
     #[allow(dead_code)]
     pub repository_id: i32,
 }
 
 impl Moonbase {
-    pub async fn signin(secret_key: String, api_key: String, slug: String) -> Option<Moonbase> {
+    pub async fn signin(secret_key: String, access_key: String, slug: String) -> Option<Moonbase> {
         debug!(
             target: LOG_TARGET,
             "API keys detected, attempting to sign in to moonbase for repository {}",
@@ -40,7 +42,7 @@ impl Moonbase {
             SigninInput {
                 organization_key: secret_key,
                 repository: slug,
-                repository_key: api_key,
+                repository_key: access_key,
             },
             None,
         )
@@ -49,11 +51,13 @@ impl Moonbase {
         match data {
             Ok(Response::Success(SigninResponse {
                 organization_id,
+                remote_caching,
                 repository_id,
                 token,
             })) => Some(Moonbase {
                 auth_token: token,
                 organization_id,
+                remote_caching_enabled: remote_caching,
                 repository_id,
             }),
             Ok(Response::Failure { message, status }) => {

--- a/crates/core/moonbase/src/lib.rs
+++ b/crates/core/moonbase/src/lib.rs
@@ -30,6 +30,13 @@ pub struct Moonbase {
 }
 
 impl Moonbase {
+    pub fn no_vcs_root() {
+        warn!(
+            target: LOG_TARGET,
+            "Unable to login to moonbase as no version control system was detected. We require VCS to infer the repository to sign in for!"
+        );
+    }
+
     pub async fn signin(secret_key: String, access_key: String, slug: String) -> Option<Moonbase> {
         debug!(
             target: LOG_TARGET,

--- a/crates/core/workspace/src/workspace.rs
+++ b/crates/core/workspace/src/workspace.rs
@@ -259,7 +259,8 @@ impl Workspace {
             return Ok(());
         };
 
-        let Ok(api_key) = env::var("MOONBASE_API_KEY") else {
+        let Ok(access_key) = env::var("MOONBASE_ACCESS_KEY")
+            .or_else(|_| env::var("MOONBASE_API_KEY")) else {
             return Ok(());
         };
 
@@ -269,7 +270,7 @@ impl Workspace {
             return Ok(());
         };
 
-        self.session = Moonbase::signin(secret_key, api_key, repo_slug).await;
+        self.session = Moonbase::signin(secret_key, access_key, repo_slug).await;
 
         Ok(())
     }

--- a/crates/core/workspace/src/workspace.rs
+++ b/crates/core/workspace/src/workspace.rs
@@ -267,6 +267,8 @@ impl Workspace {
         let repo_slug = if self.vcs.is_enabled() {
             self.vcs.get_repository_slug().await?
         } else {
+            Moonbase::no_vcs_root();
+
             return Ok(());
         };
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
+## Unreleased
+
 ## 0.23.2
+
+#### ⚙️ Internal
+
+- Minor internal changes for upcoming remote caching changes.
 
 #### 🐞 Fixes
 

--- a/website/docs/guides/remote-cache.mdx
+++ b/website/docs/guides/remote-cache.mdx
@@ -36,7 +36,7 @@ In that repositories CI environment, set the following environment variables.
 
 ```
 MOONBASE_SECRET_KEY=<secret key>
-MOONBASE_API_KEY=<api key>
+MOONBASE_ACCESS_KEY=<access key>
 ```
 
 moon will automatically authenticate the remote caching service when all credentials in the
@@ -71,6 +71,6 @@ No, moon does not collect any PII as part of the remote caching process.
 However, to use remote caching, you must create a moonrepo account in which we require an email
 address, and information about your organization and repository.
 
-#### What is an artifacts lifetime / retention policy?
+#### Are artifacts encrypted?
 
-Public artifacts are stored for 1 month. Private artifacts are stored for 3 months.
+Yes! We use AWS built-in SSE-S3 encryption for all S3 buckets.


### PR DESCRIPTION
We'll be launching our remote caching service real real soon. This makes the final changes in preparation for that.