### PR TITLE
new: Support periods (`.`) in identifiers.

### DIFF
--- a/crates/core/config/src/validators.rs
+++ b/crates/core/config/src/validators.rs
@@ -101,7 +101,7 @@ pub fn validate_id<K: AsRef<str>, V: AsRef<str>>(key: K, id: V) -> Result<(), Va
         return Err(create_validation_error(
             "invalid_id",
             key.as_ref(),
-            "Must be a valid ID (accepts A-Z, a-z, 0-9, - (dashes), _ (underscores), /, and must start with a letter)",
+            "Must be a valid ID (accepts A-Z, a-z, 0-9, . (periods), - (dashes), _ (underscores), /, and must start with a letter)",
         ));
     }
 
@@ -315,6 +315,11 @@ mod tests {
             assert!(validate_id("key", "-foo").is_err());
             assert!(validate_id("key", "_foo").is_err());
         }
+
+        #[test]
+        fn supports_periods() {
+            assert!(validate_id("key", "a.b").is_ok());
+        }
     }
 
     mod validate_target {
@@ -353,6 +358,24 @@ mod tests {
             assert!(validate_target("key", "a:^").is_err());
             assert!(validate_target("key", "b:~").is_err());
             assert!(validate_target("key", "c:").is_err());
+        }
+
+        #[test]
+        fn supports_periods() {
+            assert!(validate_target("key", ":a.b").is_ok());
+            assert!(validate_target("key", "a.b:c.d").is_ok());
+            assert!(validate_target("key", "^:a.b").is_ok());
+            assert!(validate_target("key", "~:b.c").is_ok());
+            assert!(validate_target("key", ":c.d").is_ok());
+        }
+
+        #[test]
+        fn supports_slashes() {
+            assert!(validate_target("key", ":a/b").is_ok());
+            assert!(validate_target("key", "a/b:c/d").is_ok());
+            assert!(validate_target("key", "^:a/b").is_ok());
+            assert!(validate_target("key", "~:b/c").is_ok());
+            assert!(validate_target("key", ":c/d").is_ok());
         }
     }
 

--- a/crates/core/config/tests/global_tasks_test.rs
+++ b/crates/core/config/tests/global_tasks_test.rs
@@ -66,7 +66,7 @@ implicitDeps:
 
 #[test]
 #[should_panic(
-    expected = "Must be a valid ID (accepts A-Z, a-z, 0-9, - (dashes), _ (underscores), /, and must start with a letter)"
+    expected = "Must be a valid ID (accepts A-Z, a-z, 0-9, . (periods), - (dashes), _ (underscores), /, and must start with a letter)"
 )]
 fn invalid_dep_target_no_scope() {
     figment::Jail::expect_with(|jail| {

--- a/crates/core/config/tests/local_project_test.rs
+++ b/crates/core/config/tests/local_project_test.rs
@@ -414,6 +414,41 @@ tasks:
             Ok(())
         });
     }
