### PR TITLE
internal: Add `bin`, `global`, and `local` commands for proto.

### DIFF
--- a/crates/proto/cli/src/bin.rs
+++ b/crates/proto/cli/src/bin.rs
@@ -22,15 +22,15 @@ struct App {
     command: Commands,
 }
 
-// TODO: alias, unalias, shell completions, local, global
+// TODO: alias, unalias, shell completions, local
 #[derive(Debug, Subcommand)]
 enum Commands {
     #[command(name = "bin", about = "Display the absolute path to a tools binary")]
     Bin {
-        #[arg(required = true, value_enum, help = "Name of tool to display")]
+        #[arg(required = true, value_enum, help = "Type of tool")]
         tool: ToolType,
 
-        #[arg(help = "Version of tool to display")]
+        #[arg(help = "Version of tool")]
         semver: Option<String>,
 
         #[arg(long, help = "Display shim path when available")]
@@ -39,22 +39,31 @@ enum Commands {
 
     #[command(name = "install", about = "Download and install a tool")]
     Install {
-        #[arg(required = true, value_enum, help = "Name of tool to install")]
+        #[arg(required = true, value_enum, help = "Type of tool")]
         tool: ToolType,
 
-        #[arg(default_value = "latest", help = "Version of tool to install")]
+        #[arg(default_value = "latest", help = "Version of tool")]
         semver: Option<String>,
+    },
+
+    #[command(name = "global", about = "Set the global default version of a tool")]
+    Global {
+        #[arg(required = true, value_enum, help = "Type of tool")]
+        tool: ToolType,
+
+        #[arg(required = true, help = "Version of tool")]
+        semver: String,
     },
 
     #[command(name = "list", alias = "ls", about = "List installed versions")]
     List {
-        #[arg(required = true, value_enum, help = "Name of tool to list")]
+        #[arg(required = true, value_enum, help = "Type of tool")]
         tool: ToolType,
     },
 
     #[command(name = "list-remote", alias = "lsr", about = "List available versions")]
     ListRemote {
-        #[arg(required = true, value_enum, help = "Name of tool to list")]
+        #[arg(required = true, value_enum, help = "Type of tool")]
         tool: ToolType,
     },
 
@@ -63,10 +72,10 @@ enum Commands {
         about = "Run a tool after detecting a version from the environment"
     )]
     Run {
-        #[arg(required = true, value_enum, help = "Name of tool to run")]
+        #[arg(required = true, value_enum, help = "Type of tool")]
         tool: ToolType,
 
-        #[arg(help = "Version of tool to run")]
+        #[arg(help = "Version of tool")]
         semver: Option<String>,
 
         // Passthrough args (after --)
@@ -79,7 +88,7 @@ enum Commands {
 
     #[command(name = "uninstall", about = "Uninstall a tool")]
     Uninstall {
-        #[arg(required = true, value_enum, help = "Name of tool to uninstall")]
+        #[arg(required = true, value_enum, help = "Type of tool to uninstall")]
         tool: ToolType,
 
         #[arg(required = true, help = "Version of tool to uninstall")]
@@ -96,6 +105,7 @@ async fn main() {
     let result = match app.command {
         Commands::Bin { tool, semver, shim } => commands::bin(tool, semver, shim).await,
         Commands::Install { tool, semver } => commands::install(tool, semver).await,
+        Commands::Global { tool, semver } => commands::global(tool, semver).await,
         Commands::List { tool } => commands::list(tool).await,
         Commands::ListRemote { tool } => commands::list_remote(tool).await,
         Commands::Run {

--- a/crates/proto/cli/src/bin.rs
+++ b/crates/proto/cli/src/bin.rs
@@ -25,7 +25,11 @@ struct App {
 // TODO: alias, unalias, shell completions
 #[derive(Debug, Subcommand)]
 enum Commands {
-    #[command(name = "bin", about = "Display the absolute path to a tools binary")]
+    #[command(
+        name = "bin",
+        about = "Display the absolute path to a tools binary",
+        long_about = "Display the absolute path to a tools binary. If no version is provided,\nit will detected from the current environment."
+    )]
     Bin {
         #[arg(required = true, value_enum, help = "Type of tool")]
         tool: ToolType,
@@ -37,7 +41,11 @@ enum Commands {
         shim: bool,
     },
 
-    #[command(name = "install", about = "Download and install a tool")]
+    #[command(
+        name = "install",
+        about = "Download and install a tool",
+        long_about = "Download and install a tool by unpacking the archive to ~/.proto/tools."
+    )]
     Install {
         #[arg(required = true, value_enum, help = "Type of tool")]
         tool: ToolType,
@@ -46,7 +54,11 @@ enum Commands {
         semver: Option<String>,
     },
 
-    #[command(name = "global", about = "Set the global default version of a tool")]
+    #[command(
+        name = "global",
+        about = "Set the global default version of a tool",
+        long_about = "Set the global default version of a tool. This will create a version file in the ~/.proto/tools installation directory."
+    )]
     Global {
         #[arg(required = true, value_enum, help = "Type of tool")]
         tool: ToolType,
@@ -55,13 +67,23 @@ enum Commands {
         semver: String,
     },
 
-    #[command(name = "list", alias = "ls", about = "List installed versions")]
+    #[command(
+        name = "list",
+        alias = "ls",
+        about = "List installed versions",
+        long_about = "List installed versions by scanning the ~/.proto/tools directory for possible versions."
+    )]
     List {
         #[arg(required = true, value_enum, help = "Type of tool")]
         tool: ToolType,
     },
 
-    #[command(name = "list-remote", alias = "lsr", about = "List available versions")]
+    #[command(
+        name = "list-remote",
+        alias = "lsr",
+        about = "List available versions",
+        long_about = "List available versions by resolving versions from the tool's remote release manifest."
+    )]
     ListRemote {
         #[arg(required = true, value_enum, help = "Type of tool")]
         tool: ToolType,
@@ -70,7 +92,7 @@ enum Commands {
     #[command(
         name = "local",
         about = "Set the local version of a tool",
-        long_about = "This will create a .prototools file (if it does not exist) in the current working directory with the appropriate tool and version."
+        long_about = "Set the local version of a tool. This will create a .prototools file (if it does not exist)\nin the current working directory with the appropriate tool and version."
     )]
     Local {
         #[arg(required = true, value_enum, help = "Type of tool")]
@@ -82,7 +104,8 @@ enum Commands {
 
     #[command(
         name = "run",
-        about = "Run a tool after detecting a version from the environment"
+        about = "Run a tool after detecting a version from the environment",
+        long_about = "Run a tool after detecting a version from the environment. In order of priority,\na version will be resolved from a provided CLI argument, a PROTO_VERSION environment variable,\na local version file (.prototools), and lastly a global version file (~/.proto/tools/version).\n\nIf no version can be found, the program will exit with an error."
     )]
     Run {
         #[arg(required = true, value_enum, help = "Type of tool")]
@@ -99,7 +122,11 @@ enum Commands {
         passthrough: Vec<String>,
     },
 
-    #[command(name = "uninstall", about = "Uninstall a tool")]
+    #[command(
+        name = "uninstall",
+        about = "Uninstall a tool",
+        long_about = "Uninstall a tool and remove the installation from ~/.proto/tools."
+    )]
     Uninstall {
         #[arg(required = true, value_enum, help = "Type of tool to uninstall")]
         tool: ToolType,

--- a/crates/proto/cli/src/bin.rs
+++ b/crates/proto/cli/src/bin.rs
@@ -22,7 +22,7 @@ struct App {
     command: Commands,
 }
 
-// TODO: alias, unalias, shell completions, local
+// TODO: alias, unalias, shell completions
 #[derive(Debug, Subcommand)]
 enum Commands {
     #[command(name = "bin", about = "Display the absolute path to a tools binary")]
@@ -68,6 +68,19 @@ enum Commands {
     },
 
     #[command(
+        name = "local",
+        about = "Set the local version of a tool",
+        long_about = "This will create a .prototools file (if it does not exist) in the current working directory with the appropriate tool and version."
+    )]
+    Local {
+        #[arg(required = true, value_enum, help = "Type of tool")]
+        tool: ToolType,
+
+        #[arg(required = true, help = "Version of tool")]
+        semver: String,
+    },
+
+    #[command(
         name = "run",
         about = "Run a tool after detecting a version from the environment"
     )]
