### PR TITLE
fix: Fix missing visualizer assets.

### DIFF
--- a/.yarn/versions/bd3ba277.yml
+++ b/.yarn/versions/bd3ba277.yml
@@ -1,0 +1,2 @@
+releases:
+  "@moonrepo/visualizer": patch

--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -20,6 +20,9 @@
   "files": [
     "dist"
   ],
+  "scripts": {
+    "build": "vite build"
+  },
   "dependencies": {
     "cytoscape": "^3.23.0",
     "cytoscape-dagre": "^2.5.0",

--- a/scripts/release/buildPackages.sh
+++ b/scripts/release/buildPackages.sh
@@ -9,3 +9,6 @@ yarn packemon build-workspace --filter @moonrepo/types $args
 
 # Then just build everything
 yarn packemon build-workspace $args
+
+# Then build the visualizer with vite
+yarn workspace @moonrepo/visualizer run build


### PR DESCRIPTION
Looks like dist folder is missing upstream: https://unpkg.com/browse/@moonrepo/visualizer@0.1.2/

After we migrated to packemon, we forgot to build the visualizer with vite.