### PR TITLE
fix: Attempt to fix GLIBC errors by using older runners.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
       - develop-*
       - release-*
   # Uncomment to test in PRs (its safe)
-  pull_request:
+  # pull_request:
 
 permissions:
   contents: write
@@ -117,7 +117,7 @@ jobs:
         env:
           BINARY: ${{ matrix.binary }}
           TARGET: ${{ matrix.target }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Upload artifact
         with:
           name: binary-${{ matrix.target }}
@@ -168,7 +168,7 @@ jobs:
         run: ${{ matrix.setup }}
       - name: Install dependencies
         run: yarn install --immutable
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         name: Download artifacts
         with:
           path: artifacts
@@ -207,7 +207,7 @@ jobs:
           node-version: 16
       - name: Install dependencies
         run: yarn install --immutable
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         name: Download artifacts
         with:
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,37 +26,37 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            host: ubuntu-latest
+            host: ubuntu-20.04
             binary: moon
             docker-target: bin-gnu
             docker-platform: linux/amd64
 
           - target: x86_64-unknown-linux-musl
-            host: ubuntu-latest
+            host: ubuntu-20.04
             binary: moon
             docker-target: bin-musl
             docker-platform: linux/amd64
 
           - target: aarch64-unknown-linux-gnu
-            host: ubuntu-latest
+            host: ubuntu-20.04
             binary: moon
             docker-target: bin-gnu
             docker-platform: linux/arm64
 
           - target: aarch64-unknown-linux-musl
-            host: ubuntu-latest
+            host: ubuntu-20.04
             binary: moon
             docker-target: bin-musl
             docker-platform: linux/arm64
 
           - target: x86_64-apple-darwin
-            host: macos-latest
+            host: macos-12
             binary: moon
             setup: |
               export MACOSX_DEPLOYMENT_TARGET="10.13";
 
           - target: aarch64-apple-darwin
-            host: macos-latest
+            host: macos-12
             binary: moon
             setup: |
               export CC=$(xcrun -f clang);
@@ -66,7 +66,7 @@ jobs:
               export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version);
 
           - target: x86_64-pc-windows-msvc
-            host: windows-latest
+            host: windows-2022
             binary: moon.exe
     name: Stable - ${{ matrix.target }}
     runs-on: ${{ matrix.host }}
@@ -130,25 +130,25 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            host: ubuntu-latest
+            host: ubuntu-20.04
 
           - target: x86_64-unknown-linux-musl
-            host: ubuntu-latest
+            host: ubuntu-20.04
             image: clux/muslrust:stable
             setup: yarn config set supportedArchitectures.libc "musl"
 
           - target: x86_64-apple-darwin
-            host: macos-latest
+            host: macos-12
 
           # - target: aarch64-apple-darwin
-          #   host: ubuntu-latest
+          #   host: ubuntu-20.04
           #   image: arm64v8/node
           #   setup: |
           #     sudo apt-get install binfmt-support qemu qemu-user-static
           #     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
           - target: x86_64-pc-windows-msvc
-            host: windows-latest
+            host: windows-2022
     needs:
       - build
     name: Test - ${{ matrix.target }}
@@ -193,7 +193,7 @@ jobs:
   publish:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     name: Publish cli/core packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - test
     env:
@@ -233,7 +233,7 @@ jobs:
   publish-npm:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     name: Publish npm packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       NPM_CHANNEL: latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
       - develop-*
       - release-*
   # Uncomment to test in PRs (its safe)
-  # pull_request:
+  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,7 +99,7 @@ jobs:
         if: ${{ runner.os != 'Windows' && env.WITH_COVERAGE == 'true' }}
         run: cargo make generate-report
       - name: Upload coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ runner.os != 'Windows' && env.WITH_COVERAGE == 'true' }}
         with:
           name: coverage-${{ matrix.os }}
@@ -113,7 +113,7 @@ jobs:
       - test
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         name: Download coverage reports
         with:
           path: coverage

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### 🚀 Updates
 
 - Added offline (no internet connection) support.
+- Added project-level TypeScript settings via `toolchain.typescript` in `moon.yml`.
 
 ##### Moonbase
 
@@ -23,6 +24,7 @@
 
 - Updated Rust to v1.67.
 - Added `context` to `pipeline.started` and `pipeline.finished` events.
+- We now build against older operating systems in an attempt to solve GLIBC version errors.
 
 ## 0.24.2
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -6,7 +6,8 @@
 # glibc
 
 FROM ubuntu:20.04 AS base-gnu
-RUN apt-get update && apt-get install curl -y
+RUN apt-get update
+RUN apt-get install --no-install-recommends -y ca-certificates curl file build-essential autoconf automake autotools-dev libtool xutils-dev
 
 WORKDIR /app
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable -y

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -5,12 +5,17 @@
 
 # glibc
 
-FROM rust:1.67.0 AS base-gnu
-RUN cargo install cargo-chef --version ^0.1
+FROM ubuntu:20.04 AS base-gnu
+RUN apt-get update && apt-get install curl -y
+
 WORKDIR /app
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable -y
+ENV PATH=/root/.cargo/bin:$PATH
+
 COPY .cargo .cargo
 COPY rust-toolchain.toml .
 RUN rustup update
+RUN cargo install cargo-chef --version ^0.1
 
 FROM base-gnu AS plan-gnu
 COPY Cargo* .

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -7,7 +7,7 @@
 
 FROM ubuntu:20.04 AS base-gnu
 RUN apt-get update
-RUN apt-get install --no-install-recommends -y ca-certificates curl file build-essential autoconf automake autotools-dev libtool xutils-dev
+RUN apt install --no-install-recommends -y ca-certificates curl file build-essential autoconf automake autotools-dev libtool xutils-dev
 
 WORKDIR /app
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable -y


### PR DESCRIPTION
Problem: https://moonrepo.dev/docs/faq#how-to-resolve-the-version-glibc_xxx-not-found-error

This attempts to fix it by building against Ubuntu 20, instead of Ubuntu 22, which should have an older and more compatible GLIBC.