+
+    #[test]
+    fn supports_name_patterns() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                super::CONFIG_PROJECT_FILENAME,
+                r#"
+tasks:
+    normal:
+      command: 'a'
+    kebab-case:
+      command: 'b'
+    camelCase:
+      command: 'c'
+    snake_case:
+      command: 'd'
+    dot.case:
+      command: 'e'
+    slash/case:
+      command: 'f'
+"#,
+            )?;
+
+            let config: ProjectConfig = super::load_jailed_config()?;
+
+            assert!(config.tasks.contains_key("normal"));
+            assert!(config.tasks.contains_key("kebab-case"));
+            assert!(config.tasks.contains_key("camelCase"));
+            assert!(config.tasks.contains_key("snake_case"));
+            assert!(config.tasks.contains_key("dot.case"));
+            assert!(config.tasks.contains_key("slash/case"));
+
+            Ok(())
+        });
+    }
 }
 
 mod project {

--- a/crates/core/config/tests/tasks_test.rs
+++ b/crates/core/config/tests/tasks_test.rs
@@ -395,7 +395,7 @@ deps:
 
     #[test]
     #[should_panic(
-        expected = "Must be a valid ID (accepts A-Z, a-z, 0-9, - (dashes), _ (underscores), /, and must start with a letter)"
+        expected = "Must be a valid ID (accepts A-Z, a-z, 0-9, . (periods), - (dashes), _ (underscores), /, and must start with a letter)"
     )]
     fn invalid_dep_target_no_scope() {
         figment::Jail::expect_with(|jail| {

--- a/crates/core/config/tests/workspace_test.rs
+++ b/crates/core/config/tests/workspace_test.rs
@@ -258,7 +258,12 @@ projects:
                 r#"
 projects:
   app: apps/app
-  foo: ./packages/foo"#,
+  foo-kebab: ./packages/foo
+  barCamel: ./packages/bar
+  baz_snake: ./packages/baz
+  qux.dot: ./packages/qux
+  wat/slash: ./packages/wat
+"#,
             )?;
 
             let config = super::load_jailed_config(jail.directory())?;
@@ -267,7 +272,11 @@ projects:
                 config.projects,
                 WorkspaceProjects::Sources(FxHashMap::from_iter([
                     (String::from("app"), String::from("apps/app")),
-                    (String::from("foo"), String::from("./packages/foo"))
+                    (String::from("foo-kebab"), String::from("./packages/foo")),
+                    (String::from("barCamel"), String::from("./packages/bar")),
+                    (String::from("baz_snake"), String::from("./packages/baz")),
+                    (String::from("qux.dot"), String::from("./packages/qux")),
+                    (String::from("wat/slash"), String::from("./packages/wat"))
                 ])),
             );
 

--- a/crates/core/utils/src/regex.rs
+++ b/crates/core/utils/src/regex.rs
@@ -5,14 +5,14 @@ pub use regex::{Captures, Regex};
 
 lazy_static! {
     // Capture group for IDs/names/etc
-    static ref ID_GROUP: &'static str = "([A-Za-z]{1}[0-9A-Za-z/_-]*)";
-    static ref ID_CLEAN: Regex = Regex::new("[^0-9A-Za-z/_-]+").unwrap();
+    static ref ID_GROUP: &'static str = "([A-Za-z]{1}[0-9A-Za-z/\\._-]*)";
+    static ref ID_CLEAN: Regex = Regex::new("[^0-9A-Za-z/\\._-]+").unwrap();
 
     pub static ref ID_PATTERN: Regex = Regex::new(&format!("^{}$", *ID_GROUP)).unwrap();
     pub static ref TARGET_PATTERN: Regex = Regex::new(
         // Only target projects support `@` because of Node.js,
         // we don't want to support it in regular IDs!
-        "^(?P<project>(?:[A-Za-z@]{1}[0-9A-Za-z/_-]*|\\^|~))?:(?P<task>[A-Za-z]{1}[0-9A-Za-z/_-]*)$").unwrap();
+        "^(?P<project>(?:[A-Za-z@]{1}[0-9A-Za-z/\\._-]*|\\^|~))?:(?P<task>[A-Za-z]{1}[0-9A-Za-z/\\._-]*)$").unwrap();
 
     // Input values
     pub static ref ENV_VAR: Regex = Regex::new("^\\$[A-Z0-9_]+$").unwrap();
@@ -76,7 +76,7 @@ mod tests {
 
         #[test]
         fn replaces_unsupported_chars() {
-            assert_eq!(clean_id("foo bar.baz$123"), "foo-bar-baz-123");
+            assert_eq!(clean_id("foo bar.baz$123"), "foo-bar.baz-123");
         }
     }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.24.3
+## Unreleased
 
 #### 💥 Breaking
 
@@ -14,21 +14,24 @@
 - Updated `language` setting in `moon.yml` to support any custom language.
 - Updated `toolchain.typescript` setting in `moon.yml` to support overriding workspace-level
   settings.
+- Updated project, task, and target identifiers to support periods (`.`).
 
 ##### Moonbase
 
 - CI runs can now be tracked in moonbase to gather insights and metrics.
-
-#### 🐞 Fixes
-
-- Fixed an issue where `moon query projects --affected` would hang indefinitely waiting for stdin.
-- Fixed an issue where changing `projects` globs wouldn't immediately invalidate the cache.
 
 #### ⚙️ Internal
 
 - Updated Rust to v1.67.
 - Added `context` to `pipeline.started` and `pipeline.finished` events.
 - We now build against older operating systems in an attempt to solve GLIBC version errors.
+
+## 0.24.3
+
+#### 🐞 Fixes
+
+- Fixed an issue where `moon query projects --affected` would hang indefinitely waiting for stdin.
+- Fixed an issue where changing `projects` globs wouldn't immediately invalidate the cache.
 
 ## 0.24.2
 

--- a/website/blog/2023-02-27_v0.25.mdx
+++ b/website/blog/2023-02-27_v0.25.mdx
@@ -73,3 +73,17 @@ toolchain:
 	typescript:
 		disabled: true
 ```
+
+## Other changes
+
+View the
+[official release](https://github.com/moonrepo/moon/releases/tag/%40moonrepo%2Fcli%400.25.0) for a
+full list of changes.
+
+- Updated project, task, and target identifiers to support periods (`.`).
+
+## What's next?
+
+Expect the following in the v0.26 release!
+
+- ???

--- a/website/docs/concepts/project.mdx
+++ b/website/docs/concepts/project.mdx
@@ -11,7 +11,7 @@ files, assets, resources, and more. A project must exist and be configured withi
 A project name (or identifier) is a unique resource for locating a project. The name is explicitly
 configured within [`.moon/workspace.yml`](../config/workspace), as a key within the
 [`projects`](../config/workspace#projects) setting, and can be written in camel/kebab/snake case.
-Names support `a-z`, `A-Z`, `0-9`, `_`, `-`, `/`, and must start with a character.
+Names support `a-z`, `A-Z`, `0-9`, `_`, `-`, `/`, `.`, and must start with a character.
 
 Names are used heavily by configuration and the command line to link and reference everything.
 They're also a much easier concept for remembering projects than file system paths, and they

--- a/website/docs/concepts/task.mdx
+++ b/website/docs/concepts/task.mdx
@@ -9,8 +9,8 @@ task is simply a binary or system command that is ran as a child process.
 
 A task name (or identifier) is a unique resource for locating a task _within_ a project. The name is
 explicitly configured as a key within the [`tasks`](../config/project#tasks) setting, and can be
-written in camel/kebab/snake case. Names support `a-z`, `A-Z`, `0-9`, `_`, `-`, `/`, and must start
-with a character.
+written in camel/kebab/snake case. Names support `a-z`, `A-Z`, `0-9`, `_`, `-`, `/`, `.`, and must
+start with a character.
 
 A task name can be paired with a project name to create a [target](./target).
 


### PR DESCRIPTION
Because why not?