@@ -108,6 +121,7 @@ async fn main() {
         Commands::Global { tool, semver } => commands::global(tool, semver).await,
         Commands::List { tool } => commands::list(tool).await,
         Commands::ListRemote { tool } => commands::list_remote(tool).await,
+        Commands::Local { tool, semver } => commands::local(tool, semver).await,
         Commands::Run {
             tool,
             semver,

--- a/crates/proto/cli/src/commands/bin.rs
+++ b/crates/proto/cli/src/commands/bin.rs
@@ -4,7 +4,7 @@ use proto::{create_tool, ProtoError, ToolType};
 pub async fn bin(
     tool_type: ToolType,
     forced_version: Option<String>,
-    shim: bool,
+    use_shim: bool,
 ) -> Result<(), ProtoError> {
     let mut tool = create_tool(&tool_type)?;
     let version = detect_version_from_environment(&tool, &tool_type, forced_version).await?;
@@ -12,7 +12,7 @@ pub async fn bin(
     tool.resolve_version(&version).await?;
     tool.find_bin_path().await?;
 
-    if shim {
+    if use_shim {
         tool.create_shims().await?;
 
         if let Some(shim_path) = tool.get_shim_path() {

--- a/crates/proto/cli/src/commands/bin.rs
+++ b/crates/proto/cli/src/commands/bin.rs
@@ -1,0 +1,28 @@
+use crate::helpers::detect_version_from_environment;
+use proto::{create_tool, ProtoError, ToolType};
+
+pub async fn bin(
+    tool_type: ToolType,
+    forced_version: Option<String>,
+    shim: bool,
+) -> Result<(), ProtoError> {
+    let mut tool = create_tool(&tool_type)?;
+    let version = detect_version_from_environment(&tool, &tool_type, forced_version).await?;
+
+    tool.resolve_version(&version).await?;
+    tool.find_bin_path().await?;
+
+    if shim {
+        tool.create_shims().await?;
+
+        if let Some(shim_path) = tool.get_shim_path() {
+            println!("{}", shim_path.to_string_lossy().to_string());
+
+            return Ok(());
+        }
+    }
+
+    println!("{}", tool.get_bin_path()?.to_string_lossy().to_string());
+
+    Ok(())
+}

--- a/crates/proto/cli/src/commands/bin.rs
+++ b/crates/proto/cli/src/commands/bin.rs
@@ -16,13 +16,13 @@ pub async fn bin(
         tool.create_shims().await?;
 
         if let Some(shim_path) = tool.get_shim_path() {
-            println!("{}", shim_path.to_string_lossy().to_string());
+            println!("{}", shim_path.to_string_lossy());
 
             return Ok(());
         }
     }
 
-    println!("{}", tool.get_bin_path()?.to_string_lossy().to_string());
+    println!("{}", tool.get_bin_path()?.to_string_lossy());
 
     Ok(())
 }

--- a/crates/proto/cli/src/commands/global.rs
+++ b/crates/proto/cli/src/commands/global.rs
@@ -1,0 +1,30 @@
+use crate::helpers::get_global_version_path;
+use log::{info, trace};
+use proto::{color, create_tool, ProtoError, ToolType};
+use std::fs;
+
+pub async fn global(tool_type: ToolType, version: String) -> Result<(), ProtoError> {
+    let mut tool = create_tool(&tool_type)?;
+
+    tool.resolve_version(&version).await?;
+
+    let global_path = get_global_version_path(&tool)?;
+
+    fs::write(&global_path, tool.get_resolved_version())
+        .map_err(|e| ProtoError::Fs(global_path.to_path_buf(), e.to_string()))?;
+
+    trace!(
+        target: "proto:global",
+        "Wrote the global version to {}",
+        color::path(&global_path),
+    );
+
+    info!(
+        target: "proto:global",
+        "Set the global {} version to {}",
+        tool.get_name(),
+        tool.get_resolved_version(),
+    );
+
+    Ok(())
+}

--- a/crates/proto/cli/src/commands/global.rs
+++ b/crates/proto/cli/src/commands/global.rs
@@ -1,9 +1,11 @@
-use crate::helpers::get_global_version_path;
+use crate::helpers::{enable_logging, get_global_version_path};
 use log::{info, trace};
 use proto::{color, create_tool, ProtoError, ToolType};
 use std::fs;
 
 pub async fn global(tool_type: ToolType, version: String) -> Result<(), ProtoError> {
+    enable_logging();
+
     let mut tool = create_tool(&tool_type)?;
 
     tool.resolve_version(&version).await?;

--- a/crates/proto/cli/src/commands/install.rs
+++ b/crates/proto/cli/src/commands/install.rs
@@ -1,5 +1,6 @@
+use crate::helpers::enable_logging;
 use log::info;
-use proto::{create_tool, enable_logging, ProtoError, ToolType};
+use proto::{create_tool, ProtoError, ToolType};
 
 pub async fn install(tool_type: ToolType, version: Option<String>) -> Result<(), ProtoError> {
     enable_logging();

--- a/crates/proto/cli/src/commands/list.rs
+++ b/crates/proto/cli/src/commands/list.rs
@@ -1,5 +1,6 @@
+use crate::helpers::enable_logging;
 use log::{debug, info};
-use proto::{color, create_tool, enable_logging, ProtoError, ToolType};
+use proto::{color, create_tool, ProtoError, ToolType};
 use std::fs;
 
 pub async fn list(tool_type: ToolType) -> Result<(), ProtoError> {

--- a/crates/proto/cli/src/commands/list_remote.rs
+++ b/crates/proto/cli/src/commands/list_remote.rs
@@ -1,6 +1,7 @@
+use crate::helpers::enable_logging;
 use human_sort::compare;
 use log::{debug, info};
-use proto::{create_tool, enable_logging, ProtoError, ToolType};
+use proto::{create_tool, ProtoError, ToolType};
 use std::io::{self, Write};
 
 // TODO: only show LTS, dont show pre-releases?

--- a/crates/proto/cli/src/commands/local.rs
+++ b/crates/proto/cli/src/commands/local.rs
@@ -1,0 +1,46 @@
+use crate::{
+    config::{Config, CONFIG_NAME},
+    helpers::enable_logging,
+};
+use log::{info, trace};
+use proto::{color, create_tool, ProtoError, ToolType};
+use std::{env, path::PathBuf};
+
+pub async fn local(tool_type: ToolType, version: String) -> Result<(), ProtoError> {
+    enable_logging();
+
+    let mut tool = create_tool(&tool_type)?;
+
+    tool.resolve_version(&version).await?;
+
+    let local_path = env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(CONFIG_NAME);
+
+    let mut config = if local_path.exists() {
+        Config::load(&local_path)?
+    } else {
+        Config::default()
+    };
+
+    config
+        .tools
+        .insert(tool_type, tool.get_resolved_version().to_owned());
+
+    config.save(&local_path)?;
+
+    trace!(
+        target: "proto:local",
+        "Wrote the local version to {}",
+        color::path(&local_path),
+    );
+
+    info!(
+        target: "proto:local",
+        "Set the local {} version to {}",
+        tool.get_name(),
+        tool.get_resolved_version(),
+    );
+
+    Ok(())
+}

--- a/crates/proto/cli/src/commands/mod.rs
+++ b/crates/proto/cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ mod global;
 mod install;
 mod list;
 mod list_remote;
+mod local;
 mod run;
 mod uninstall;
 
@@ -11,5 +12,6 @@ pub use global::*;
 pub use install::*;
 pub use list::*;
 pub use list_remote::*;
+pub use local::*;
 pub use run::*;
 pub use uninstall::*;

--- a/crates/proto/cli/src/commands/mod.rs
+++ b/crates/proto/cli/src/commands/mod.rs
@@ -1,9 +1,11 @@
+mod bin;
 mod install;
 mod list;
 mod list_remote;
 mod run;
 mod uninstall;
 
+pub use bin::*;
 pub use install::*;
 pub use list::*;
 pub use list_remote::*;

--- a/crates/proto/cli/src/commands/mod.rs
+++ b/crates/proto/cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 mod bin;
+mod global;
 mod install;
 mod list;
 mod list_remote;
@@ -6,6 +7,7 @@ mod run;
 mod uninstall;
 
 pub use bin::*;
+pub use global::*;
 pub use install::*;
 pub use list::*;
 pub use list_remote::*;

--- a/crates/proto/cli/src/commands/run.rs
+++ b/crates/proto/cli/src/commands/run.rs
@@ -1,132 +1,26 @@
-use crate::config::{Config, CONFIG_NAME};
-use log::{debug, trace};
-use proto::{color, create_tool, get_tools_dir, load_version_file, ProtoError, ToolType};
-use std::{env, path::Path, process::exit};
+use crate::helpers::detect_version_from_environment;
+use proto::{create_tool, ProtoError, ToolType};
+use std::process::exit;
 use tokio::process::Command;
 
-pub async fn run(tool_type: ToolType, args: Vec<String>) -> Result<(), ProtoError> {
+pub async fn run(
+    tool_type: ToolType,
+    forced_version: Option<String>,
+    args: Vec<String>,
+) -> Result<(), ProtoError> {
     let mut tool = create_tool(&tool_type)?;
-    let mut version = None;
+    let version = detect_version_from_environment(&tool, &tool_type, forced_version).await?;
 
-    // Env var takes highest priority
-    let env_var = format!("PROTO_{}_VERSION", tool.get_bin_name().to_uppercase());
-
-    if let Ok(session_version) = env::var(&env_var) {
-        debug!(
-            target: "proto:run",
-            "Detected version {} from environment variable {}",
-            session_version,
-            env_var
-        );
-
-        version = Some(session_version);
-    }
-
-    // Traverse upwards and attempt to detect a local version
-    if let Ok(working_dir) = env::current_dir() {
-        trace!(
-            target: "proto:run",
-            "Attempting to find local version"
-        );
-
-        let mut current_dir: Option<&Path> = Some(&working_dir);
-
-        while let Some(dir) = &current_dir {
-            trace!(
-                target: "proto:run",
-                "Checking in directory {}",
-                color::path(dir)
-            );
-
-            // We already found a version, so exit
-            if version.is_some() {
-                break;
-            }
-
-            // Detect from our config file
-            trace!(
-                target: "proto:run",
-                "Checking proto configuration file"
-            );
-
-            let config_file = dir.join(CONFIG_NAME);
-
-            if config_file.exists() {
-                let config = Config::load(&config_file)?;
-
-                if let Some(config_version) = config.tools.get(&tool_type) {
-                    debug!(
-                        target: "proto:run",
-                        "Detected version {} from configuration file {}",
-                        config_version,
-                        color::path(&config_file)
-                    );
-
-                    version = Some(config_version.to_owned());
-                    break;
-                }
-            }
-
-            // Detect using the tool
-            trace!(
-                target: "proto:run",
-                "Detecting from the tool's ecosystem"
-            );
-
-            if let Some(eco_version) = tool.detect_version_from(dir).await? {
-                debug!(
-                    target: "proto:run",
-                    "Detected version {} from tool's ecosystem",
-                    eco_version,
-                );
-
-                version = Some(eco_version);
-                break;
-            }
-
-            current_dir = dir.parent();
-        }
-    }
-
-    // If still no version, load the global version
-    if version.is_none() {
-        trace!(
-            target: "proto:run",
-            "Attempting to find global version"
-        );
-
-        let global_file = get_tools_dir()?.join(tool.get_bin_name()).join("version");
-
-        if global_file.exists() {
-            let global_version = load_version_file(&global_file)?;
-
-            debug!(
-                target: "proto:run",
-                "Detected global version {} from {}",
-                global_version,
-                color::path(&global_file)
-            );
-
-            version = Some(global_version);
-        }
-    }
-
-    // We didn't find anything!
-    let Some(version) = version else {
-        return Err(ProtoError::Message(
-            "Unable to detect an applicable version. Try setting a local or global version."
-                .into(),
-        ));
-    };
-
-    // Does the tool exist?
     if !tool.is_setup(&version).await? {
         return Err(ProtoError::MissingTool(tool.get_name()));
     }
 
     let status = Command::new(tool.get_bin_path()?)
         .args(&args)
-        .env(env_var, tool.get_resolved_version())
+        .env(
+            format!("PROTO_{}_VERSION", tool.get_bin_name().to_uppercase()),
+            tool.get_resolved_version(),
+        )
         .env(
             format!("PROTO_{}_BIN", tool.get_bin_name().to_uppercase()),
             tool.get_bin_path()?.to_string_lossy().to_string(),

--- a/crates/proto/cli/src/commands/uninstall.rs
+++ b/crates/proto/cli/src/commands/uninstall.rs
@@ -1,5 +1,6 @@
+use crate::helpers::enable_logging;
 use log::info;
-use proto::{create_tool, enable_logging, ProtoError, ToolType};
+use proto::{create_tool, ProtoError, ToolType};
 
 pub async fn uninstall(tool_type: ToolType, version: String) -> Result<(), ProtoError> {
     enable_logging();

--- a/crates/proto/cli/src/helpers.rs
+++ b/crates/proto/cli/src/helpers.rs
@@ -1,7 +1,14 @@
 use crate::config::{Config, CONFIG_NAME};
 use log::{debug, trace};
 use proto::{color, get_tools_dir, load_version_file, ProtoError, Tool, ToolType};
-use std::{env, path::Path};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+pub fn get_global_version_path<'l>(tool: &Box<dyn Tool<'l>>) -> Result<PathBuf, ProtoError> {
+    Ok(get_tools_dir()?.join(tool.get_bin_name()).join("version"))
+}
 
 pub async fn detect_version_from_environment<'l>(
     tool: &Box<dyn Tool<'l>>,
@@ -104,7 +111,7 @@ pub async fn detect_version_from_environment<'l>(
             "Attempting to find global version"
         );
 
-        let global_file = get_tools_dir()?.join(tool.get_bin_name()).join("version");
+        let global_file = get_global_version_path(&tool)?;
 
         if global_file.exists() {
             let global_version = load_version_file(&global_file)?;

--- a/crates/proto/cli/src/helpers.rs
+++ b/crates/proto/cli/src/helpers.rs
@@ -1,0 +1,130 @@
+use crate::config::{Config, CONFIG_NAME};
+use log::{debug, trace};
+use proto::{color, get_tools_dir, load_version_file, ProtoError, Tool, ToolType};
+use std::{env, path::Path};
+
+pub async fn detect_version_from_environment<'l>(
+    tool: &Box<dyn Tool<'l>>,
+    tool_type: &ToolType,
+    forced_version: Option<String>,
+) -> Result<String, ProtoError> {
+    let mut version = forced_version;
+    let env_var = format!("PROTO_{}_VERSION", tool.get_bin_name().to_uppercase());
+
+    // Env var takes highest priority
+    if version.is_none() {
+        if let Ok(session_version) = env::var(&env_var) {
+            debug!(
+                target: "proto:version",
+                "Detected version {} from environment variable {}",
+                session_version,
+                env_var
+            );
+
+            version = Some(session_version);
+        }
+    } else {
+        debug!(
+            target: "proto:version",
+            "Using explicit version {} passed on the command line",
+            version.as_ref().unwrap(),
+        );
+    }
+
+    // Traverse upwards and attempt to detect a local version
+    if let Ok(working_dir) = env::current_dir() {
+        trace!(
+            target: "proto:version",
+            "Attempting to find local version"
+        );
+
+        let mut current_dir: Option<&Path> = Some(&working_dir);
+
+        while let Some(dir) = &current_dir {
+            trace!(
+                target: "proto:version",
+                "Checking in directory {}",
+                color::path(dir)
+            );
+
+            // We already found a version, so exit
+            if version.is_some() {
+                break;
+            }
+
+            // Detect from our config file
+            trace!(
+                target: "proto:version",
+                "Checking proto configuration file"
+            );
+
+            let config_file = dir.join(CONFIG_NAME);
+
+            if config_file.exists() {
+                let config = Config::load(&config_file)?;
+
+                if let Some(config_version) = config.tools.get(&tool_type) {
+                    debug!(
+                        target: "proto:version",
+                        "Detected version {} from configuration file {}",
+                        config_version,
+                        color::path(&config_file)
+                    );
+
+                    version = Some(config_version.to_owned());
+                    break;
+                }
+            }
+
+            // Detect using the tool
+            trace!(
+                target: "proto:version",
+                "Detecting from the tool's ecosystem"
+            );
+
+            if let Some(eco_version) = tool.detect_version_from(dir).await? {
+                debug!(
+                    target: "proto:version",
+                    "Detected version {} from tool's ecosystem",
+                    eco_version,
+                );
+
+                version = Some(eco_version);
+                break;
+            }
+
+            current_dir = dir.parent();
+        }
+    }
+
+    // If still no version, load the global version
+    if version.is_none() {
+        trace!(
+            target: "proto:version",
+            "Attempting to find global version"
+        );
+
+        let global_file = get_tools_dir()?.join(tool.get_bin_name()).join("version");
+
+        if global_file.exists() {
+            let global_version = load_version_file(&global_file)?;
+
+            debug!(
+                target: "proto:version",
+                "Detected global version {} from {}",
+                global_version,
+                color::path(&global_file)
+            );
+
+            version = Some(global_version);
+        }
+    }
+
+    // We didn't find anything!
+    match version {
+        Some(ver) => Ok(ver),
+        None => Err(ProtoError::Message(
+            "Unable to detect an applicable version. Try setting a local or global version, or passing a command line argument.".into(),
+        )),
+    }
+}

--- a/crates/proto/cli/src/lib.rs
+++ b/crates/proto/cli/src/lib.rs
@@ -1,5 +1,4 @@
 use clap::ValueEnum;
-use std::env;
 use std::str::FromStr;
 
 pub use proto_core::*;
@@ -55,10 +54,4 @@ pub fn create_tool(tool: &ToolType) -> Result<Box<dyn Tool<'static>>, ProtoError
         // Go
         ToolType::Go => Box::new(go::GoLanguage::new(&proto)),
     })
-}
-
-pub fn enable_logging() {
-    if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "proto=debug");
-    }
 }

--- a/crates/proto/error/src/lib.rs
+++ b/crates/proto/error/src/lib.rs
@@ -39,6 +39,9 @@ pub enum ProtoError {
     #[error("Failed shim: {0}")]
     Shim(String),
 
+    #[error("TOML failure for {0}: {1}")]
+    Toml(PathBuf, String),
+
     #[error("Unable to install {0}, unsupported architecture {1}.")]
     UnsupportedArchitecture(String, String),
 


### PR DESCRIPTION
One step closer to finalizing the proto CLI!