### PR TITLE
internal: Normalize path related settings on Windows.

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,4 +1,4 @@
-# Trigger CI: 12
+# Trigger CI: 13
 
 $schema: '../website/static/schemas/workspace.json'
 

--- a/crates/cli/tests/project_test.rs
+++ b/crates/cli/tests/project_test.rs
@@ -113,7 +113,7 @@ fn depends_on_paths() {
         cmd.arg("project").arg("foo");
     });
 
-    assert_snapshot!(assert.output());
+    assert_snapshot!(assert.output_standardized());
 }
 
 #[test]

--- a/crates/cli/tests/query_test.rs
+++ b/crates/cli/tests/query_test.rs
@@ -48,7 +48,7 @@ mod projects {
             cmd.arg("query").arg("projects");
         });
 
-        assert_snapshot!(assert.output());
+        assert_snapshot!(assert.output_standardized());
     }
 
     #[test]
@@ -331,7 +331,7 @@ mod tasks {
             cmd.arg("query").arg("tasks");
         });
 
-        assert_snapshot!(assert.output());
+        assert_snapshot!(assert.output_standardized());
     }
 
     #[test]

--- a/crates/core/project-graph/src/token_resolver.rs
+++ b/crates/core/project-graph/src/token_resolver.rs
@@ -288,7 +288,7 @@ impl<'task> TokenResolver<'task> {
                 .ok_or_else(|| TokenError::UnknownFileGroup(token.to_owned(), id.to_owned()))
         };
 
-        let workspace_root = &self.workspace_root;
+        let workspace_root = self.workspace_root;
         let project_root = &self.project.root;
 
         match token_type {

--- a/crates/core/project/tests/project_test.rs
+++ b/crates/core/project/tests/project_test.rs
@@ -5,7 +5,7 @@ use moon_config::{
 use moon_project::Project;
 use moon_task::FileGroup;
 use moon_test_utils::get_fixtures_root;
-use moon_utils::string_vec;
+use moon_utils::{path, string_vec};
 use rustc_hash::FxHashMap;
 
 fn mock_file_groups() -> FxHashMap<String, FileGroup> {
@@ -28,7 +28,7 @@ fn mock_tasks_config() -> InheritedTasksManager {
 }
 
 #[test]
-#[should_panic(expected = "MissingProjectAtSource(\"projects/missing\")")]
+#[should_panic(expected = "MissingProjectAtSource")]
 fn doesnt_exist() {
     Project::new(
         "missing",
@@ -57,9 +57,9 @@ fn no_config() {
         Project {
             id: "no-config".into(),
             log_target: "moon:project:no-config".into(),
-            root: workspace_root.join("projects/no-config"),
+            root: workspace_root.join(path::normalize_separators("projects/no-config")),
             file_groups: mock_file_groups(),
-            source: "projects/no-config".into(),
+            source: path::normalize_separators("projects/no-config"),
             ..Project::default()
         }
     );
@@ -83,9 +83,9 @@ fn empty_config() {
             id: "empty-config".into(),
             config: ProjectConfig::default(),
             log_target: "moon:project:empty-config".into(),
-            root: workspace_root.join("projects/empty-config"),
+            root: workspace_root.join(path::normalize_separators("projects/empty-config")),
             file_groups: mock_file_groups(),
-            source: "projects/empty-config".into(),
+            source: path::normalize_separators("projects/empty-config"),
             ..Project::default()
         }
     );
@@ -102,7 +102,7 @@ fn basic_config() {
         |_| ProjectLanguage::Unknown,
     )
     .unwrap();
-    let project_root = workspace_root.join("projects/basic");
+    let project_root = workspace_root.join(path::normalize_separators("projects/basic"));
 
     // Merges with global
     let mut file_groups = mock_file_groups();
@@ -124,7 +124,7 @@ fn basic_config() {
             log_target: "moon:project:basic".into(),
             root: project_root,
             file_groups,
-            source: "projects/basic".into(),
+            source: path::normalize_separators("projects/basic"),
             ..Project::default()
         }
     );
@@ -159,9 +159,9 @@ fn advanced_config() {
                 ..ProjectConfig::default()
             },
             log_target: "moon:project:advanced".into(),
-            root: workspace_root.join("projects/advanced"),
+            root: workspace_root.join(path::normalize_separators("projects/advanced")),
             file_groups: mock_file_groups(),
-            source: "projects/advanced".into(),
+            source: path::normalize_separators("projects/advanced"),
             ..Project::default()
         }
     );

--- a/crates/core/task/src/file_group.rs
+++ b/crates/core/task/src/file_group.rs
@@ -137,7 +137,7 @@ impl FileGroup {
                     project_root
                 };
 
-                for path in glob::walk(root, &[file.clone()])? {
+                for path in glob::walk(root, &[file])? {
                     let allowed = if is_dir {
                         path.is_dir()
                     } else {

--- a/crates/core/utils/src/path.rs
+++ b/crates/core/utils/src/path.rs
@@ -17,9 +17,9 @@ where
     if file.starts_with('/') {
         workspace_root
             .as_ref()
-            .join(file.strip_prefix('/').unwrap())
+            .join(normalize_separators(file.strip_prefix('/').unwrap()))
     } else {
-        project_root.as_ref().join(file)
+        project_root.as_ref().join(normalize_separators(file))
     }
 }
 


### PR DESCRIPTION
While working on https://github.com/moonrepo/moon/pull/649 I noticed that Windows path use both / and \, resulting in patterns not matching, and duplicate paths. This attempts to normalize them.