### PR TITLE
fix: Fix workspace relative `outputs` not being included in tarballs.

### DIFF
--- a/.yarn/versions/04bbcb16.yml
+++ b/.yarn/versions/04bbcb16.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -632,10 +632,58 @@ mod outputs {
 
         moon_archive::untar(tarball, &dir, None).unwrap();
 
-        assert!(dir.join("build/one.js").exists());
-        assert!(dir.join("build/two.js").exists());
-        assert!(!dir.join("build/styles.css").exists());
-        assert!(!dir.join("build/image.png").exists());
+        assert!(dir.join("outputs/build/one.js").exists());
+        assert!(dir.join("outputs/build/two.js").exists());
+        assert!(!dir.join("outputs/build/styles.css").exists());
+        assert!(!dir.join("outputs/build/image.png").exists());
+    }
+
+    #[test]
+    fn includes_project_files() {
+        let sandbox = cases_sandbox();
+        sandbox.enable_git();
+
+        sandbox.run_moon(|cmd| {
+            cmd.arg("run").arg("outputs:generateFileAndFolder");
+        });
+
+        let hash = extract_hash_from_run(sandbox.path(), "outputs:generateFileAndFolder");
+        let tarball = sandbox
+            .path()
+            .join(".moon/cache/outputs")
+            .join(format!("{hash}.tar.gz"));
+        let dir = sandbox.path().join(".moon/cache/outputs").join(hash);
+
+        moon_archive::untar(tarball, &dir, None).unwrap();
+
+        assert!(dir.join("stdout.log").exists());
+        assert!(dir.join("stderr.log").exists());
+        assert!(dir.join("outputs/lib/one.js").exists());
+        assert!(dir.join("outputs/esm/two.js").exists());
+    }
+
+    #[test]
+    fn includes_workspace_files() {
+        let sandbox = cases_sandbox();
+        sandbox.enable_git();
+
+        sandbox.run_moon(|cmd| {
+            cmd.arg("run").arg("outputs:generateFileAndFolderWorkspace");
+        });
+
+        let hash = extract_hash_from_run(sandbox.path(), "outputs:generateFileAndFolderWorkspace");
+        let tarball = sandbox
+            .path()
+            .join(".moon/cache/outputs")
+            .join(format!("{hash}.tar.gz"));
+        let dir = sandbox.path().join(".moon/cache/outputs").join(hash);
+
+        moon_archive::untar(tarball, &dir, None).unwrap();
+
+        assert!(dir.join("stdout.log").exists());
+        assert!(dir.join("stderr.log").exists());
+        assert!(dir.join("lib/one.js").exists());
+        assert!(dir.join("esm/two.js").exists());
     }
 
     #[test]

--- a/crates/cli/tests/snapshots/run_test__dependencies__changes_primary_hash_if_deps_hash_changes.snap
+++ b/crates/cli/tests/snapshots/run_test__dependencies__changes_primary_hash_if_deps_hash_changes.snap
@@ -3,8 +3,8 @@ source: crates/cli/tests/run_test.rs
 expression: "[h1, h2, extract_hash_from_run(sandbox.path(), \"outputs:asDep\"),\n        extract_hash_from_run(sandbox.path(), \"outputs:withDeps\")]"
 ---
 [
-    "ffa8fa180703215c8fe5fa2b113c80fe34c2fc20060dbe03617f1307c7385a66",
-    "dfbc2145142551a608e3bd8e4f8d08b1b0d5e5f9b213a0cc5487f077ae084ae4",
-    "a165810fd88d5e217c4ac55d0126db3db6bccb1a6abf03089e3c0c7727496510",
-    "25044b63ffccef9996c3160816b4d94ef7b1b9c606165f038aef3b50a71c7f37",
+    "c278cfc0764985a774a74ff43e0c5d8c29e2897844578140d875caed2a30ffae",
+    "ed94e971772a28cb43a88cd92df0927e23af27340e0b35bf8ebba631f7f925fc",
+    "d21b79c6b8ca75ba25b6edb1d3bddc2ac4c3a45ae2377ad71afcece8b2a0188b",
+    "7d3978a569e4eb1b36b03f1e629dfe19edddb0f30750c576622874a7a1c3e75c",
 ]

