### PR TITLE
Introduce upgrade command in CLI

### DIFF
--- a/.yarn/versions/7f63437c.yml
+++ b/.yarn/versions/7f63437c.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,9 +407,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bzip2"
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
@@ -1289,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -1310,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1321,21 +1321,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2233,11 +2233,13 @@ dependencies = [
 name = "moon_cli"
 version = "0.24.1"
 dependencies = [
+ "bytes",
  "clap 4.1.4",
  "clap_complete",
  "clap_lex 0.3.0",
  "console",
  "dialoguer",
+ "futures-util",
  "httpmock",
  "indicatif",
  "itertools",
@@ -2277,6 +2279,8 @@ dependencies = [
  "moon_workspace",
  "open",
  "petgraph",
+ "proto",
+ "reqwest",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -2286,6 +2290,7 @@ dependencies = [
  "tera",
  "tiny_http",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4293,6 +4298,7 @@ checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -41,18 +41,22 @@ moon_typescript_lang = { path = "../typescript/lang" }
 moon_utils = { path = "../core/utils" }
 moon_vcs = { path = "../core/vcs" }
 moon_workspace = { path = "../core/workspace" }
+bytes = "1.4.0"
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 clap_complete = { workspace = true }
 clap_lex = "0.3.0"
 console = { workspace = true }
 # console-subscriber = "0.1.8"
 dialoguer = "0.10.2"
+futures-util = "0.3.26"
 indicatif = "0.17.2"
 itertools = "0.10.5"
 lazy_static = { workspace = true }
 mimalloc = { version = "0.1.34", default-features = false }
 open = "3.2.0"
 petgraph = { workspace = true }
+proto = { path = "../proto/cli" }
+reqwest = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -61,6 +65,7 @@ strum = { version = "0.24.1", features = ["derive"] }
 tera = { version = "1.17.1", features = ["preserve_order"] }
 tiny_http = "0.12.0"
 tokio = { workspace = true }
+tokio-util = { version = "0.7.4", features = ["compat"] }
 
 [dev-dependencies]
 moon_archive = { path = "../core/archive" }

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -497,6 +497,10 @@ pub enum Commands {
         #[command(subcommand)]
         command: QueryCommands,
     },
+
+    // moon upgrade
+    #[command(name = "upgrade", about = "Upgrade to the latest version of moon.")]
+    Upgrade,
 }
 
 #[derive(Debug, Parser)]

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -15,3 +15,4 @@ pub mod run;
 pub mod setup;
 pub mod sync;
 pub mod teardown;
+pub mod upgrade;

--- a/crates/cli/src/commands/upgrade.rs
+++ b/crates/cli/src/commands/upgrade.rs
@@ -1,0 +1,107 @@
+use crate::helpers::{create_progress_bar, AnyError};
+use bytes::Buf;
+use itertools::Itertools;
+use moon_launchpad::check_version;
+use moon_logger::error;
+use moon_utils::{
+    fs::{create_dir_all, rename},
+    semver::Version,
+};
+use proto::ProtoError;
+use std::{env, fs::File, io::copy, path::Component};
+
+pub async fn upgrade() -> Result<(), AnyError> {
+    let version = env!("CARGO_PKG_VERSION");
+    let version_check = check_version(version).await;
+
+    let new_version = match version_check {
+        Ok((newer_version, _)) if Version::parse(&newer_version)? > Version::parse(version)? => {
+            newer_version
+        }
+        Ok(_) => {
+            println!("You're already on the latest version of moon!");
+            return Ok(());
+        }
+        Err(err) => {
+            error!("Failed to get current version of the cli from remote: {err}");
+            return Err(err);
+        }
+    };
+
+    let target = match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", arch) => {
+            // Run ldd to check if we're running on musl
+            let output = std::process::Command::new("ldd")
+                .arg("--version")
+                .output()?;
+            let output = String::from_utf8(output.stdout)?;
+            let libc = match output.contains("musl") {
+                true => "musl",
+                false => "gnu",
+            };
+            format!("moon-{arch}-unknown-linux-{libc}")
+        }
+        ("macos", arch) => format!("moon-{arch}-apple-darwin"),
+        ("windows", "x86_64") => "moon-x86_64-pc-windows-msvc.exe".to_owned(),
+        (_, arch) => {
+            return Err(
+                ProtoError::UnsupportedArchitecture("moon".to_owned(), arch.to_owned()).into(),
+            )
+        }
+    };
+
+    let bin_path = env::current_exe()?;
+
+    // We can only upgrade moon if it's installed under .moon
+    let upgradeable = bin_path
+        .components()
+        .contains(&Component::Normal(".moon".as_ref()));
+
+    if !upgradeable {
+        return Err(format!(
+            "Moon can only upgrade itself from the default .moon directory. \n\
+            Moon is currently installed at: {}",
+            bin_path.to_string_lossy()
+        )
+        .into());
+    }
+
+    let done = create_progress_bar(format!("Upgrading moon to version {new_version}..."));
+
+    // Move the old binary to a versioned path
+    let ver_path = bin_path
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join(version)
+        .join(bin_path.file_name().unwrap());
+    create_dir_all(ver_path.parent().unwrap())?;
+    rename(&bin_path, ver_path)?;
+
+    let mut file = File::create(bin_path)?;
+
+    #[cfg(target_family = "unix")]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = file.metadata()?.permissions();
+        perms.set_mode(0o755);
+        file.set_permissions(perms)?;
+    }
+
+    let new_bin = reqwest::get(format!(
+        "https://github.com/moonrepo/moon/releases/latest/download/{target}"
+    ))
+    .await?
+    .bytes()
+    .await?;
+
+    copy(&mut new_bin.reader(), &mut file)?;
+
+    done(
+        format!("Successfully upgraded moon to version {new_version}"),
+        true,
+    );
+
+    Ok(())
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -286,7 +286,7 @@ pub async fn run_cli() {
     };
 
     match version_check.await {
-        Ok(Ok(Some(newer_version))) => {
+        Ok(Ok((newer_version, true))) => {
             println!(
                 "There's a new version of moon! {newer_version}. Go to https://moonrepo.dev/docs/install to install",
             );
@@ -300,7 +300,7 @@ pub async fn run_cli() {
         Err(error) => {
             debug!("Failed to spawn check for current version: {}", error);
         }
-        Ok(Ok(None)) => {}
+        Ok(Ok((_, false))) => {}
     }
 
     if let Err(error) = result {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -21,6 +21,7 @@ use crate::commands::run::{run, RunOptions};
 use crate::commands::setup::setup;
 use crate::commands::sync::sync;
 use crate::commands::teardown::teardown;
+use crate::commands::upgrade::upgrade;
 use crate::helpers::setup_colors;
 use app::{App, Commands, DockerCommands, MigrateCommands, NodeCommands, QueryCommands};
 use clap::Parser;
@@ -281,6 +282,7 @@ pub async fn run_cli() {
             )
             .await
         }
+        Commands::Upgrade => upgrade().await,
         Commands::Setup => setup().await,
         Commands::Teardown => teardown().await,
     };
@@ -288,7 +290,8 @@ pub async fn run_cli() {
     match version_check.await {
         Ok(Ok((newer_version, true))) => {
             println!(
-                "There's a new version of moon! {newer_version}. Go to https://moonrepo.dev/docs/install to install",
+                "There's a new version of moon! {newer_version}. \n\
+                Run `moon upgrade` or go to https://moonrepo.dev/docs/install to install",
             );
         }
         Ok(Err(error)) => {

--- a/crates/core/launchpad/src/lib.rs
+++ b/crates/core/launchpad/src/lib.rs
@@ -60,11 +60,11 @@ pub async fn check_version(
             }
         }
 
+        moon_utils::fs::create_dir_all(check_state_path.parent().unwrap())?;
         let check_state = OpenOptions::new()
             .write(true)
             .create(true)
-            .open(&check_state_path)
-            .unwrap();
+            .open(&check_state_path)?;
 
         serde_json::to_writer(check_state, &CheckState { last_alert: now })?;
 


### PR DESCRIPTION
Hey!

I'm tinkering with #526. Are you open to something like this?

This doesn't consider installs through yarn and other methods. Maybe we could hide this command behind an `upgrade` feature and not compile it for distribution to npm?