### PR TITLE
fix: Fix project graph cache invalidation between moon releases.

### DIFF
--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -556,7 +556,7 @@ impl<'ws> ProjectGraphBuilder<'ws> {
             return Ok(String::new());
         }
 
-        let mut hasher = GraphHasher::default();
+        let mut hasher = GraphHasher::new();
 
         // Hash aliases and sources as-is as they're very explicit
         hasher.hash_aliases(aliases);

--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -574,6 +574,7 @@ impl<'ws> ProjectGraphBuilder<'ws> {
             &self.workspace.root,
         )?;
 
+        // Hash project-level config (moon.yml)
         let config_hashes = self
             .workspace
             .vcs
@@ -583,6 +584,7 @@ impl<'ws> ProjectGraphBuilder<'ws> {
 
         hasher.hash_configs(&config_hashes);
 
+        // Hash workspace-level configs (entire .moon folder)
         let config_hashes = self
             .workspace
             .vcs

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Fixed an issue where hashing would attempt to hash a directory and crash.
 - Fixed an issue where attempting to hash a large number of files (think 10,000) would hang.
 - Fixed an issue where offline checks would take longer than expected.
+- Fixed an issue where the project graph cache would not invalidate when Rust internals have
+  changed.
 
 ## 0.25.1
 


### PR DESCRIPTION
I encountered something weird yesterday. I was using 0.25 and noticed affected logic was not working _at all_. After digging into it, the project graph cache data was _wrong_, as all globs were using the 0.24 format, and not the new 0.25 format.

This makes sense because globs were an internal Rust change, and would not trigger a hash change, as the hash sources are based on file system contents. As such, the cache is not invalidated, putting the app in a weird state.

I'm not entirely sure how to fix this problem, or if there's a way to fix it, so for now, I'm including the moon release version in the hash contents, so that it it's invalidated with each release.