### PR TITLE
fix: Fix version check inconsistencies.

### DIFF
--- a/crates/cli/src/commands/upgrade.rs
+++ b/crates/cli/src/commands/upgrade.rs
@@ -18,7 +18,7 @@ pub async fn upgrade() -> Result<(), AnyError> {
     }
 
     let version = env!("CARGO_PKG_VERSION");
-    let version_check = check_version(version).await;
+    let version_check = check_version(version, true).await;
 
     let new_version = match version_check {
         Ok((newer_version, _)) if Version::parse(&newer_version)? > Version::parse(version)? => {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -84,7 +84,7 @@ pub async fn run_cli() {
     setup_logging(&args.log, args.log_file);
     setup_caching(&args.cache);
 
-    let version_check = tokio::spawn(check_version(env!("CARGO_PKG_VERSION")));
+    let version_check = tokio::spawn(check_version(env!("CARGO_PKG_VERSION"), false));
 
     // Match and run subcommand
     let result = match args.command {

--- a/crates/core/launchpad/src/lib.rs
+++ b/crates/core/launchpad/src/lib.rs
@@ -48,6 +48,7 @@ fn create_anonymous_rid(workspace_root: &Path) -> String {
 
 pub async fn check_version(
     local_version_str: &str,
+    bypass_cache: bool,
 ) -> Result<(String, bool), Box<dyn Error + Send + Sync>> {
     let moon_dir = fs::find_upwards(
         CONFIG_DIRNAME,
@@ -68,7 +69,7 @@ pub async fn check_version(
         let check_state: Result<CheckState, _> = serde_json::from_str(&file);
 
         if let Ok(state) = check_state {
-            if (state.last_alert + ALERT_PAUSE_DURATION) > now {
+            if (state.last_alert + ALERT_PAUSE_DURATION) > now && !bypass_cache {
                 return Ok((local_version_str.to_owned(), false));
             }
         }

--- a/crates/core/launchpad/src/lib.rs
+++ b/crates/core/launchpad/src/lib.rs
@@ -90,19 +90,16 @@ pub async fn check_version(
     let data: CurrentVersion = serde_json::from_str(&response)?;
     let local_version = Version::parse(local_version_str)?;
     let remote_version = Version::parse(data.current_version.as_str())?;
+    let new_version_available = remote_version > local_version;
 
-    if remote_version > local_version {
-        fs::create_dir_all(check_state_path.parent().unwrap())?;
+    fs::create_dir_all(check_state_path.parent().unwrap())?;
 
-        let check_state = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(&check_state_path)?;
+    let check_state = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(&check_state_path)?;
 
-        serde_json::to_writer(check_state, &CheckState { last_alert: now })?;
+    serde_json::to_writer(check_state, &CheckState { last_alert: now })?;
 
-        return Ok((remote_version.to_string(), true));
-    }
-
-    Ok((remote_version.to_string(), false))
+    Ok((remote_version.to_string(), new_version_available))
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@
 #### 🐞 Fixes
 
 - Fixed an issue where an object `browser` field in `package.json` would fail to parse.
+- Fixed an issue where checking for a new version would constantly run.
+- Fixed an issue where `moon upgrade` would not report a newer available version.
 
 ## 0.25.3
 


### PR DESCRIPTION
Actually fixes 2 things:

- We never write the cache if the same version (oops). This causes the request to always fire.
- The upgrade command would hit the stale cache.