### PR TITLE
internal: Refactor globs to not be absolute.

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,4 +1,4 @@
-# Trigger CI: 11
+# Trigger CI: 12
 
 $schema: '../website/static/schemas/workspace.json'
 

--- a/crates/cli/src/commands/docker/scaffold.rs
+++ b/crates/cli/src/commands/docker/scaffold.rs
@@ -79,7 +79,7 @@ fn scaffold_workspace(
     copy_files(&files, &workspace.root, &docker_workspace_root)?;
 
     // Copy moon configuration
-    let moon_configs = glob::walk(&workspace.root.join(CONFIG_DIRNAME), &["*.yml"])?;
+    let moon_configs = glob::walk(&workspace.root.join(CONFIG_DIRNAME), ["*.yml"])?;
     let moon_configs = moon_configs
         .iter()
         .map(|f| path::to_string(f.strip_prefix(&workspace.root).unwrap()))

--- a/crates/cli/src/queries/touched_files.rs
+++ b/crates/cli/src/queries/touched_files.rs
@@ -115,7 +115,7 @@ pub async fn query_touched_files(
                 touched_files_to_log.push(format!("  {}", color::file(f)));
             }
 
-            workspace.root.join(path::normalize_separators(f))
+            PathBuf::from(path::normalize_separators(f))
         })
         .collect();
 

--- a/crates/cli/tests/snapshots/run_test__outputs__hydration__reuses_cache_from_previous_run-2.snap
+++ b/crates/cli/tests/snapshots/run_test__outputs__hydration__reuses_cache_from_previous_run-2.snap
@@ -2,6 +2,7 @@
 source: crates/cli/tests/run_test.rs
 expression: assert2.output()
 ---
+▪▪▪▪ npm install
 ▪▪▪▪ outputs:generateFileAndFolder (cached from previous run)
 
 Tasks: 1 completed (1 cached)

