### PR TITLE
new: Allow global binaries to be used for all tools.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2519,6 +2519,7 @@ dependencies = [
  "moon_config",
  "moon_logger",
  "moon_node_lang",
+ "moon_platform_runtime",
  "moon_terminal",
  "moon_tool",
  "moon_utils",

--- a/crates/cli/src/commands/init/node.rs
+++ b/crates/cli/src/commands/init/node.rs
@@ -2,10 +2,7 @@ use super::InitOptions;
 use crate::helpers::AnyError;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Confirm, Select};
-use moon_config::{
-    default_node_version, default_npm_version, default_pnpm_version, default_yarn_version,
-    load_toolchain_node_config_template,
-};
+use moon_config::load_toolchain_node_config_template;
 use moon_lang::{is_using_dependency_manager, is_using_version_manager};
 use moon_logger::color;
 use moon_node_lang::package::{PackageJson, PackageWorkspaces};
@@ -41,7 +38,7 @@ fn detect_node_version(dest_dir: &Path) -> Result<(String, String), AnyError> {
         ));
     }
 
-    Ok((default_node_version(), String::new()))
+    Ok(("18.0.0".into(), String::new()))
 }
 
 /// Verify the package manager to use. If a `package.json` exists,
@@ -96,17 +93,6 @@ fn detect_package_manager(
         };
 
         pm_type = items[index].to_owned();
-    }
-
-    // If no version, fallback to configuration default
-    if pm_version.is_empty() {
-        if pm_type == NPM.binary {
-            pm_version = default_npm_version();
-        } else if pm_type == PNPM.binary {
-            pm_version = default_pnpm_version();
-        } else if pm_type == YARN.binary {
-            pm_version = default_yarn_version();
-        }
     }
 
     Ok((pm_type, pm_version))

--- a/crates/cli/tests/check_test.rs
+++ b/crates/cli/tests/check_test.rs
@@ -67,6 +67,8 @@ fn runs_tasks_from_multiple_project() {
         cmd.arg("check").arg("base").arg("noop");
     });
 
+    assert.debug();
+
     let output = assert.output();
 
     assert!(predicate::str::contains("base:base").eval(&output));

--- a/crates/cli/tests/check_test.rs
+++ b/crates/cli/tests/check_test.rs
@@ -67,8 +67,6 @@ fn runs_tasks_from_multiple_project() {
         cmd.arg("check").arg("base").arg("noop");
     });
 
-    assert.debug();
-
     let output = assert.output();
 
     assert!(predicate::str::contains("base:base").eval(&output));

--- a/crates/cli/tests/snapshots/init_node_test__init_node__minimal.snap
+++ b/crates/cli/tests/snapshots/init_node_test__init_node__minimal.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/init_node_test.rs
-assertion_line: 17
 expression: "fs::read_to_string(config).unwrap()"
 ---
 # https://moonrepo.dev/docs/config/toolchain
@@ -10,10 +9,8 @@ $schema: 'https://moonrepo.dev/schemas/toolchain.json'
 # extends: './shared/toolchain.yml'
 
 node:
-  version: '18.12.0'
+  version: '18.0.0'
   packageManager: 'npm'
-  npm:
-    version: '8.19.2'
 
 typescript:
   syncProjectReferences: true

--- a/crates/cli/tests/snapshots/run_node_test__engines__adds_engines_constraint.snap
+++ b/crates/cli/tests/snapshots/run_node_test__engines__adds_engines_constraint.snap
@@ -11,7 +11,7 @@ expression: "read_to_string(sandbox.path().join(\"package.json\")).unwrap()"
     "postinstall-recursion",
     "version-override"
   ],
-  "packageManager": "npm@8.19.2",
+  "packageManager": "npm@8.19.0",
   "engines": {
     "node": "18.0.0"
   }

--- a/crates/cli/tests/snapshots/run_node_test__engines__doesnt_add_engines_constraint.snap
+++ b/crates/cli/tests/snapshots/run_node_test__engines__doesnt_add_engines_constraint.snap
@@ -11,6 +11,6 @@ expression: "read_to_string(sandbox.path().join(\"package.json\")).unwrap()"
     "postinstall-recursion",
     "version-override"
   ],
-  "packageManager": "npm@8.19.2"
+  "packageManager": "npm@8.19.0"
 }
 

--- a/crates/cli/tests/snapshots/run_node_test__runs_package_managers.snap
+++ b/crates/cli/tests/snapshots/run_node_test__runs_package_managers.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/cli/tests/run_node_test.rs
-assertion_line: 18
-expression: get_assert_output(&assert)
+expression: assert.output()
 ---
 ▪▪▪▪ npm install
 ▪▪▪▪ node:npm
-8.19.2
+8.19.0
 ▪▪▪▪ node:npm (100ms)
 
 Tasks: 1 completed

