### PR TITLE
fix: Move version check back into a thread.

### DIFF
--- a/crates/core/launchpad/src/lib.rs
+++ b/crates/core/launchpad/src/lib.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, SystemTime};
 use uuid::Uuid;
 
 const CURRENT_VERSION_URL: &str = "https://launch.moonrepo.app/versions/cli/current";
-const ALERT_PAUSE_DURATION: Duration = Duration::from_secs(28800); // 8 hours
+const ALERT_PAUSE_DURATION: Duration = Duration::from_secs(43200); // 12 hours
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CurrentVersion {
@@ -63,7 +63,7 @@ pub async fn check_version(
     let check_state_path = moon_dir.join("cache/states/versionCheck.json");
     let now = SystemTime::now();
 
-    // Only check once every 8 hours
+    // Only check once every 12 hours
     if let Ok(file) = fs::read(&check_state_path) {
         let check_state: Result<CheckState, _> = serde_json::from_str(&file);
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fixed an issue where workspace relative `outputs` were not being included in the hashed tarball.
 
+#### ⚙️ Internal
+
+- Reduced new version check to once every 12 hours.
+
 ## 0.25.2
 
 #### 🐞 Fixes


### PR DESCRIPTION
This is causing too much delay at the end of each CLI run.