### PR TITLE
new: Add `moon query tasks` command.

### DIFF
--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -107,6 +107,40 @@ pub enum QueryCommands {
     },
 
     #[command(
+        name = "tasks",
+        about = "List all available projects & tasks.",
+        rename_all = "camelCase"
+    )]
+    Tasks {
+        #[arg(long, help = "Filter projects that match this alias")]
+        alias: Option<String>,
+
+        #[arg(
+            long,
+            help = "Filter projects that are affected based on touched files"
+        )]
+        affected: bool,
+
+        #[arg(long, help = "Filter projects that match this ID")]
+        id: Option<String>,
+
+        #[arg(long, help = "Print the projects in JSON format")]
+        json: bool,
+
+        #[arg(long, help = "Filter projects of this programming language")]
+        language: Option<String>,
+
+        #[arg(long, help = "Filter projects that match this source path")]
+        source: Option<String>,
+
+        #[arg(long, help = "Filter projects that have the following tasks")]
+        tasks: Option<String>,
+
+        #[arg(long = "type", help = "Filter projects of this type")]
+        type_of: Option<String>,
+    },
+
+    #[command(
         name = "touched-files",
         about = "Query for touched files between revisions.",
         rename_all = "camelCase"

--- a/crates/cli/src/commands/query.rs
+++ b/crates/cli/src/commands/query.rs
@@ -66,3 +66,19 @@ pub async fn touched_files(options: &mut QueryTouchedFilesOptions) -> Result<(),
 
     Ok(())
 }
+
+pub async fn tasks(options: &QueryProjectsOptions) -> Result<(), AnyError> {
+    let mut workspace = load_workspace().await?;
+    let projects = query_projects(&mut workspace, options).await?;
+    let mut stdout = io::stdout().lock();
+
+    for project in projects {
+        writeln!(stdout, "{}", &project.id,)?;
+
+        for (task_id, task) in project.tasks {
+            writeln!(stdout, "\t:{} {}", &task_id, format!("| {}", task.command),)?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -231,6 +231,28 @@ pub async fn run_cli() {
                 })
                 .await
             }
+            QueryCommands::Tasks {
+                alias,
+                affected,
+                id,
+                json,
+                language,
+                source,
+                tasks,
+                type_of,
+            } => {
+                query::tasks(&QueryProjectsOptions {
+                    alias,
+                    affected,
+                    id,
+                    json,
+                    language,
+                    source,
+                    tasks,
+                    type_of,
+                })
+                .await
+            }
         },
         Commands::Run {
             targets,


### PR DESCRIPTION
```shell
$ cargo run -- query tasks
types
        :build | packemon
        :format | prettier
        :lint | eslint
        :test | jest
        :typecheck | tsc
report
        :build | packemon
        :format | prettier
        :lint | eslint
        :test | jest
        :typecheck | tsc
runtime
        :build | packemon
        :format | prettier
        :lint | eslint
        :test | jest
        :typecheck | tsc
visualizer
        :build | vite
        :dev | vite
        :format | prettier
        :lint | eslint
        :serve | vite
        :test | jest
        :typecheck | tsc
website
        :build | docusaurus
        :format | prettier
        :lint | eslint
        :start | docusaurus
        :test | jest
        :typecheck | tsc
```