--- a/crates/core/cache/tests/engine_test.rs
+++ b/crates/core/cache/tests/engine_test.rs
@@ -283,7 +283,7 @@ mod cache_tool_state {
         let dir = create_temp_dir();
         let cache = CacheEngine::load(dir.path()).unwrap();
         let item = cache
-            .cache_tool_state(&Runtime::Node(Version("1.2.3".into(), false)))
+            .cache_tool_state(&Runtime::Node(Version::new("1.2.3")))
             .unwrap();
 
         assert!(!item.path.exists());
@@ -303,7 +303,7 @@ mod cache_tool_state {
 
         let cache = CacheEngine::load(dir.path()).unwrap();
         let item = cache
-            .cache_tool_state(&Runtime::Node(Version("1.2.3".into(), false)))
+            .cache_tool_state(&Runtime::Node(Version::new("1.2.3")))
             .unwrap();
 
         assert_eq!(
@@ -328,7 +328,7 @@ mod cache_tool_state {
             .unwrap();
 
         let cache = CacheEngine::load(dir.path()).unwrap();
-        let runtime = Runtime::Node(Version("4.5.6".into(), false));
+        let runtime = Runtime::Node(Version::new("4.5.6"));
         let item = run_with_env("read", || cache.cache_tool_state(&runtime)).unwrap();
 
         assert_eq!(
@@ -372,7 +372,7 @@ mod cache_tool_state {
         let dir = create_temp_dir();
         let cache = CacheEngine::load(dir.path()).unwrap();
         let mut item = cache
-            .cache_tool_state(&Runtime::Node(Version("7.8.9".into(), false)))
+            .cache_tool_state(&Runtime::Node(Version::new("7.8.9")))
             .unwrap();
 
         item.last_version_check_time = 123;

--- a/crates/core/config/src/toolchain/config.rs
+++ b/crates/core/config/src/toolchain/config.rs
@@ -58,18 +58,18 @@ impl ToolchainConfig {
             }
 
             if let Ok(npm_version) = env::var("MOON_NPM_VERSION") {
-                node_config.npm.version = npm_version;
+                node_config.npm.version = Some(npm_version);
             }
 
             if let Ok(pnpm_version) = env::var("MOON_PNPM_VERSION") {
                 if let Some(pnpm_config) = &mut node_config.pnpm {
-                    pnpm_config.version = pnpm_version;
+                    pnpm_config.version = Some(pnpm_version);
                 }
             }
 
             if let Ok(yarn_version) = env::var("MOON_YARN_VERSION") {
                 if let Some(yarn_config) = &mut node_config.yarn {
-                    yarn_config.version = yarn_version;
+                    yarn_config.version = Some(yarn_version);
                 }
             }
         }

--- a/crates/core/config/src/toolchain/node.rs
+++ b/crates/core/config/src/toolchain/node.rs
@@ -1,24 +1,7 @@
 use crate::validators::{is_default, is_default_true, validate_semver_version};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::env;
 use validator::{Validate, ValidationError};
-
-pub fn default_node_version() -> String {
-    env::var("MOON_NODE_VERSION").unwrap_or_else(|_| "18.12.0".to_string())
-}
-
-pub fn default_npm_version() -> String {
-    env::var("MOON_NPM_VERSION").unwrap_or_else(|_| "8.19.2".to_string())
-}
-
-pub fn default_pnpm_version() -> String {
-    env::var("MOON_PNPM_VERSION").unwrap_or_else(|_| "7.18.2".to_string())
-}
-
-pub fn default_yarn_version() -> String {
-    env::var("MOON_YARN_VERSION").unwrap_or_else(|_| "3.3.0".to_string())
-}
 
 fn validate_node_version(value: &str) -> Result<(), ValidationError> {
     validate_semver_version("node.version", value)
@@ -90,51 +73,29 @@ pub enum NodeVersionManager {
     Nvm,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize, Validate)]
 #[schemars(default)]
 pub struct NpmConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(custom = "validate_npm_version")]
-    pub version: String,
+    pub version: Option<String>,
 }
 
-impl Default for NpmConfig {
-    fn default() -> Self {
-        NpmConfig {
-            version: default_npm_version(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct PnpmConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(custom = "validate_pnpm_version")]
-    pub version: String,
+    pub version: Option<String>,
 }
 
-impl Default for PnpmConfig {
-    fn default() -> Self {
-        PnpmConfig {
-            version: default_pnpm_version(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize, Validate)]
 pub struct YarnConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plugins: Option<Vec<String>>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(custom = "validate_yarn_version")]
-    pub version: String,
-}
-
-impl Default for YarnConfig {
-    fn default() -> Self {
-        YarnConfig {
-            plugins: None,
-            version: default_yarn_version(),
-        }
-    }
+    pub version: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize, Validate)]
@@ -199,7 +160,7 @@ impl Default for NodeConfig {
             pnpm: None,
             sync_project_workspace_dependencies: true,
             sync_version_manager_config: None,
-            version: Some(default_node_version()),
+            version: None,
             yarn: None,
         }
     }

--- a/crates/core/config/templates/toolchain_node.yml
+++ b/crates/core/config/templates/toolchain_node.yml
@@ -3,8 +3,10 @@
 node:
   version: '{{ node_version }}'
   packageManager: '{{ package_manager }}'
+{%- if package_manager_version != "" %}
   {{ package_manager }}:
     version: '{{ package_manager_version }}'
+{%- endif %}
 
 {%- else -%}
 
@@ -21,8 +23,12 @@ node:
   packageManager: '{{ package_manager }}'
 
   # The version of the package manager (above) to use.
+{%- if package_manager_version != "" %}
   {{ package_manager }}:
     version: '{{ package_manager_version }}'
+{%- else %}
+  {{ package_manager }}: {}
+{%- endif %}
 
   # Add `node.version` as a constraint in the root `package.json` `engines`.
   addEnginesConstraint: true

--- a/crates/core/config/tests/toolchain_test.rs
+++ b/crates/core/config/tests/toolchain_test.rs
@@ -57,7 +57,7 @@ mod extends {
                     package_manager: NodePackageManager::Yarn,
                     yarn: Some(YarnConfig {
                         plugins: None,
-                        version: "3.3.0".into()
+                        version: Some("3.3.0".into())
                     }),
                     ..NodeConfig::default()
                 }),
@@ -197,8 +197,8 @@ node:
                 "18.0.0"
             );
             assert_eq!(
-                config.node.as_ref().unwrap().npm.version,
-                "8.0.0".to_owned()
+                config.node.as_ref().unwrap().npm.version.as_ref().unwrap(),
+                "8.0.0"
             );
 
             Ok(())
@@ -251,8 +251,8 @@ node:
                 "18.0.0"
             );
             assert_eq!(
-                config.node.as_ref().unwrap().npm.version,
-                "8.0.0".to_owned()
+                config.node.as_ref().unwrap().npm.version.as_ref().unwrap(),
+                "8.0.0"
             );
 
             Ok(())
