### PR TITLE
new: Integrate `.prototools` and support Windows for proto.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,6 +2915,7 @@ dependencies = [
  "moon_error",
  "moon_logger",
  "moon_platform",
+ "moon_test_utils",
  "moon_utils",
  "moon_vcs",
  "moonbase",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "proto_bun"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3982a86f8f4077751f709b454ca794d60a89b5a329fbea0d01fa4a5b6c37a54b"
+checksum = "5116f7ad8ffa7e85a0ccc430e9d623011584bff6eca9e736eb6a6ee322e14158"
 dependencies = [
  "log",
  "proto_core",
@@ -3512,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "proto_cli"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2aa838ad686d9de5381680156cb98d986c2976844a9645cd6db2d16896cf8c2"
+checksum = "e8da8fef530977d67ef3ac769326eee223c72786ced643ac2d8f0cfe7e894819"
 dependencies = [
  "clap 4.1.4",
  "clap_complete",
@@ -3535,9 +3535,9 @@ dependencies = [
 
 [[package]]
 name = "proto_core"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcc4e593fcd922b98614211a437f8d84a1ceea38526981c5afd8e88be24943d"
+checksum = "b3d136414c2d906a70c0e6e59ab19cf585a6a9fe8f101a00c9935556836ba1bc"
 dependencies = [
  "async-trait",
  "cached",
@@ -3560,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "proto_deno"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ad72c4a06e2ac70f4bd76c66b58f869506bcf8523a38b65f039b439bd86f45"
+checksum = "9eb3ae5ef65ba41f120bd67df7d68056919ea90cfb370db5a2714cb7d82881aa"
 dependencies = [
  "log",
  "proto_core",
@@ -3572,9 +3572,9 @@ dependencies = [
 
 [[package]]
 name = "proto_go"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693e4c67db0e3a2a38e5f4952133d8a6d29f959ffbfa1406b48ca39f485dc573"
+checksum = "b6524ddfddd52612c069f7e9ab536794c722b8eb45033281c2b04b66e72a2318"
 dependencies = [
  "log",
  "proto_core",
@@ -3584,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "proto_node"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501b738a7b77d5610949b3238e7f597460c2791372edb1dc5199c473af2a9572"
+checksum = "1c3973d1a23fef2ff15b4dd68e0d272ea620c1c12dbbab0dd91cb824bc6ec2a0"
 dependencies = [
  "clean-path",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,6 +2307,7 @@ dependencies = [
  "moon_error",
  "moon_test_utils",
  "moon_utils",
+ "proto_cli",
  "reqwest",
  "rustc-hash",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ console = "0.15.5"
 criterion = { version = "0.4.0", features = ["async_tokio"] }
 lazy_static = "1.4.0"
 petgraph = { version = "0.6.3", features = ["serde-1"] }
-proto_cli = "0.1.8"
+proto_cli = "0.1.9"
 reqwest = "0.11.14"
 rustc-hash = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/crates/cli/tests/snapshots/run_node_test__handles_process_exit_code_nonzero.snap
+++ b/crates/cli/tests/snapshots/run_node_test__handles_process_exit_code_nonzero.snap
@@ -9,9 +9,7 @@ This should appear!
 ▪▪▪▪ node:exitCodeNonZero (100ms)
 stderr
 
- ERROR 
-
-Process ~/.proto/tools/node/18.0.0/shims/node failed with a 1 exit code.
+ ERROR  Process ~/.proto/tools/node/18.0.0/bin/node failed with a 1 exit code.
 
 
 

--- a/crates/cli/tests/snapshots/run_node_test__handles_process_exit_nonzero.snap
+++ b/crates/cli/tests/snapshots/run_node_test__handles_process_exit_nonzero.snap
@@ -8,9 +8,7 @@ stdout
 ▪▪▪▪ node:processExitNonZero (100ms)
 stderr
 
- ERROR 
-
-Process ~/.proto/tools/node/18.0.0/shims/node failed with a 1 exit code.
+ ERROR  Process ~/.proto/tools/node/18.0.0/bin/node failed with a 1 exit code.
 
 
 

--- a/crates/cli/tests/snapshots/run_node_test__handles_unhandled_promise.snap
+++ b/crates/cli/tests/snapshots/run_node_test__handles_unhandled_promise.snap
@@ -17,9 +17,7 @@ node:internal/process/promises:288
 
 Node.js v18.0.0
 
- ERROR 
-
-Process ~/.proto/tools/node/18.0.0/shims/node failed with a 1 exit code.
+ ERROR  Process ~/.proto/tools/node/18.0.0/bin/node failed with a 1 exit code.
 
 
 

--- a/crates/cli/tests/snapshots/run_test__output_styles__buffer_on_failure_when_failure.snap
+++ b/crates/cli/tests/snapshots/run_test__output_styles__buffer_on_failure_when_failure.snap
@@ -10,9 +10,7 @@ stdout
 stderr
 
 
- ERROR 
-
-Process ~/.proto/tools/node/18.0.0/shims/node failed with a 1 exit code.
+ ERROR  Process ~/.proto/tools/node/18.0.0/bin/node failed with a 1 exit code.
 
 
 

--- a/crates/core/config/Cargo.toml
+++ b/crates/core/config/Cargo.toml
@@ -17,6 +17,7 @@ moon_constants = { path = "../constants" }
 moon_error = { path = "../error" }
 moon_utils = { path = "../utils" }
 figment = { version = "0.10.8", features = ["test", "yaml"] }
+proto_cli = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "native-tls-vendored"] }
 rustc-hash = { workspace = true }
 schemars = "0.8.11"

--- a/crates/core/config/tests/toolchain_test.rs
+++ b/crates/core/config/tests/toolchain_test.rs
@@ -2,10 +2,11 @@ use httpmock::prelude::*;
 use moon_config::{ConfigError, NodeConfig, ToolchainConfig};
 use moon_constants::CONFIG_TOOLCHAIN_FILENAME;
 use moon_test_utils::get_fixtures_path;
+use proto::Config as ProtoTools;
 use std::path::Path;
 
 fn load_jailed_config(root: &Path) -> Result<ToolchainConfig, figment::Error> {
-    match ToolchainConfig::load(root.join(CONFIG_TOOLCHAIN_FILENAME)) {
+    match ToolchainConfig::load(root.join(CONFIG_TOOLCHAIN_FILENAME), &ProtoTools::default()) {
         Ok(cfg) => Ok(cfg),
         Err(err) => Err(match err {
             ConfigError::FailedValidation(errors) => errors.first().unwrap().to_owned(),
@@ -46,7 +47,8 @@ mod extends {
     #[test]
     fn recursive_merges() {
         let fixture = get_fixtures_path("config-extends/toolchain");
-        let config = ToolchainConfig::load(fixture.join("base-2.yml")).unwrap();
+        let config =
+            ToolchainConfig::load(fixture.join("base-2.yml"), &ProtoTools::default()).unwrap();
 
         assert_eq!(
             config,
@@ -70,7 +72,9 @@ mod extends {
     #[test]
     fn recursive_merges_typescript() {
         let fixture = get_fixtures_path("config-extends/toolchain");
-        let config = ToolchainConfig::load(fixture.join("typescript-2.yml")).unwrap();
+        let config =
+            ToolchainConfig::load(fixture.join("typescript-2.yml"), &ProtoTools::default())
+                .unwrap();
 
         assert_eq!(
             config.typescript,

--- a/crates/core/workspace/Cargo.toml
+++ b/crates/core/workspace/Cargo.toml
@@ -16,3 +16,6 @@ moon_vcs = { path = "../vcs" }
 proto_cli = { workspace = true }
 reqwest = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+moon_test_utils = { path = "../test-utils" }

--- a/crates/core/workspace/tests/workspace_test.rs
+++ b/crates/core/workspace/tests/workspace_test.rs
@@ -1,0 +1,29 @@
+use moon_test_utils::{assert_fs::prelude::*, create_sandbox_with_config};
+use moon_workspace::Workspace;
+use proto::ToolType;
+
+#[test]
+fn loads_proto_tools() {
+    let temp = create_sandbox_with_config("base", None, None, None);
+
+    temp.fixture
+        .child(".prototools")
+        .write_str(
+            r#"
+node = "18.0.0"
+npm = "9.0.0"
+"#,
+        )
+        .unwrap();
+
+    let workspace = Workspace::load_from(temp.path()).unwrap();
+
+    assert_eq!(
+        workspace.proto_tools.tools.get(&ToolType::Node).unwrap(),
+        "18.0.0"
+    );
+    assert_eq!(
+        workspace.proto_tools.tools.get(&ToolType::Npm).unwrap(),
+        "9.0.0"
+    );
+}

--- a/crates/node/tool/src/node_tool.rs
+++ b/crates/node/tool/src/node_tool.rs
@@ -9,8 +9,7 @@ use moon_terminal::{print_checkpoint, Checkpoint};
 use moon_tool::{get_path_env_var, DependencyManager, Tool, ToolError};
 use moon_utils::process::Command;
 use proto::{
-    async_trait, node::NodeLanguage, Describable, Executable, Installable, Proto, Shimable,
-    Tool as ProtoTool,
+    async_trait, node::NodeLanguage, Describable, Executable, Installable, Proto, Tool as ProtoTool,
 };
 use rustc_hash::FxHashMap;
 use std::path::{Path, PathBuf};
@@ -154,10 +153,6 @@ impl Tool for NodeTool {
         } else {
             self.tool.get_bin_path()?.to_path_buf()
         })
-    }
-
-    fn get_shim_path(&self) -> Option<PathBuf> {
-        self.tool.get_shim_path().map(|p| p.to_path_buf())
     }
 
     async fn setup(

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added a `moon docker setup` command for efficiently installing project dependencies.
 - Updated moon's toolchain to build upon [proto](https://github.com/moonrepo/proto), our new
   toolchain layer.
+- Updated our toolchain and configuration to take `.prototools` into account.
 
 ## 0.25.4
 

--- a/website/blog/2023-03-13_v0.26.mdx
+++ b/website/blog/2023-03-13_v0.26.mdx
@@ -31,6 +31,15 @@ crates. For the most part, everything will continue to work the same. However, t
 that the toolchain has moved from `~/.moon` to `~/.proto`, and will result in tools being
 re-downloaded and installed. Feel free to delete the old `~/.moon` directory manually.
 
+Furthermore, we've added first-class support for the new [`.prototools`](/docs/proto/config)
+configuration file. If this file is found in the workspace root, we'll automatically enable the
+tools in our toolchain, and inject the versions (when not defined in `.moon/toolchain.yml`).
+
+```toml title=".prototools"
+node = "18.0.0"
+pnpm = "7.29.0"
+```
+
 ## New `moon docker setup` command
 
 moon has provided [built-in `Dockerfile` support](/docs/guides/docker) since v0.15 (11 versions

--- a/website/docs/config/toolchain.mdx
+++ b/website/docs/config/toolchain.mdx
@@ -92,7 +92,8 @@ node:
   version: '16.13.0'
 ```
 
-> Version can be overridden with the `MOON_NODE_VERSION` environment variable.
+> Version can also be defined with [`.prototools`](../proto/config) or be overridden with the
+> `MOON_NODE_VERSION` environment variable.
 
 ### `packageManager`
 
@@ -127,8 +128,8 @@ node:
     version: '3.1.0'
 ```
 
-> Version can be overridden with the `MOON_NPM_VERSION`, `MOON_PNPM_VERSION`, or `MOON_YARN_VERSION`
-> environment variables.
+> Version can also be defined with [`.prototools`](../proto/config) or be overridden with the
+> `MOON_NPM_VERSION`, `MOON_PNPM_VERSION`, or `MOON_YARN_VERSION` environment variables.
 
 ### `yarn`
 

--- a/website/docs/guides/javascript/deno-handbook.mdx
+++ b/website/docs/guides/javascript/deno-handbook.mdx
@@ -35,6 +35,12 @@ deno:
 	lockfile: true
 ```
 
+Or by pinning a `deno` version in [`.prototools`](../../proto/config) in the workspace root.
+
+```toml title=".prototools"
+deno = "1.31.0"
+```
+
 This will enable the Deno platform and provide the following automations around its ecosystem:
 
 - Automatic handling and caching of lockfiles (when the setting is enabled).

--- a/website/docs/guides/javascript/node-handbook.mdx
+++ b/website/docs/guides/javascript/node-handbook.mdx
@@ -40,6 +40,7 @@ Or by pinning a `node` version in [`.prototools`](../../proto/config) in the wor
 
 ```toml title=".prototools"
 node = "18.0.0"
+pnpm = "7.29.0"
 ```
 
 This will enable the Node.js platform and provide the following automations around its ecosystem:
@@ -74,6 +75,8 @@ setting.
 node:
 	version: '18.0.0'
 ```
+
+> Versions can also be defined with [`.prototools`](../../proto/config).
 
 ### Using `package.json` names and scripts
 

--- a/website/docs/guides/javascript/node-handbook.mdx
+++ b/website/docs/guides/javascript/node-handbook.mdx
@@ -36,6 +36,12 @@ node:
 	packageManager: 'pnpm'
 ```
 
+Or by pinning a `node` version in [`.prototools`](../../proto/config) in the workspace root.
+
+```toml title=".prototools"
+node = "18.0.0"
+```
+
 This will enable the Node.js platform and provide the following automations around its ecosystem:
 
 - Node modules will automatically be installed if dependencies in `package.json` have changed, or

--- a/website/docs/proto/config.mdx
+++ b/website/docs/proto/config.mdx
@@ -14,7 +14,7 @@ This configuration simply maps tools to semantic versions for the current direct
 [TOML](https://toml.io/en/), which is pretty straight forward if you've never used it before, for
 example:
 
-```toml title="<project>/.prototools"
+```toml title=".prototools"
 node = "16.16.0"
 npm = "9.0.0"
 go = "1.20"

--- a/website/docs/proto/index.mdx
+++ b/website/docs/proto/index.mdx
@@ -92,7 +92,6 @@ are currently:
 
 ## Roadmap
 
-- Windows shim support.
 - Linux ARM/musl support.
 - Custom version aliasing.
 - Build from source for existing languages.

--- a/website/docs/proto/install.mdx
+++ b/website/docs/proto/install.mdx
@@ -24,11 +24,13 @@ curl -fsSL https://moonrepo.dev/install/proto.sh | bash
 
 ### Windows
 
-:::caution
+In Powershell or Windows Terminal, run:
 
-Windows is blocked until we finalize better shim support. If you'd like to help, join us on Discord!
+```
+irm https://moonrepo.dev/install/proto.ps1 | iex
+```
 
-:::
+> Windows support is currently experimental. Please report any issues!
 
 ### Other
 
@@ -40,3 +42,7 @@ rename the file after downloading, and apply the executable bit (`chmod +x`) on 
 
 We provide no formal mechanism for upgrading the proto binary. However, you can re-run the install
 scripts above and it will download, install, and overwrite with the latest version.
+
+## Uninstalling
+
+To uninstall proto, delete the `~/.proto` directory.

--- a/website/src/components/Products/Proto/HeroTerminal.tsx
+++ b/website/src/components/Products/Proto/HeroTerminal.tsx
@@ -9,7 +9,10 @@ function random(min: number, max: number) {
 }
 
 export default function HeroTerminal() {
-	const isWindows = window.navigator.userAgent.toLowerCase().includes('win');
+	const isWindows =
+		typeof window === 'undefined'
+			? false
+			: window.navigator.userAgent.toLowerCase().includes('win');
 	const lang = LANGS[random(0, LANGS.length)] || LANGS[0];
 
 	return (

--- a/website/src/components/Products/Proto/HeroTerminal.tsx
+++ b/website/src/components/Products/Proto/HeroTerminal.tsx
@@ -9,6 +9,7 @@ function random(min: number, max: number) {
 }
 
 export default function HeroTerminal() {
+	const isWindows = window.navigator.userAgent.toLowerCase().includes('win');
 	const lang = LANGS[random(0, LANGS.length)] || LANGS[0];
 
 	return (
@@ -17,30 +18,34 @@ export default function HeroTerminal() {
 			style={{ height: 230 }}
 		>
 			<li className="text-gray-800"># Install proto</li>
-			<li>curl -fsSL https://moonrepo.dev/install/proto.sh | bash</li>
+			<li>
+				{isWindows
+					? 'irm https://moonrepo.dev/install/proto.ps1 | iex'
+					: 'curl -fsSL https://moonrepo.dev/install/proto.sh | bash'}
+			</li>
 
 			{lang === 'bun' && (
-				<>
+				<React.Fragment key="bun">
 					<li className="text-gray-800 pt-2"># Install Bun</li>
 					<li>proto install bun 0.5</li>
 
 					<li className="text-gray-800 pt-2"># Use immediately</li>
 					<li>bun run index.ts</li>
-				</>
+				</React.Fragment>
 			)}
 
 			{lang === 'deno' && (
-				<>
+				<React.Fragment key="deno">
 					<li className="text-gray-800 pt-2"># Install Deno</li>
 					<li>proto install deno 1.31</li>
 
 					<li className="text-gray-800 pt-2"># Use immediately</li>
 					<li>deno run index.ts</li>
-				</>
+				</React.Fragment>
 			)}
 
 			{lang === 'node' && (
-				<>
+				<React.Fragment key="node">
 					<li className="text-gray-800 pt-2"># Install Node.js</li>
 					<li>proto install node 18</li>
 					<li>proto install pnpm</li>
@@ -48,17 +53,17 @@ export default function HeroTerminal() {
 					<li className="text-gray-800 pt-2"># Use immediately</li>
 					<li>pnpm install</li>
 					<li>pnpm run dev</li>
-				</>
+				</React.Fragment>
 			)}
 
 			{lang === 'go' && (
-				<>
+				<React.Fragment key="go">
 					<li className="text-gray-800 pt-2"># Install Go</li>
 					<li>proto install go 1.20</li>
 
 					<li className="text-gray-800 pt-2"># Use immediately</li>
 					<li>go run .</li>
-				</>
+				</React.Fragment>
 			)}
 		</ul>
 	);

--- a/website/src/pages/proto.tsx
+++ b/website/src/pages/proto.tsx
@@ -63,12 +63,17 @@ export default function ProductProto() {
 										</Heading>
 
 										<Text className="mb-1">Install proto for Linux, macOS, or WSL:</Text>
-										<Text className="mb-2" variant="muted">
-											Windows support coming soon!
-										</Text>
 
 										<CodeBlock language="shell">
 											{'curl -fsSL https://moonrepo.dev/install/proto.sh | bash'}
+										</CodeBlock>
+
+										<Text className="mb-1" variant="muted">
+											Or Windows:
+										</Text>
+
+										<CodeBlock language="shell">
+											{'irm https://moonrepo.dev/install/proto.ps1 | iex'}
 										</CodeBlock>
 
 										<Heading level={4} className="mt-4 mb-2">

--- a/website/static/install/proto.ps1
+++ b/website/static/install/proto.ps1
@@ -6,7 +6,7 @@
 
 $ErrorActionPreference = 'Stop'
 
-$Version = "0.1.8" # TODO
+$Version = "0.1.9" # TODO
 
 if ($Args.Length -eq 1) {
   $Version = $Args.Get(0)

--- a/website/static/install/proto.sh
+++ b/website/static/install/proto.sh
@@ -8,7 +8,7 @@ set -e
 
 bin="proto"
 arch=$(uname -sm)
-version="${1:-0.1.8}" # TODO
+version="${1:-0.1.9}" # TODO
 ext=".tar.xz"
 
 if [ "$OS" = "Windows_NT" ]; then

--- a/website/static/schemas/project.json
+++ b/website/static/schemas/project.json
@@ -113,18 +113,34 @@
       ]
     },
     "ProjectLanguage": {
-      "type": "string",
-      "enum": [
-        "bash",
-        "batch",
-        "go",
-        "javascript",
-        "php",
-        "python",
-        "ruby",
-        "rust",
-        "typescript",
-        "unknown"
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "bash",
+            "batch",
+            "go",
+            "javascript",
+            "php",
+            "python",
+            "ruby",
+            "rust",
+            "typescript",
+            "unknown"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "other"
+          ],
+          "properties": {
+            "other": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
       ]
     },
     "ProjectMetadataConfig": {

--- a/website/static/schemas/toolchain.json
+++ b/website/static/schemas/toolchain.json
@@ -4,6 +4,16 @@
   "description": "Docs: https://moonrepo.dev/docs/config/toolchain",
   "type": "object",
   "properties": {
+    "deno": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DenoConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "extends": {
       "type": [
         "string",
@@ -32,6 +42,18 @@
     }
   },
   "definitions": {
+    "DenoConfig": {
+      "type": "object",
+      "properties": {
+        "depsFile": {
+          "default": "deps.ts",
+          "type": "string"
+        },
+        "lockfile": {
+          "type": "boolean"
+        }
+      }
+    },
     "NodeConfig": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
When this config file is found, it'll enable the tools in the toolchain, and inject the versions.