--- a/crates/core/action-pipeline/src/subscribers/moonbase.rs
+++ b/crates/core/action-pipeline/src/subscribers/moonbase.rs
@@ -164,12 +164,7 @@ impl Subscriber for MoonbaseSubscriber {
                     let touched_files = context
                         .touched_files
                         .iter()
-                        .map(|f| {
-                            f.strip_prefix(&workspace.root)
-                                .unwrap_or(f)
-                                .to_string_lossy()
-                                .to_string()
-                        })
+                        .map(|f| f.to_string_lossy().to_string())
                         .collect::<Vec<_>>();
 
                     let response = match graphql::post_mutation::<create_run::ResponseData>(

--- a/crates/core/archive/src/tar.rs
+++ b/crates/core/archive/src/tar.rs
@@ -115,7 +115,7 @@ impl<'l> TarArchiver<'l> {
                 color::path(self.input_root.join(glob))
             );
 
-            for file in glob::walk_files(self.input_root, &[glob])? {
+            for file in glob::walk_files(self.input_root, [glob])? {
                 let mut fh =
                     File::open(&file).map_err(|e| map_io_to_fs_error(e, file.to_path_buf()))?;
                 let file_name = path::to_string(file.strip_prefix(self.input_root).unwrap())?;

--- a/crates/core/archive/src/tree_differ.rs
+++ b/crates/core/archive/src/tree_differ.rs
@@ -33,7 +33,7 @@ impl TreeDiffer {
 
         for path in paths {
             if glob::is_glob(path) {
-                for file in glob::walk_files(dest_root, &[path])
+                for file in glob::walk_files(dest_root, [path])
                     .map_err(|e| MoonError::Generic(e.to_string()))?
                 {
                     track(file);

--- a/crates/core/dep-graph/Cargo.toml
+++ b/crates/core/dep-graph/Cargo.toml
@@ -19,7 +19,6 @@ moon_project = { path = "../project" }
 moon_project_graph = { path = "../project-graph" }
 moon_target = { path = "../target" }
 moon_task = { path = "../task" }
-moon_utils = { path = "../utils" }
 petgraph = { version = "0.6.2", features = ["serde"] }
 rustc-hash = { workspace = true }
 thiserror = { workspace = true }
@@ -28,6 +27,7 @@ thiserror = { workspace = true }
 moon = { path = "../moon" }
 moon_config = { path = "../config" }
 moon_test_utils = { path = "../test-utils" }
+moon_utils = { path = "../utils" }
 moon_workspace = { path = "../workspace" }
 criterion = { workspace = true }
 tokio = { workspace = true }

--- a/crates/core/dep-graph/Cargo.toml
+++ b/crates/core/dep-graph/Cargo.toml
@@ -19,6 +19,7 @@ moon_project = { path = "../project" }
 moon_project_graph = { path = "../project-graph" }
 moon_target = { path = "../target" }
 moon_task = { path = "../task" }
+moon_utils = { path = "../utils" }
 petgraph = { version = "0.6.2", features = ["serde"] }
 rustc-hash = { workspace = true }
 thiserror = { workspace = true }
@@ -27,7 +28,6 @@ thiserror = { workspace = true }
 moon = { path = "../moon" }
 moon_config = { path = "../config" }
 moon_test_utils = { path = "../test-utils" }
-moon_utils = { path = "../utils" }
 moon_workspace = { path = "../workspace" }
 criterion = { workspace = true }
 tokio = { workspace = true }

--- a/crates/core/dep-graph/src/dep_builder.rs
+++ b/crates/core/dep-graph/src/dep_builder.rs
@@ -7,12 +7,11 @@ use moon_project::Project;
 use moon_project_graph::ProjectGraph;
 use moon_target::{Target, TargetError, TargetProjectScope};
 use moon_task::{Task, TouchedFilePaths};
-use moon_utils::get_workspace_root;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::mem;
-use std::path::PathBuf;
+use std::path::Path;
 
 const LOG_TARGET: &str = "moon:dep-graph";
 
@@ -27,11 +26,15 @@ pub struct DepGraphBuilder<'ws> {
     platforms: &'ws PlatformManager,
     project_graph: &'ws ProjectGraph,
     runtimes: FxHashMap<String, RuntimePair>,
-    workspace_root: PathBuf,
+    workspace_root: &'ws Path,
 }
 
 impl<'ws> DepGraphBuilder<'ws> {
-    pub fn new(platforms: &'ws PlatformManager, project_graph: &'ws ProjectGraph) -> Self {
+    pub fn new(
+        workspace_root: &'ws Path,
+        platforms: &'ws PlatformManager,
+        project_graph: &'ws ProjectGraph,
+    ) -> Self {
         debug!(target: LOG_TARGET, "Creating dependency graph",);
 
         DepGraphBuilder {
@@ -40,7 +43,7 @@ impl<'ws> DepGraphBuilder<'ws> {
             platforms,
             project_graph,
             runtimes: FxHashMap::default(),
-            workspace_root: get_workspace_root(),
+            workspace_root,
         }
     }
 
@@ -253,7 +256,7 @@ impl<'ws> DepGraphBuilder<'ws> {
 
         // Compare against touched files if provided
         if let Some(touched) = touched_files {
-            if !task.is_affected(touched, &self.workspace_root)? {
+            if !task.is_affected(touched, self.workspace_root)? {
                 trace!(
                     target: LOG_TARGET,
                     "Target {} not affected based on touched files, skipping",

--- a/crates/core/dep-graph/src/dep_builder.rs
+++ b/crates/core/dep-graph/src/dep_builder.rs
@@ -7,10 +7,12 @@ use moon_project::Project;
 use moon_project_graph::ProjectGraph;
 use moon_target::{Target, TargetError, TargetProjectScope};
 use moon_task::{Task, TouchedFilePaths};
+use moon_utils::get_workspace_root;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::mem;
+use std::path::PathBuf;
 
 const LOG_TARGET: &str = "moon:dep-graph";
 
@@ -25,6 +27,7 @@ pub struct DepGraphBuilder<'ws> {
     platforms: &'ws PlatformManager,
     project_graph: &'ws ProjectGraph,
     runtimes: FxHashMap<String, RuntimePair>,
+    workspace_root: PathBuf,
 }
 
 impl<'ws> DepGraphBuilder<'ws> {
@@ -37,6 +40,7 @@ impl<'ws> DepGraphBuilder<'ws> {
             platforms,
             project_graph,
             runtimes: FxHashMap::default(),
+            workspace_root: get_workspace_root(),
         }
     }
 
@@ -249,7 +253,7 @@ impl<'ws> DepGraphBuilder<'ws> {
 
         // Compare against touched files if provided
         if let Some(touched) = touched_files {
-            if !task.is_affected(touched)? {
+            if !task.is_affected(touched, &self.workspace_root)? {
                 trace!(
                     target: LOG_TARGET,
                     "Target {} not affected based on touched files, skipping",

--- a/crates/core/dep-graph/tests/dep_graph_test.rs
+++ b/crates/core/dep-graph/tests/dep_graph_test.rs
@@ -10,6 +10,7 @@ use moon_utils::string_vec;
 use moon_workspace::Workspace;
 use petgraph::graph::NodeIndex;
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::path::PathBuf;
 
 async fn create_project_graph() -> (Workspace, ProjectGraph, Sandbox) {
     let workspace_config = WorkspaceConfig {
@@ -371,11 +372,11 @@ mod run_target_if_touched {
 
     #[tokio::test]
     async fn skips_if_untouched_project() {
-        let (workspace, projects, sandbox) = create_tasks_project_graph().await;
+        let (workspace, projects, _sandbox) = create_tasks_project_graph().await;
 
         let mut touched_files = FxHashSet::default();
-        touched_files.insert(sandbox.path().join("input-a/a.ts"));
-        touched_files.insert(sandbox.path().join("input-c/c.ts"));
+        touched_files.insert(PathBuf::from("input-a/a.ts"));
+        touched_files.insert(PathBuf::from("input-c/c.ts"));
 
         let mut graph = build_dep_graph(&workspace, &projects);
         graph
@@ -391,12 +392,12 @@ mod run_target_if_touched {
 
     #[tokio::test]
     async fn skips_if_untouched_task() {
-        let (workspace, projects, sandbox) = create_tasks_project_graph().await;
+        let (workspace, projects, _sandbox) = create_tasks_project_graph().await;
 
         let mut touched_files = FxHashSet::default();
-        touched_files.insert(sandbox.path().join("input-a/a2.ts"));
-        touched_files.insert(sandbox.path().join("input-b/b2.ts"));
-        touched_files.insert(sandbox.path().join("input-c/any.ts"));
+        touched_files.insert(PathBuf::from("input-a/a2.ts"));
+        touched_files.insert(PathBuf::from("input-b/b2.ts"));
+        touched_files.insert(PathBuf::from("input-c/any.ts"));
 
         let mut graph = build_dep_graph(&workspace, &projects);
         graph

--- a/crates/core/launchpad/src/lib.rs
+++ b/crates/core/launchpad/src/lib.rs
@@ -23,10 +23,8 @@ pub struct CheckState {
 }
 
 fn load_or_create_anonymous_uid() -> Result<String, MoonError> {
-    let id_path = path::get_home_dir()
-        .unwrap()
-        .join(CONFIG_DIRNAME)
-        .join("id");
+    let moon_dir = path::get_home_dir().unwrap().join(CONFIG_DIRNAME);
+    let id_path = moon_dir.join("id");
 
     if id_path.exists() {
         return fs::read(id_path);
@@ -34,6 +32,7 @@ fn load_or_create_anonymous_uid() -> Result<String, MoonError> {
 
     let id = Uuid::new_v4().to_string();
 
+    fs::create_dir_all(&moon_dir)?;
     fs::write(id_path, &id)?;
 
     Ok(id)

--- a/crates/core/moon/src/lib.rs
+++ b/crates/core/moon/src/lib.rs
@@ -67,7 +67,7 @@ pub fn build_dep_graph<'g>(
     workspace: &'g Workspace,
     project_graph: &'g ProjectGraph,
 ) -> DepGraphBuilder<'g> {
-    DepGraphBuilder::new(&workspace.platforms, project_graph)
+    DepGraphBuilder::new(&workspace.root, &workspace.platforms, project_graph)
 }
 
 pub async fn build_project_graph(

--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -597,8 +597,7 @@ impl<'ws> ProjectGraphBuilder<'ws> {
 
         for glob in globs {
             normalized_globs.push(glob::normalize(
-                //  glob.strip_prefix(&self.workspace.root).unwrap(),
-                glob,
+                glob.strip_prefix(&self.workspace.root).unwrap(),
             )?);
         }
 

--- a/crates/core/project-graph/tests/projects_test.rs
+++ b/crates/core/project-graph/tests/projects_test.rs
@@ -1042,9 +1042,9 @@ mod task_expansion {
             assert_eq!(
                 task.input_globs,
                 FxHashSet::from_iter([
-                    glob::normalize(sandbox.path().join(".moon/*.yml")).unwrap(),
-                    glob::normalize(project.root.join("**/*.{ts,tsx}")).unwrap(),
-                    glob::normalize(project.root.join("*.js")).unwrap()
+                    glob::normalize(".moon/*.yml").unwrap(),
+                    glob::normalize(PathBuf::from(&project.source).join("**/*.{ts,tsx}")).unwrap(),
+                    glob::normalize(PathBuf::from(&project.source).join("*.js")).unwrap()
                 ]),
             );
 
@@ -1074,9 +1074,9 @@ mod task_expansion {
             let project = project_graph.get("tokens").unwrap();
             let task = project.get_task("inputsVars").unwrap();
 
-            assert!(task
-                .input_globs
-                .contains(&glob::normalize(project.root.join("$unknown.*")).unwrap()));
+            assert!(task.input_globs.contains(
+                &glob::normalize(PathBuf::from(&project.source).join("$unknown.*")).unwrap()
+            ));
 
             assert!(task
                 .input_paths
@@ -1094,12 +1094,12 @@ mod task_expansion {
             let project = project_graph.get("tokens").unwrap();
             let task = project.get_task("inputs").unwrap();
 
+            assert!(task.input_globs.contains(
+                &glob::normalize(PathBuf::from(&project.source).join("glob/*")).unwrap()
+            ));
             assert!(task
                 .input_globs
-                .contains(&glob::normalize(project.root.join("glob/*")).unwrap()));
-            assert!(task
-                .input_globs
-                .contains(&glob::normalize(sandbox.path().join("glob.*")).unwrap()));
+                .contains(&glob::normalize("glob.*").unwrap()));
 
             assert!(task.input_paths.contains(&project.root.join("path.ts")));
             assert!(task.input_paths.contains(&sandbox.path().join("path/dir")));
@@ -1125,19 +1125,9 @@ mod task_expansion {
 
             let task = project.get_task("outputsGlobs").unwrap();
 
-            if cfg!(windows) {
-                assert!(task
-                    .output_globs
-                    .contains(&glob::normalize(project.root.join("dir/**/*.js")).unwrap()));
-            } else {
-                assert!(task.output_globs.contains(
-                    &project
-                        .root
-                        .join("dir/**/*.js")
-                        .to_string_lossy()
-                        .to_string()
-                ));
-            }
+            assert!(task.output_globs.contains(
+                &glob::normalize(PathBuf::from(&project.source).join("dir/**/*.js")).unwrap()
+            ));
         }
 
         #[tokio::test]
@@ -1150,8 +1140,8 @@ mod task_expansion {
             assert_eq!(
                 task.output_globs,
                 FxHashSet::from_iter([
-                    glob::normalize(project.root.join("**/*.{ts,tsx}")).unwrap(),
-                    glob::normalize(project.root.join("*.js")).unwrap()
+                    glob::normalize(PathBuf::from(&project.source).join("**/*.{ts,tsx}")).unwrap(),
+                    glob::normalize(PathBuf::from(&project.source).join("*.js")).unwrap()
                 ]),
             );
 

--- a/crates/core/project-graph/tests/token_resolver_test.rs
+++ b/crates/core/project-graph/tests/token_resolver_test.rs
@@ -77,7 +77,7 @@ pub fn expand_task(project: &Project, task: &mut Task) {
     for input in &task.inputs {
         if glob::is_glob(input) {
             task.input_globs
-                .insert(glob::normalize(project.root.join(input)).unwrap());
+                .insert(glob::normalize(PathBuf::from(&project.source).join(input)).unwrap());
         } else {
             task.input_paths.insert(project.root.join(input));
         }
@@ -86,7 +86,7 @@ pub fn expand_task(project: &Project, task: &mut Task) {
     for output in &task.outputs {
         if glob::is_glob(output) {
             task.output_globs
-                .insert(glob::normalize(project.root.join(output)).unwrap());
+                .insert(glob::normalize(PathBuf::from(&project.source).join(output)).unwrap());
         } else {
             task.output_paths.insert(project.root.join(output));
         }

--- a/crates/core/project-graph/tests/token_resolver_test.rs
+++ b/crates/core/project-graph/tests/token_resolver_test.rs
@@ -353,7 +353,7 @@ mod resolve_args {
 
         assert_eq!(
             resolver.resolve(&string_vec!["@in(0)"], &task).unwrap(),
-            (vec![], vec![project.root.join("src/**/*")])
+            (vec![], vec![PathBuf::from(project.source).join("src/**/*")])
         );
     }
 

--- a/crates/core/project/src/project.rs
+++ b/crates/core/project/src/project.rs
@@ -404,7 +404,7 @@ impl Project {
     /// Since the project is a folder, we check if a file starts with the root.
     pub fn is_affected(&self, touched_files: &TouchedFilePaths) -> bool {
         for file in touched_files {
-            if file.starts_with(&self.root) {
+            if file.starts_with(&self.source) {
                 return true;
             }
         }

--- a/crates/core/runner/src/runner.rs
+++ b/crates/core/runner/src/runner.rs
@@ -325,8 +325,11 @@ impl<'a> Runner<'a> {
         // Affected files (must be last args)
         if let Some(check_affected) = &self.task.options.affected_files {
             let mut affected_files = if context.affected_only {
-                self.task
-                    .get_affected_files(&context.touched_files, &self.project.root)?
+                self.task.get_affected_files(
+                    &context.touched_files,
+                    &self.workspace.root,
+                    &self.project.source,
+                )?
             } else {
                 Vec::with_capacity(0)
             };

--- a/crates/core/task/src/task.rs
+++ b/crates/core/task/src/task.rs
@@ -44,6 +44,7 @@ pub struct Task {
 
     pub inputs: Vec<InputValue>,
 
+    // Relative from workspace root
     pub input_globs: FxHashSet<FileGlob>,
 
     pub input_paths: FxHashSet<PathBuf>,
@@ -57,6 +58,7 @@ pub struct Task {
 
     pub outputs: Vec<FilePath>,
 
+    // Relative from workspace root
     pub output_globs: FxHashSet<FileGlob>,
 
     pub output_paths: FxHashSet<PathBuf>,
@@ -173,18 +175,7 @@ impl Task {
 
     /// Create a globset of all input globs to match with.
     pub fn create_globset(&self) -> Result<glob::GlobSet, TaskError> {
-        Ok(glob::GlobSet::new(
-            self.input_globs
-                .iter()
-                .map(|g| {
-                    if cfg!(windows) {
-                        glob::remove_drive_prefix(g)
-                    } else {
-                        g.to_owned()
-                    }
-                })
-                .collect::<Vec<String>>(),
-        )?)
+        Ok(glob::GlobSet::new(&self.input_globs)?)
     }
 
     /// Determine the type of task after inheritance and expansion.

--- a/crates/core/task/src/task.rs
+++ b/crates/core/task/src/task.rs
@@ -47,6 +47,7 @@ pub struct Task {
     // Relative from workspace root
     pub input_globs: FxHashSet<FileGlob>,
 
+    // Absolute paths
     pub input_paths: FxHashSet<PathBuf>,
 
     pub input_vars: FxHashSet<String>,
@@ -61,6 +62,7 @@ pub struct Task {
     // Relative from workspace root
     pub output_globs: FxHashSet<FileGlob>,
 
+    // Absolute paths
     pub output_paths: FxHashSet<PathBuf>,
 
     pub platform: PlatformType,

--- a/crates/core/task/tests/task_test.rs
+++ b/crates/core/task/tests/task_test.rs
@@ -5,6 +5,7 @@ use moon_test_utils::{create_sandbox, get_fixtures_path};
 use moon_utils::{glob, string_vec};
 use rustc_hash::FxHashSet;
 use std::env;
+use std::path::PathBuf;
 
 pub fn create_task(config: TaskConfig) -> Task {
     Task::from_config(Target::new("project", "task").unwrap(), &config).unwrap()
@@ -326,6 +327,7 @@ mod merge {
 }
 
 mod is_affected {
+
     use super::*;
 
     #[test]
@@ -339,7 +341,9 @@ mod is_affected {
 
         env::set_var("FOO", "foo");
 
-        assert!(task.is_affected(&FxHashSet::default()).unwrap());
+        assert!(task
+            .is_affected(&FxHashSet::default(), &PathBuf::new())
+            .unwrap());
 
         env::remove_var("FOO");
     }
@@ -353,7 +357,9 @@ mod is_affected {
 
         task.input_vars.insert("BAR".into());
 
-        assert!(!task.is_affected(&FxHashSet::default()).unwrap());
+        assert!(!task
+            .is_affected(&FxHashSet::default(), &PathBuf::new())
+            .unwrap());
     }
 
     #[test]
@@ -367,7 +373,9 @@ mod is_affected {
 
         env::set_var("BAZ", "");
 
-        assert!(!task.is_affected(&FxHashSet::default()).unwrap());
+        assert!(!task
+            .is_affected(&FxHashSet::default(), &PathBuf::new())
+            .unwrap());
 
         env::remove_var("BAZ");
     }
@@ -386,7 +394,7 @@ mod is_affected {
         let mut set = FxHashSet::default();
         set.insert(project_root.join("file.ts"));
 
-        assert!(task.is_affected(&set).unwrap());
+        assert!(task.is_affected(&set, &workspace_root).unwrap());
     }
 
     #[test]
@@ -404,7 +412,7 @@ mod is_affected {
         let mut set = FxHashSet::default();
         set.insert(project_root.join("file.ts"));
 
-        assert!(task.is_affected(&set).unwrap());
+        assert!(task.is_affected(&set, &workspace_root).unwrap());
     }
 
     #[test]
@@ -420,7 +428,7 @@ mod is_affected {
         let mut set = FxHashSet::default();
         set.insert(workspace_root.join("package.json"));
 
-        assert!(task.is_affected(&set).unwrap());
+        assert!(task.is_affected(&set, &workspace_root).unwrap());
     }
 
     #[test]
@@ -437,7 +445,7 @@ mod is_affected {
         let mut set = FxHashSet::default();
         set.insert(workspace_root.join("base/other/outside.ts"));
 
-        assert!(!task.is_affected(&set).unwrap());
+        assert!(!task.is_affected(&set, &workspace_root).unwrap());
     }
 
     #[test]
@@ -456,7 +464,7 @@ mod is_affected {
         let mut set = FxHashSet::default();
         set.insert(project_root.join("another.rs"));
 
-        assert!(!task.is_affected(&set).unwrap());
+        assert!(!task.is_affected(&set, &workspace_root).unwrap());
     }
 
     #[test]
@@ -478,6 +486,6 @@ mod is_affected {
         let mut set = FxHashSet::default();
         set.insert(project_root.join(".env"));
 
-        assert!(task.is_affected(&set).unwrap());
+        assert!(task.is_affected(&set, sandbox.path()).unwrap());
     }
 }

--- a/crates/core/test-utils/src/sandbox.rs
+++ b/crates/core/test-utils/src/sandbox.rs
@@ -28,7 +28,7 @@ impl Sandbox {
     }
 
     pub fn debug_configs(&self) -> &Self {
-        for cfg in glob::walk_files(self.path(), &[".moon/**/*.yml"]).unwrap() {
+        for cfg in glob::walk_files(self.path(), [".moon/**/*.yml"]).unwrap() {
             if cfg.exists() {
                 println!("{:?} = {}", &cfg, fs::read_to_string(&cfg).unwrap());
             }

--- a/crates/core/utils/src/glob.rs
+++ b/crates/core/utils/src/glob.rs
@@ -132,11 +132,15 @@ pub fn split_patterns<P: AsRef<str>>(patterns: &[P]) -> Result<(Vec<Glob>, Vec<G
 
 #[inline]
 #[track_caller]
-pub fn walk<T: AsRef<Path>, P: AsRef<str>>(
-    base_dir: T,
-    patterns: &[P],
-) -> Result<Vec<PathBuf>, GlobError> {
-    let (globs, negations) = split_patterns(patterns)?;
+pub fn walk<P, V, I>(base_dir: P, patterns: I) -> Result<Vec<PathBuf>, GlobError>
+where
+    P: AsRef<Path>,
+    V: AsRef<str>,
+    I: IntoIterator<Item = V>,
+{
+    let patterns = patterns.into_iter().collect::<Vec<_>>();
+
+    let (globs, negations) = split_patterns(&patterns)?;
     let negation = Negation::try_from_patterns(negations).unwrap();
     let mut paths = vec![];
 
@@ -163,10 +167,12 @@ pub fn walk<T: AsRef<Path>, P: AsRef<str>>(
 }
 
 #[inline]
-pub fn walk_files<T: AsRef<Path>, P: AsRef<str>>(
-    base_dir: T,
-    patterns: &[P],
-) -> Result<Vec<PathBuf>, GlobError> {
+pub fn walk_files<P, V, I>(base_dir: P, patterns: I) -> Result<Vec<PathBuf>, GlobError>
+where
+    P: AsRef<Path>,
+    V: AsRef<str>,
+    I: IntoIterator<Item = V>,
+{
     let paths = walk(base_dir, patterns)?;
 
     Ok(paths

--- a/crates/core/utils/src/glob.rs
+++ b/crates/core/utils/src/glob.rs
@@ -21,11 +21,15 @@ pub struct GlobSet<'t> {
 
 impl<'t> GlobSet<'t> {
     #[track_caller]
-    pub fn new(patterns: Vec<String>) -> Result<Self, GlobError> {
+    pub fn new<V, I>(patterns: I) -> Result<Self, GlobError>
+    where
+        V: AsRef<str>,
+        I: IntoIterator<Item = V>,
+    {
         let mut globs = vec![];
 
-        for pattern in &patterns {
-            globs.push(create_glob(pattern)?.into_owned());
+        for pattern in patterns.into_iter() {
+            globs.push(create_glob(pattern.as_ref())?.into_owned());
         }
 
         Ok(GlobSet {

--- a/crates/core/utils/src/glob.rs
+++ b/crates/core/utils/src/glob.rs
@@ -139,7 +139,6 @@ where
     I: IntoIterator<Item = V>,
 {
     let patterns = patterns.into_iter().collect::<Vec<_>>();
-
     let (globs, negations) = split_patterns(&patterns)?;
     let negation = Negation::try_from_patterns(negations).unwrap();
     let mut paths = vec![];

--- a/crates/core/workspace/src/workspace.rs
+++ b/crates/core/workspace/src/workspace.rs
@@ -85,7 +85,7 @@ fn load_tasks_config(root_dir: &Path) -> Result<InheritedTasksManager, Workspace
 
     for config_path in glob::walk_files(
         root_dir.join(constants::CONFIG_DIRNAME).join("tasks"),
-        &["*.yml"],
+        ["*.yml"],
     )? {
         trace!(target: LOG_TARGET, "Found {}", color::path(&config_path));
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Updated `node.version` and `node.<packageManager>.version` to no longer default to a hard-coded
   version. When not defined, will fallback to the binary available on `PATH`.
+- Updated touched files (in context and queries) to be workspace relative paths instead of absolute.
 
 #### 🚀 Updates
 
@@ -24,6 +25,8 @@
 
 - Updated Rust to v1.67.
 - Added `context` to `pipeline.started` and `pipeline.finished` events.
+- Refactored glob matching to use workspace relative paths instead of absolute. Please report an
+  issue if hashing or affected is now inaccurate.
 - We now build against older operating systems in an attempt to solve GLIBC version errors.
 
 ## 0.24.3


### PR DESCRIPTION
Up until now, our glob matching would use and work on absolute paths. This is non-trivial, especially for Windows machines that include a drive prefix, and globs do not understand that.

It also over-complicated pieces, as the VCS is always workspace relative, and we had to constantly re-join paths to be either relative or absolute. Instead, this moves all globs and touched files to workspace relative. In a future PR, we may move input/output paths to relative too.