@@ -496,7 +496,10 @@ node:
 
             let config = super::load_jailed_config(jail.directory())?;
 
-            assert_eq!(config.node.unwrap().npm.version, String::from("4.5.6"));
+            assert_eq!(
+                config.node.unwrap().npm.version.unwrap(),
+                String::from("4.5.6")
+            );
 
             Ok(())
         });
@@ -564,7 +567,7 @@ node:
             let config = super::load_jailed_config(jail.directory())?;
 
             assert_eq!(
-                config.node.unwrap().pnpm.unwrap().version,
+                config.node.unwrap().pnpm.unwrap().version.unwrap(),
                 String::from("4.5.6")
             );
 
@@ -634,7 +637,7 @@ node:
             let config = super::load_jailed_config(jail.directory())?;
 
             assert_eq!(
-                config.node.unwrap().yarn.unwrap().version,
+                config.node.unwrap().yarn.unwrap().version.unwrap(),
                 String::from("4.5.6")
             );
 

--- a/crates/core/dep-graph/src/dep_builder.rs
+++ b/crates/core/dep-graph/src/dep_builder.rs
@@ -65,8 +65,8 @@ impl<'ws> DepGraphBuilder<'ws> {
             return pair.clone();
         }
 
-        let mut project_runtime = None;
-        let mut workspace_runtime = None;
+        let mut project_runtime = Runtime::System;
+        let mut workspace_runtime = Runtime::System;
 
         if let Some(platform) = self.platforms.find(|p| match task {
             Some(task) => p.matches(&task.platform, None),
@@ -76,10 +76,7 @@ impl<'ws> DepGraphBuilder<'ws> {
             workspace_runtime = platform.get_runtime_from_config(None);
         }
 
-        let pair = (
-            project_runtime.unwrap_or(Runtime::System),
-            workspace_runtime.unwrap_or(Runtime::System),
-        );
+        let pair = (project_runtime, workspace_runtime);
 
         self.runtimes.insert(key, pair.clone());
 

--- a/crates/core/platform-runtime/src/runtime.rs
+++ b/crates/core/platform-runtime/src/runtime.rs
@@ -13,7 +13,13 @@ pub enum Runtime {
 impl Runtime {
     pub fn label(&self) -> String {
         match self {
-            Runtime::Node(version) => format!("Node.js v{version}"),
+            Runtime::Node(version) => {
+                if version.is_global() {
+                    "Node.js".into()
+                } else {
+                    format!("Node.js v{version}")
+                }
+            }
             Runtime::System => "system".into(),
         }
     }

--- a/crates/core/platform-runtime/src/runtime.rs
+++ b/crates/core/platform-runtime/src/runtime.rs
@@ -13,13 +13,7 @@ pub enum Runtime {
 impl Runtime {
     pub fn label(&self) -> String {
         match self {
-            Runtime::Node(version) => {
-                if version.is_global() {
-                    "Node.js".into()
-                } else {
-                    format!("Node.js v{version}")
-                }
-            }
+            Runtime::Node(version) => format!("Node.js {version}"),
             Runtime::System => "system".into(),
         }
     }

--- a/crates/core/platform-runtime/src/version.rs
+++ b/crates/core/platform-runtime/src/version.rs
@@ -3,35 +3,53 @@ use serde::Serialize;
 use std::fmt::{self, Debug};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub struct Version(pub String, pub bool);
+pub struct Version {
+    pub number: String,
+
+    // Is version available on PATH
+    pub path_executable: bool,
+
+    // Is overriding the workspace version in a project
+    pub project_override: bool,
+}
 
 impl Version {
     pub fn new(version: &str) -> Self {
-        Version(version.to_owned(), false)
+        Version {
+            number: version.to_owned(),
+            path_executable: false,
+            project_override: false,
+        }
+    }
+
+    pub fn new_global() -> Self {
+        Version {
+            number: "global".into(),
+            path_executable: true,
+            project_override: false,
+        }
     }
 
     pub fn new_override(version: &str) -> Self {
-        Version(version.to_owned(), true)
+        Version {
+            number: version.to_owned(),
+            path_executable: false,
+            project_override: true,
+        }
     }
 
-    pub fn is_latest(&self) -> bool {
-        self.0 == "latest"
+    pub fn is_global(&self) -> bool {
+        self.number == "global" && self.path_executable
     }
 
     pub fn is_override(&self) -> bool {
-        self.1
-    }
-}
-
-impl Default for Version {
-    fn default() -> Self {
-        Version::new("latest")
+        self.project_override
     }
 }
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.number)
     }
 }
 

--- a/crates/core/platform-runtime/src/version.rs
+++ b/crates/core/platform-runtime/src/version.rs
@@ -6,7 +6,7 @@ use std::fmt::{self, Debug};
 pub struct Version {
     pub number: String,
 
-    // Is version available on PATH
+    // Use version available on PATH
     pub path_executable: bool,
 
     // Is overriding the workspace version in a project
@@ -49,7 +49,11 @@ impl Version {
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.number)
+        if self.is_global() {
+            write!(f, "(global)")
+        } else {
+            write!(f, "{}", self.number)
+        }
     }
 }
 

--- a/crates/core/platform-runtime/src/version.rs
+++ b/crates/core/platform-runtime/src/version.rs
@@ -49,11 +49,7 @@ impl Version {
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.is_global() {
-            write!(f, "(global)")
-        } else {
-            write!(f, "{}", self.number)
-        }
+        write!(f, "{}", self.number)
     }
 }
 

--- a/crates/core/platform/src/platform.rs
+++ b/crates/core/platform/src/platform.rs
@@ -22,7 +22,7 @@ pub trait Platform: Debug + Send + Sync {
     fn get_type(&self) -> PlatformType;
 
     /// Return a runtime with an appropriate version based on the provided configs.
-    fn get_runtime_from_config(&self, project_config: Option<&ProjectConfig>) -> Option<Runtime>;
+    fn get_runtime_from_config(&self, project_config: Option<&ProjectConfig>) -> Runtime;
 
     /// Return true if the current platform is for the provided project or runtime.
     fn matches(&self, platform: &PlatformType, runtime: Option<&Runtime>) -> bool;

--- a/crates/core/platform/src/platform.rs
+++ b/crates/core/platform/src/platform.rs
@@ -74,6 +74,8 @@ pub trait Platform: Debug + Send + Sync {
 
     // TOOLCHAIN
 
+    fn is_toolchain_enabled(&self) -> Result<bool, ToolError>;
+
     /// Return a tool instance from the internal toolchain for the top-level version.
     /// If the version does not exist in the toolchain, return an error.
     fn get_tool(&self) -> Result<Box<&dyn Tool>, ToolError>;

--- a/crates/core/test-utils/src/configs.rs
+++ b/crates/core/test-utils/src/configs.rs
@@ -17,7 +17,6 @@ pub fn get_default_toolchain() -> ToolchainConfig {
             sync_project_workspace_dependencies: false,
             npm: NpmConfig {
                 version: Some("8.19.0".into()),
-                ..NpmConfig::default()
             },
             ..NodeConfig::default()
         }),

--- a/crates/core/test-utils/src/configs.rs
+++ b/crates/core/test-utils/src/configs.rs
@@ -15,6 +15,10 @@ pub fn get_default_toolchain() -> ToolchainConfig {
             dedupe_on_lockfile_change: false,
             infer_tasks_from_scripts: false,
             sync_project_workspace_dependencies: false,
+            npm: NpmConfig {
+                version: Some("8.19.0".into()),
+                ..NpmConfig::default()
+            },
             ..NodeConfig::default()
         }),
         typescript: Some(TypeScriptConfig {

--- a/crates/core/test-utils/src/configs.rs
+++ b/crates/core/test-utils/src/configs.rs
@@ -131,6 +131,9 @@ pub fn get_project_graph_aliases_fixture_configs(
             add_engines_constraint: false,
             alias_package_names: Some(NodeProjectAliasFormat::NameAndScope),
             dedupe_on_lockfile_change: false,
+            npm: NpmConfig {
+                version: Some("8.19.0".into()),
+            },
             ..NodeConfig::default()
         }),
         ..ToolchainConfig::default()

--- a/crates/core/test-utils/src/configs.rs
+++ b/crates/core/test-utils/src/configs.rs
@@ -303,26 +303,26 @@ pub fn get_node_depman_fixture_configs(
             "npm" => {
                 node_config.package_manager = NodePackageManager::Npm;
                 node_config.npm = NpmConfig {
-                    version: "8.0.0".into(),
+                    version: Some("8.0.0".into()),
                 };
             }
             "pnpm" => {
                 node_config.package_manager = NodePackageManager::Pnpm;
                 node_config.pnpm = Some(PnpmConfig {
-                    version: "7.5.0".into(),
+                    version: Some("7.5.0".into()),
                 });
             }
             "yarn" => {
                 node_config.package_manager = NodePackageManager::Yarn;
                 node_config.yarn = Some(YarnConfig {
-                    version: "3.3.0".into(),
+                    version: Some("3.3.0".into()),
                     plugins: Some(vec!["workspace-tools".into()]),
                 });
             }
             "yarn1" => {
                 node_config.package_manager = NodePackageManager::Yarn;
                 node_config.yarn = Some(YarnConfig {
-                    version: "1.22.0".into(),
+                    version: Some("1.22.0".into()),
                     plugins: None,
                 });
             }

--- a/crates/core/tool/src/manager.rs
+++ b/crates/core/tool/src/manager.rs
@@ -30,25 +30,25 @@ impl<T: Tool> ToolManager<T> {
         if !self.has(version) {
             return Err(ToolError::UnknownTool(format!(
                 "{} v{}",
-                self.runtime, version.0
+                self.runtime, version.number
             )));
         }
 
-        Ok(self.cache.get(&version.0).unwrap())
+        Ok(self.cache.get(&version.number).unwrap())
     }
 
     pub fn has(&self, version: &Version) -> bool {
-        self.cache.contains_key(&version.0)
+        self.cache.contains_key(&version.number)
     }
 
     pub fn register(&mut self, version: &Version, tool: T) {
         // Nothing exists in the cache yet, so this tool must be the top-level
         // workspace tool. If so, update the default version within the platform.
-        if self.default_version.0 == "latest" && !version.is_override() {
+        if self.default_version.is_global() && !version.is_global() {
             self.default_version = version.to_owned();
         }
 
-        self.cache.insert(version.0.to_owned(), tool);
+        self.cache.insert(version.number.to_owned(), tool);
     }
 
     pub async fn setup(
@@ -56,14 +56,14 @@ impl<T: Tool> ToolManager<T> {
         version: &Version,
         last_versions: &mut FxHashMap<String, String>,
     ) -> Result<u8, ToolError> {
-        match self.cache.get_mut(&version.0) {
+        match self.cache.get_mut(&version.number) {
             Some(cache) => Ok(cache.setup(last_versions).await?),
             None => Err(ToolError::UnknownTool(self.runtime.to_string())),
         }
     }
 
     pub async fn teardown(&mut self, version: &Version) -> Result<(), ToolError> {
-        if let Some(mut tool) = self.cache.remove(&version.0) {
+        if let Some(mut tool) = self.cache.remove(&version.number) {
             tool.teardown().await?;
         }
 

--- a/crates/core/tool/src/manager.rs
+++ b/crates/core/tool/src/manager.rs
@@ -29,7 +29,7 @@ impl<T: Tool> ToolManager<T> {
 
         if !self.has(version) {
             return Err(ToolError::UnknownTool(format!(
-                "{} v{}",
+                "{} {}",
                 self.runtime, version.number
             )));
         }

--- a/crates/core/tool/src/tool.rs
+++ b/crates/core/tool/src/tool.rs
@@ -5,22 +5,19 @@ use moon_utils::process::Command;
 use rustc_hash::FxHashMap;
 use std::any::Any;
 use std::fmt::Debug;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[async_trait]
 pub trait Tool: Any + Debug + Send + Sync {
     fn as_any(&self) -> &dyn Any;
 
     /// Return an absolute path to the tool's binary.
-    fn get_bin_path(&self) -> Result<&Path, ToolError>;
+    fn get_bin_path(&self) -> Result<PathBuf, ToolError>;
 
     /// Return an absolute path to an applicable tool shim.
-    fn get_shim_path(&self) -> Option<&Path> {
+    fn get_shim_path(&self) -> Option<PathBuf> {
         None
     }
-
-    /// Return the resolved version of the current tool.
-    fn get_version(&self) -> &str;
 
     /// Setup the tool by downloading and installing it.
     /// Return a count of how many sub-tools were installed.

--- a/crates/node/platform/src/platform.rs
+++ b/crates/node/platform/src/platform.rs
@@ -59,20 +59,21 @@ impl Platform for NodePlatform {
         PlatformType::Node
     }
 
-    fn get_runtime_from_config(&self, project_config: Option<&ProjectConfig>) -> Option<Runtime> {
+    fn get_runtime_from_config(&self, project_config: Option<&ProjectConfig>) -> Runtime {
         if let Some(config) = &project_config {
             if let Some(node_config) = &config.toolchain.node {
                 if let Some(version) = &node_config.version {
-                    return Some(Runtime::Node(Version::new_override(version)));
+                    return Runtime::Node(Version::new_override(version));
                 }
             }
         }
 
         if let Some(node_version) = &self.config.version {
-            return Some(Runtime::Node(Version::new(node_version)));
+            return Runtime::Node(Version::new(node_version));
         }
 
-        None
+        // Global
+        Runtime::Node(Version::default())
     }
 
     fn matches(&self, platform: &PlatformType, runtime: Option<&Runtime>) -> bool {

--- a/crates/node/platform/src/platform.rs
+++ b/crates/node/platform/src/platform.rs
@@ -274,6 +274,10 @@ impl Platform for NodePlatform {
 
     // TOOLCHAIN
 
+    fn is_toolchain_enabled(&self) -> Result<bool, ToolError> {
+        Ok(self.config.version.is_some())
+    }
+
     fn get_tool(&self) -> Result<Box<&dyn Tool>, ToolError> {
         let tool = self.toolchain.get()?;
 

--- a/crates/node/tool/Cargo.toml
+++ b/crates/node/tool/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 moon_config = { path = "../../core/config" }
 moon_logger = { path = "../../core/logger" }
+moon_platform_runtime = { path = "../../core/platform-runtime" }
 moon_node_lang = { path = "../lang" }
 moon_terminal = { path = "../../core/terminal" }
 moon_tool = { path = "../../core/tool" }

--- a/crates/node/tool/src/node_tool.rs
+++ b/crates/node/tool/src/node_tool.rs
@@ -37,8 +37,8 @@ impl NodeTool {
         version: &Version,
     ) -> Result<NodeTool, ToolError> {
         let mut node = NodeTool {
-            config: config.to_owned(),
             global: false,
+            config: config.to_owned(),
             tool: NodeLanguage::new(proto),
             npm: None,
             pnpm: None,
@@ -76,11 +76,14 @@ impl NodeTool {
         let mut exec_args = vec!["--silent", "--package", package, "--"];
         exec_args.extend(args);
 
-        Command::new(self.get_npx_path()?)
-            .args(exec_args)
+        let mut cmd = Command::new(self.get_npx_path()?);
+
+        if !self.global {
+            cmd.env("PATH", get_path_env_var(&self.tool.get_install_dir()?));
+        }
+
+        cmd.args(exec_args)
             .cwd(working_dir)
-            // TODO
-            .env("PATH", get_path_env_var(&self.tool.get_install_dir()?))
             .exec_stream_output()
             .await?;
 

--- a/crates/node/tool/src/npm_tool.rs
+++ b/crates/node/tool/src/npm_tool.rs
@@ -57,26 +57,28 @@ impl Tool for NpmTool {
         last_versions: &mut FxHashMap<String, String>,
     ) -> Result<u8, ToolError> {
         let mut count = 0;
+        let version = self.config.version.clone();
 
-        if self.tool.is_setup(&self.config.version).await? {
+        let Some(version) = version else {
+            return Ok(count);
+        };
+
+        if self.tool.is_setup(&version).await? {
             debug!(target: self.tool.get_log_target(), "npm has already been setup");
 
             return Ok(count);
         }
 
         if let Some(last) = last_versions.get("npm") {
-            if last == &self.config.version && self.tool.get_install_dir()?.exists() {
+            if last == &version && self.tool.get_install_dir()?.exists() {
                 return Ok(count);
             }
         }
 
-        print_checkpoint(
-            format!("installing npm v{}", self.config.version),
-            Checkpoint::Setup,
-        );
+        print_checkpoint(format!("installing npm v{version}"), Checkpoint::Setup);
 
-        if self.tool.setup(&self.config.version).await? {
-            last_versions.insert("npm".into(), self.config.version.clone());
+        if self.tool.setup(&version).await? {
+            last_versions.insert("npm".into(), version);
             count += 1;
         }
 

--- a/crates/node/tool/src/npm_tool.rs
+++ b/crates/node/tool/src/npm_tool.rs
@@ -7,8 +7,9 @@ use moon_tool::{get_path_env_var, DependencyManager, Tool, ToolError};
 use moon_utils::process::Command;
 use moon_utils::{fs, is_ci};
 use proto::{
-    async_trait, node::NodeDependencyManager, Describable, Executable, Installable, Proto,
-    Resolvable, Shimable, Tool as ProtoTool,
+    async_trait,
+    node::{NodeDependencyManager, NodeDependencyManagerType},
+    Describable, Executable, Installable, Proto, Resolvable, Shimable, Tool as ProtoTool,
 };
 use rustc_hash::FxHashMap;
 use std::env;
@@ -18,6 +19,8 @@ use std::path::Path;
 pub struct NpmTool {
     pub config: NpmConfig,
 
+    pub global: bool,
+
     pub tool: NodeDependencyManager,
 }
 
@@ -25,7 +28,8 @@ impl NpmTool {
     pub fn new(proto: &Proto, config: &NpmConfig) -> Result<NpmTool, ToolError> {
         Ok(NpmTool {
             config: config.to_owned(),
-            tool: NodeDependencyManager::new(proto, proto::node::NodeDependencyManagerType::Npm),
+            global: false,
+            tool: NodeDependencyManager::new(proto, NodeDependencyManagerType::Npm),
         })
     }
 }

--- a/crates/node/tool/src/pnpm_tool.rs
+++ b/crates/node/tool/src/pnpm_tool.rs
@@ -9,11 +9,11 @@ use moon_utils::{fs, is_ci, semver};
 use proto::{
     async_trait,
     node::{NodeDependencyManager, NodeDependencyManagerType},
-    Describable, Executable, Installable, Proto, Resolvable, Shimable, Tool as ProtoTool,
+    Describable, Executable, Installable, Proto, Shimable, Tool as ProtoTool,
 };
 use rustc_hash::FxHashMap;
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct PnpmTool {
@@ -40,16 +40,16 @@ impl Tool for PnpmTool {
         self
     }
 
-    fn get_bin_path(&self) -> Result<&Path, ToolError> {
-        Ok(self.tool.get_bin_path()?)
+    fn get_bin_path(&self) -> Result<PathBuf, ToolError> {
+        Ok(if self.global {
+            "pnpm".into()
+        } else {
+            self.tool.get_bin_path()?.to_path_buf()
+        })
     }
 
-    fn get_shim_path(&self) -> Option<&Path> {
-        self.tool.get_shim_path()
-    }
-
-    fn get_version(&self) -> &str {
-        self.tool.get_resolved_version()
+    fn get_shim_path(&self) -> Option<PathBuf> {
+        self.tool.get_shim_path().map(|p| p.to_path_buf())
     }
 
     async fn setup(
@@ -95,6 +95,8 @@ impl DependencyManager<NodeTool> for PnpmTool {
     fn create_command(&self, node: &NodeTool) -> Result<Command, ToolError> {
         let mut cmd = if let Some(shim) = self.get_shim_path() {
             Command::new(shim)
+        } else if self.global {
+            Command::new("pnpm")
         } else {
             let mut cmd = Command::new(node.get_bin_path()?);
             cmd.arg(self.get_bin_path()?);

--- a/crates/node/tool/src/pnpm_tool.rs
+++ b/crates/node/tool/src/pnpm_tool.rs
@@ -7,8 +7,9 @@ use moon_tool::{get_path_env_var, DependencyManager, Tool, ToolError};
 use moon_utils::process::Command;
 use moon_utils::{fs, is_ci, semver};
 use proto::{
-    async_trait, node::NodeDependencyManager, Describable, Executable, Installable, Proto,
-    Resolvable, Shimable, Tool as ProtoTool,
+    async_trait,
+    node::{NodeDependencyManager, NodeDependencyManagerType},
+    Describable, Executable, Installable, Proto, Resolvable, Shimable, Tool as ProtoTool,
 };
 use rustc_hash::FxHashMap;
 use std::env;
@@ -18,6 +19,8 @@ use std::path::Path;
 pub struct PnpmTool {
     pub config: PnpmConfig,
 
+    pub global: bool,
+
     pub tool: NodeDependencyManager,
 }
 
@@ -25,7 +28,8 @@ impl PnpmTool {
     pub fn new(proto: &Proto, config: &Option<PnpmConfig>) -> Result<PnpmTool, ToolError> {
         Ok(PnpmTool {
             config: config.to_owned().unwrap_or_default(),
-            tool: NodeDependencyManager::new(proto, proto::node::NodeDependencyManagerType::Pnpm),
+            global: false,
+            tool: NodeDependencyManager::new(proto, NodeDependencyManagerType::Pnpm),
         })
     }
 }

--- a/crates/node/tool/src/yarn_tool.rs
+++ b/crates/node/tool/src/yarn_tool.rs
@@ -26,9 +26,11 @@ pub struct YarnTool {
 
 impl YarnTool {
     pub fn new(proto: &Proto, config: &Option<YarnConfig>) -> Result<YarnTool, ToolError> {
+        let config = config.to_owned().unwrap_or_default();
+
         Ok(YarnTool {
-            config: config.to_owned().unwrap_or_default(),
-            global: false,
+            global: config.version.is_none(),
+            config,
             tool: NodeDependencyManager::new(proto, NodeDependencyManagerType::Yarn),
         })
     }
@@ -141,18 +143,20 @@ impl Tool for YarnTool {
 #[async_trait]
 impl DependencyManager<NodeTool> for YarnTool {
     fn create_command(&self, node: &NodeTool) -> Result<Command, ToolError> {
-        let mut cmd = if let Some(shim) = self.get_shim_path() {
-            Command::new(shim)
-        } else if self.global {
+        let mut cmd = if self.global {
             Command::new("yarn")
+        } else if let Some(shim) = self.get_shim_path() {
+            Command::new(shim)
         } else {
             let mut cmd = Command::new(node.get_bin_path()?);
             cmd.arg(self.get_bin_path()?);
             cmd
         };
 
-        // TODO
-        cmd.env("PATH", get_path_env_var(&self.tool.get_install_dir()?));
+        if !self.global {
+            cmd.env("PATH", get_path_env_var(&self.tool.get_install_dir()?));
+        }
+
         cmd.env("PROTO_NODE_BIN", node.get_bin_path()?);
 
         Ok(cmd)

--- a/crates/node/tool/src/yarn_tool.rs
+++ b/crates/node/tool/src/yarn_tool.rs
@@ -9,11 +9,11 @@ use moon_utils::{fs, get_workspace_root, is_ci};
 use proto::{
     async_trait,
     node::{NodeDependencyManager, NodeDependencyManagerType},
-    Describable, Executable, Installable, Proto, Resolvable, Shimable, Tool as ProtoTool,
+    Describable, Executable, Installable, Proto, Shimable, Tool as ProtoTool,
 };
 use rustc_hash::FxHashMap;
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct YarnTool {
@@ -78,16 +78,16 @@ impl Tool for YarnTool {
         self
     }
 
-    fn get_bin_path(&self) -> Result<&Path, ToolError> {
-        Ok(self.tool.get_bin_path()?)
+    fn get_bin_path(&self) -> Result<PathBuf, ToolError> {
+        Ok(if self.global {
+            "yarn".into()
+        } else {
+            self.tool.get_bin_path()?.to_path_buf()
+        })
     }
 
-    fn get_shim_path(&self) -> Option<&Path> {
-        self.tool.get_shim_path()
-    }
-
-    fn get_version(&self) -> &str {
-        self.tool.get_resolved_version()
+    fn get_shim_path(&self) -> Option<PathBuf> {
+        self.tool.get_shim_path().map(|p| p.to_path_buf())
     }
 
     async fn setup(
@@ -133,12 +133,15 @@ impl DependencyManager<NodeTool> for YarnTool {
     fn create_command(&self, node: &NodeTool) -> Result<Command, ToolError> {
         let mut cmd = if let Some(shim) = self.get_shim_path() {
             Command::new(shim)
+        } else if self.global {
+            Command::new("yarn")
         } else {
             let mut cmd = Command::new(node.get_bin_path()?);
             cmd.arg(self.get_bin_path()?);
             cmd
         };
 
+        // TODO
         cmd.env("PATH", get_path_env_var(&self.tool.get_install_dir()?));
         cmd.env("PROTO_NODE_BIN", node.get_bin_path()?);
 

--- a/crates/node/tool/src/yarn_tool.rs
+++ b/crates/node/tool/src/yarn_tool.rs
@@ -7,8 +7,9 @@ use moon_tool::{get_path_env_var, DependencyManager, Tool, ToolError};
 use moon_utils::process::Command;
 use moon_utils::{fs, get_workspace_root, is_ci};
 use proto::{
-    async_trait, node::NodeDependencyManager, Describable, Executable, Installable, Proto,
-    Resolvable, Shimable, Tool as ProtoTool,
+    async_trait,
+    node::{NodeDependencyManager, NodeDependencyManagerType},
+    Describable, Executable, Installable, Proto, Resolvable, Shimable, Tool as ProtoTool,
 };
 use rustc_hash::FxHashMap;
 use std::env;
@@ -18,6 +19,8 @@ use std::path::Path;
 pub struct YarnTool {
     pub config: YarnConfig,
 
+    pub global: bool,
+
     pub tool: NodeDependencyManager,
 }
 
@@ -25,7 +28,8 @@ impl YarnTool {
     pub fn new(proto: &Proto, config: &Option<YarnConfig>) -> Result<YarnTool, ToolError> {
         Ok(YarnTool {
             config: config.to_owned().unwrap_or_default(),
-            tool: NodeDependencyManager::new(proto, proto::node::NodeDependencyManagerType::Yarn),
+            global: false,
+            tool: NodeDependencyManager::new(proto, NodeDependencyManagerType::Yarn),
         })
     }
 

--- a/crates/system/platform/src/platform.rs
+++ b/crates/system/platform/src/platform.rs
@@ -21,8 +21,8 @@ impl Platform for SystemPlatform {
         PlatformType::System
     }
 
-    fn get_runtime_from_config(&self, _project_config: Option<&ProjectConfig>) -> Option<Runtime> {
-        Some(Runtime::System)
+    fn get_runtime_from_config(&self, _project_config: Option<&ProjectConfig>) -> Runtime {
+        Runtime::System
     }
 
     fn matches(&self, platform: &PlatformType, runtime: Option<&Runtime>) -> bool {

--- a/crates/system/platform/src/platform.rs
+++ b/crates/system/platform/src/platform.rs
@@ -39,6 +39,10 @@ impl Platform for SystemPlatform {
 
     // TOOLCHAIN
 
+    fn is_toolchain_enabled(&self) -> Result<bool, ToolError> {
+        Ok(false)
+    }
+
     fn get_tool(&self) -> Result<Box<&dyn Tool>, ToolError> {
         Ok(Box::new(&self.tool))
     }

--- a/crates/system/platform/src/tool.rs
+++ b/crates/system/platform/src/tool.rs
@@ -1,5 +1,5 @@
 use moon_tool::{Tool, ToolError};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Debug, Default)]
 pub struct SystemToolStub {
@@ -11,11 +11,7 @@ impl Tool for SystemToolStub {
         self
     }
 
-    fn get_bin_path(&self) -> Result<&Path, ToolError> {
-        Ok(&self.bin_path)
-    }
-
-    fn get_version(&self) -> &str {
-        "latest"
+    fn get_bin_path(&self) -> Result<PathBuf, ToolError> {
+        Ok(self.bin_path.to_path_buf())
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moon",
   "private": true,
-  "packageManager": "",
+  "packageManager": "yarn@3.3.0",
   "scripts": {
     "docs": "cargo run -- run website:start",
     "moon": "target/debug/moon --log trace",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moon",
   "private": true,
-  "packageManager": "yarn@3.3.0",
+  "packageManager": "",
   "scripts": {
     "docs": "cargo run -- run website:start",
     "moon": "target/debug/moon --log trace",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+#### 💥 Breaking
+
+- Updated `node.version` and `node.<packageManager>.version` to no longer default to a hard-coded
+  version. When not defined, will fallback to the binary available on `PATH`.
+
 #### ⚙️ Internal
 
 - Updated Rust to v1.67.

--- a/website/static/schemas/project.json
+++ b/website/static/schemas/project.json
@@ -96,6 +96,7 @@
     "PlatformType": {
       "type": "string",
       "enum": [
+        "deno",
         "node",
         "system",
         "unknown"

--- a/website/static/schemas/tasks.json
+++ b/website/static/schemas/tasks.json
@@ -42,6 +42,7 @@
     "PlatformType": {
       "type": "string",
       "enum": [
+        "deno",
         "node",
         "system",
         "unknown"

--- a/website/static/schemas/toolchain.json
+++ b/website/static/schemas/toolchain.json
@@ -93,7 +93,6 @@
           ]
         },
         "version": {
-          "default": "18.12.0",
           "type": [
             "string",
             "null"
@@ -151,19 +150,21 @@
       "type": "object",
       "properties": {
         "version": {
-          "default": "8.19.2",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },
     "PnpmConfig": {
       "type": "object",
-      "required": [
-        "version"
-      ],
       "properties": {
         "version": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },
@@ -198,9 +199,6 @@
     },
     "YarnConfig": {
       "type": "object",
-      "required": [
-        "version"
-      ],
       "properties": {
         "plugins": {
           "type": [
@@ -212,7 +210,10 @@
           }
         },
         "version": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     }

--- a/website/static/schemas/workspace.json
+++ b/website/static/schemas/workspace.json
@@ -55,6 +55,9 @@
       "properties": {
         "optimization": {
           "$ref": "#/definitions/HasherOptimization"
+        },
+        "walkStrategy": {
+          "$ref": "#/definitions/HasherWalkStrategy"
         }
       }
     },
@@ -63,6 +66,13 @@
       "enum": [
         "accuracy",
         "performance"
+      ]
+    },
+    "HasherWalkStrategy": {
+      "type": "string",
+      "enum": [
+        "glob",
+        "vcs"
       ]
     },
     "NotifierConfig": {


### PR DESCRIPTION
This updates all existing tools (mostly node.js) to support global binaries (those found on `PATH`), instead of relying entirely on the toolchain.