### PR TITLE
internal: Generate a UUID for anonymous users.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,12 +2450,15 @@ dependencies = [
 name = "moon_launchpad"
 version = "0.1.0"
 dependencies = [
+ "moon_constants",
+ "moon_error",
  "moon_logger",
  "moon_utils",
  "proto_cli",
  "reqwest",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/core/launchpad/Cargo.toml
+++ b/crates/core/launchpad/Cargo.toml
@@ -4,9 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+moon_constants = { path = "../constants" }
+moon_error = { path = "../error" }
 moon_logger = { path = "../logger" }
 moon_utils = { path = "../utils" }
 proto_cli = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uuid = { version = "1.2.2", features = ["v4"] }

--- a/crates/core/launchpad/src/lib.rs
+++ b/crates/core/launchpad/src/lib.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, SystemTime};
 use uuid::Uuid;
 
 const CURRENT_VERSION_URL: &str = "https://launch.moonrepo.app/versions/cli/current";
-const ALERT_PAUSE_DURATION: Duration = Duration::from_secs(43200); // 12 hours
+const ALERT_PAUSE_DURATION: Duration = Duration::from_secs(28800); // 8 hours
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CurrentVersion {
@@ -49,7 +49,7 @@ pub async fn check_version(
     let check_state_path = get_cache_dir().join("states/versionCheck.json");
     let now = SystemTime::now();
 
-    // Only check once every 12 hours
+    // Only check once every 8 hours
     if let Ok(file) = fs::read(&check_state_path) {
         let check_state: Result<CheckState, _> = serde_json::from_str(&file);
 

--- a/crates/core/launchpad/src/lib.rs
+++ b/crates/core/launchpad/src/lib.rs
@@ -1,14 +1,16 @@
+use moon_constants::CONFIG_DIRNAME;
+use moon_error::MoonError;
 use moon_logger::debug;
 use moon_utils::semver::Version;
-use moon_utils::{get_cache_dir, is_ci, is_test_env};
+use moon_utils::{fs, get_cache_dir, is_ci, is_test_env, path};
 use serde::{Deserialize, Serialize};
-use std::env;
 use std::error::Error;
-use std::fs::{self, OpenOptions};
+use std::fs::OpenOptions;
 use std::time::{Duration, SystemTime};
+use uuid::Uuid;
 
 const CURRENT_VERSION_URL: &str = "https://launch.moonrepo.app/versions/cli/current";
-const ALERT_PAUSE_DURATION: Duration = Duration::from_secs(3600);
+const ALERT_PAUSE_DURATION: Duration = Duration::from_secs(43200); // 12 hours
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CurrentVersion {
@@ -20,11 +22,42 @@ pub struct CheckState {
     pub last_alert: SystemTime,
 }
 
+fn load_or_create_anonymous_id() -> Result<String, MoonError> {
+    let id_path = path::get_home_dir()
+        .unwrap()
+        .join(CONFIG_DIRNAME)
+        .join("id");
+
+    if id_path.exists() {
+        return fs::read(id_path);
+    }
+
+    let id = Uuid::new_v4().to_string();
+
+    fs::write(id_path, &id)?;
+
+    return Ok(id);
+}
+
 pub async fn check_version(
     local_version_str: &str,
 ) -> Result<(String, bool), Box<dyn Error + Send + Sync>> {
     if is_test_env() || proto::is_offline() {
-        return Ok((env!("CARGO_PKG_VERSION").to_owned(), false));
+        return Ok((local_version_str.to_owned(), false));
+    }
+
+    let check_state_path = get_cache_dir().join("states/versionCheck.json");
+    let now = SystemTime::now();
+
+    // Only check once every 12 hours
+    if let Ok(file) = fs::read(&check_state_path) {
+        let check_state: Result<CheckState, _> = serde_json::from_str(&file);
+
+        if let Ok(state) = check_state {
+            if (state.last_alert + ALERT_PAUSE_DURATION) > now {
+                return Ok((local_version_str.to_owned(), false));
+            }
+        }
     }
 
     debug!(target: "moon:launchpad", "Checking for new version of moon");
@@ -33,37 +66,18 @@ pub async fn check_version(
         .get(CURRENT_VERSION_URL)
         .header("X-Moon-Version", local_version_str)
         .header("X-Moon-CI", is_ci().to_string())
-        .header(
-            "X-Moon-ID",
-            env::var("MOONBASE_ACCESS_KEY")
-                .or_else(|_| env::var("MOONBASE_API_KEY"))
-                .unwrap_or_default(),
-        )
+        .header("X-Moon-ID", load_or_create_anonymous_id()?)
         .send()
         .await?
         .text()
         .await?;
 
     let data: CurrentVersion = serde_json::from_str(&response)?;
-
     let local_version = Version::parse(local_version_str)?;
     let remote_version = Version::parse(data.current_version.as_str())?;
 
     if remote_version > local_version {
-        let check_state_path = get_cache_dir().join("states/versionCheck.json");
-        let now = SystemTime::now();
-
-        if let Ok(file) = fs::read_to_string(&check_state_path) {
-            let check_state: Result<CheckState, _> = serde_json::from_str(&file);
-
-            if let Ok(state) = check_state {
-                if (state.last_alert + ALERT_PAUSE_DURATION) > now {
-                    return Ok((remote_version.to_string(), false));
-                }
-            }
-        }
-
-        moon_utils::fs::create_dir_all(check_state_path.parent().unwrap())?;
+        fs::create_dir_all(check_state_path.parent().unwrap())?;
 
         let check_state = OpenOptions::new()
             .write(true)

--- a/crates/core/utils/src/fs.rs
+++ b/crates/core/utils/src/fs.rs
@@ -282,7 +282,7 @@ pub mod temp {
     }
 
     pub fn get_file(source: &str, ext: &str) -> PathBuf {
-        get_dir().join(format!("{:x}.{}", md5::compute(source), ext))
+        get_dir().join(format!("{}.{}", crate::hash(source), ext))
     }
 
     pub fn read<P: AsRef<Path>>(path: P) -> Result<Option<String>, MoonError> {

--- a/crates/core/utils/src/lib.rs
+++ b/crates/core/utils/src/lib.rs
@@ -29,6 +29,10 @@ macro_rules! string_vec {
     }};
 }
 
+pub fn hash<T: AsRef<str>>(value: T) -> String {
+    format!("{:x}", md5::compute(value.as_ref()))
+}
+
 #[cached]
 pub fn get_workspace_root() -> PathBuf {
     if let Ok(root) = env::var("MOON_WORKSPACE_ROOT") {


### PR DESCRIPTION
Relying on IP's for usage stats isn't very reliable, so let's generate a UUID for each user.