--- a/crates/cli/tests/snapshots/run_test__dependencies__changes_primary_hash_if_deps_hash_changes.snap
+++ b/crates/cli/tests/snapshots/run_test__dependencies__changes_primary_hash_if_deps_hash_changes.snap
@@ -3,8 +3,8 @@ source: crates/cli/tests/run_test.rs
 expression: "[h1, h2, extract_hash_from_run(sandbox.path(), \"outputs:asDep\"),\n        extract_hash_from_run(sandbox.path(), \"outputs:withDeps\")]"
 ---
 [
-    "c278cfc0764985a774a74ff43e0c5d8c29e2897844578140d875caed2a30ffae",
-    "ed94e971772a28cb43a88cd92df0927e23af27340e0b35bf8ebba631f7f925fc",
-    "d21b79c6b8ca75ba25b6edb1d3bddc2ac4c3a45ae2377ad71afcece8b2a0188b",
-    "7d3978a569e4eb1b36b03f1e629dfe19edddb0f30750c576622874a7a1c3e75c",
+    "9be09da77eaf86c9f86c138644ca0385ee621eb9a199ea235d8e9b7006122818",
+    "d7c663fab422ad3ef8e5d54e0bfa9307c270fd02848ee736de4cd0d2e4979887",
+    "2b8fa51a96b0eeb390d8561ee0bf402238a1f218e9d7336ce60a9dfb1c960b12",
+    "1b21ce423a208d63c3148c68c8e253b61678586381a05368f52cccb74d85dc7d",
 ]

--- a/crates/cli/tests/snapshots/run_test__dependencies__generates_unique_hashes_for_each_target.snap
+++ b/crates/cli/tests/snapshots/run_test__dependencies__generates_unique_hashes_for_each_target.snap
@@ -3,6 +3,6 @@ source: crates/cli/tests/run_test.rs
 expression: "[extract_hash_from_run(sandbox.path(), \"outputs:asDep\"),\n        extract_hash_from_run(sandbox.path(), \"outputs:withDeps\")]"
 ---
 [
-    "ffa8fa180703215c8fe5fa2b113c80fe34c2fc20060dbe03617f1307c7385a66",
-    "dfbc2145142551a608e3bd8e4f8d08b1b0d5e5f9b213a0cc5487f077ae084ae4",
+    "c278cfc0764985a774a74ff43e0c5d8c29e2897844578140d875caed2a30ffae",
+    "ed94e971772a28cb43a88cd92df0927e23af27340e0b35bf8ebba631f7f925fc",
 ]

--- a/crates/cli/tests/snapshots/run_test__dependencies__generates_unique_hashes_for_each_target.snap
+++ b/crates/cli/tests/snapshots/run_test__dependencies__generates_unique_hashes_for_each_target.snap
@@ -3,6 +3,6 @@ source: crates/cli/tests/run_test.rs
 expression: "[extract_hash_from_run(sandbox.path(), \"outputs:asDep\"),\n        extract_hash_from_run(sandbox.path(), \"outputs:withDeps\")]"
 ---
 [
-    "c278cfc0764985a774a74ff43e0c5d8c29e2897844578140d875caed2a30ffae",
-    "ed94e971772a28cb43a88cd92df0927e23af27340e0b35bf8ebba631f7f925fc",
+    "9be09da77eaf86c9f86c138644ca0385ee621eb9a199ea235d8e9b7006122818",
+    "d7c663fab422ad3ef8e5d54e0bfa9307c270fd02848ee736de4cd0d2e4979887",
 ]

--- a/crates/cli/tests/snapshots/run_test__output_styles__hash.snap
+++ b/crates/cli/tests/snapshots/run_test__output_styles__hash.snap
@@ -10,6 +10,6 @@ expression: assert.output()
 Tasks: 2 completed
  Time: 100ms
 
