### PR TITLE
new: Fail when a task generates or references an empty/missing hash.

### DIFF
--- a/crates/core/action-pipeline/src/actions/run_target.rs
+++ b/crates/core/action-pipeline/src/actions/run_target.rs
@@ -48,6 +48,14 @@ pub async fn run_target(
         runner.print_checkpoint(Checkpoint::RunPassed, &["no op"])?;
         runner.flush_output()?;
 
+        // We must give this task a fake hash for it to be
+        // considered complete for other tasks!
+        context
+            .write()
+            .await
+            .target_hashes
+            .insert(task.target.id.clone(), "noop".into());
+
         return Ok(ActionStatus::Passed);
     }
 

--- a/crates/core/runner/src/errors.rs
+++ b/crates/core/runner/src/errors.rs
@@ -9,6 +9,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum RunnerError {
+    #[error("Encountered an empty hash for target <target>{0}</target>, which is a dependency of <target>{1}</target>. This either means the dependency hasn't ran, has failed, or there's a misconfiguration.")]
+    EmptyDependencyHash(String, String),
+
     #[error(transparent)]
     Glob(#[from] GlobError),
 

--- a/crates/core/runner/src/runner.rs
+++ b/crates/core/runner/src/runner.rs
@@ -194,7 +194,7 @@ impl<'a> Runner<'a> {
 
         hasher.hash_project_deps(self.project.get_dependency_ids());
         hasher.hash_task(task);
-        hasher.hash_task_deps(task, &context.target_hashes);
+        hasher.hash_task_deps(task, &context.target_hashes)?;
 
         if context.should_inherit_args(&task.target) {
             hasher.hash_args(&context.passthrough_args);

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Toolchain has been moved to `~/.proto` from `~/.moon`. This should be a transparent change but at
   minimum your tools will be re-downloaded and installed. Feel free to delete the old tools
   manually!
+- Targets that generate an empty hash are now considered a failure, as they may be an edge case not
+  accounted for.
 
 #### 🚀 Updates
 


### PR DESCRIPTION
An empty hash typically means something has gone wrong, and we should bubble this up to the user instead of silently continuing.