-a7fb2d7f44ced12675dbdc6b184debe93e4658a925c65d94a51128e749d584c2
+477226c56b8f42f69bc5174ebbd231bd7540e4b62053e874ba02c7722a5d5861
 
 

--- a/crates/core/action-pipeline/src/subscribers/local_cache.rs
+++ b/crates/core/action-pipeline/src/subscribers/local_cache.rs
@@ -47,7 +47,12 @@ impl Subscriber for LocalCacheSubscriber {
             } => {
                 let archive_path = workspace.cache.get_hash_archive_path(hash);
 
-                if cache.archive_outputs(&archive_path, &project.root, &task.outputs)? {
+                if cache.archive_outputs(
+                    &archive_path,
+                    &workspace.root,
+                    &project.source,
+                    &task.outputs,
+                )? {
                     return Ok(EventFlow::Return(path::to_string(archive_path)?));
                 }
             }
@@ -62,7 +67,12 @@ impl Subscriber for LocalCacheSubscriber {
             } => {
                 let archive_path = workspace.cache.get_hash_archive_path(hash);
 
-                if cache.hydrate_outputs(&archive_path, &project.root, &task.outputs)? {
+                if cache.hydrate_outputs(
+                    &archive_path,
+                    &workspace.root,
+                    &project.source,
+                    &task.outputs,
+                )? {
                     return Ok(EventFlow::Return(path::to_string(archive_path)?));
                 }
             }

--- a/crates/core/runner/src/target_hasher.rs
+++ b/crates/core/runner/src/target_hasher.rs
@@ -32,11 +32,17 @@ pub struct TargetHasher {
 
     // Task `target`
     target: String,
+
+    // Bump this to invalidate all caches
+    version: String,
 }
 
 impl TargetHasher {
     pub fn new() -> Self {
-        TargetHasher::default()
+        TargetHasher {
+            version: "1".into(),
+            ..TargetHasher::default()
+        }
     }
 
     /// Hash additional args outside of the provided task.
@@ -103,6 +109,7 @@ impl TargetHasher {
 
 impl Hasher for TargetHasher {
     fn hash(&self, sha: &mut Sha256) {
+        sha.update(self.version.as_bytes());
         sha.update(self.command.as_bytes());
         sha.update(self.target.as_bytes());
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where workspace relative `outputs` were not being included in the hashed tarball.
+
 ## 0.25.2
 
 #### 🐞 Fixes

--- a/tests/fixtures/cases/outputs/generate.js
+++ b/tests/fixtures/cases/outputs/generate.js
@@ -2,9 +2,10 @@ const fs = require('fs');
 const path = require('path');
 
 const type = process.argv[2];
+const inWorkspace = process.argv.includes('--workspace');
 
 function createFile(file, content) {
-	const filePath = path.join(__dirname, file);
+	const filePath = path.join(inWorkspace ? process.env.MOON_WORKSPACE_ROOT : __dirname, file);
 
 	fs.mkdirSync(path.dirname(filePath), { recursive: true });
 	fs.writeFileSync(filePath, content ?? String(Date.now()), 'utf8');

--- a/tests/fixtures/cases/outputs/moon.yml
+++ b/tests/fixtures/cases/outputs/moon.yml
@@ -39,6 +39,14 @@ tasks:
     outputs:
       - 'lib/one.js'
       - 'esm'
+  generateFileAndFolderWorkspace:
+    command: node
+    args: generate.js both --workspace
+    inputs:
+      - '*.js'
+    outputs:
+      - '/lib/one.js'
+      - '/esm'
   generateFixed:
     command: node
     args: generate.js custom test.mjs


### PR DESCRIPTION
Embarrassing, but tarballs were completely excluding workspace relative outputs. This was an oversight on my part.

Note to self: I should change paths to a Rust enum so that I properly handle all variations.