### PR TITLE
fix: Fix dependencies of affected targets not being ran.

### DIFF
--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -1232,6 +1232,28 @@ mod affected {
     }
 
     #[test]
+    fn runs_if_not_affected_but_a_dep_of_an_affected() {
+        let sandbox = cases_sandbox();
+        sandbox.enable_git();
+
+        sandbox.create_file("affected/primary.js", "");
+
+        let assert = sandbox.run_moon(|cmd| {
+            cmd.arg("run")
+                .arg("affected:primaryWithDeps")
+                .arg("--affected");
+        });
+
+        assert.debug();
+
+        let output = assert.output();
+
+        assert!(predicate::str::contains("affected:dep").eval(&output));
+        assert!(predicate::str::contains("affected:primaryWithDeps").eval(&output));
+        assert!(predicate::str::contains("Tasks: 2 completed").eval(&output));
+    }
+
+    #[test]
     fn runs_if_affected_by_multi_status() {
         let sandbox = cases_sandbox();
         sandbox.enable_git();

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -1244,8 +1244,6 @@ mod affected {
                 .arg("--affected");
         });
 
-        assert.debug();
-
         let output = assert.output();
 
         assert!(predicate::str::contains("affected:dep").eval(&output));

--- a/crates/core/dep-graph/src/dep_builder.rs
+++ b/crates/core/dep-graph/src/dep_builder.rs
@@ -288,7 +288,9 @@ impl<'ws> DepGraphBuilder<'ws> {
                 color::target(target),
             );
 
-            for dep_index in self.run_target_task_dependencies(task, touched_files)? {
+            // We don't pass touched files to dependencies, because if the parent
+            // task is affected/going to run, then so should all of these!
+            for dep_index in self.run_target_task_dependencies(task, None)? {
                 self.graph.add_edge(index, dep_index, ());
             }
         }

--- a/crates/core/dep-graph/src/dep_builder.rs
+++ b/crates/core/dep-graph/src/dep_builder.rs
@@ -125,9 +125,8 @@ impl<'ws> DepGraphBuilder<'ws> {
 
         trace!(
             target: LOG_TARGET,
-            "Adding install {} dependencies (in project {}) to graph",
-            runtime.label(),
-            color::id(project_id)
+            "Adding {} to graph",
+            color::muted(node.label())
         );
 
         // Before we install deps, we must ensure the language has been installed
@@ -148,8 +147,8 @@ impl<'ws> DepGraphBuilder<'ws> {
 
         trace!(
             target: LOG_TARGET,
-            "Adding install {} dependencies (in workspace) to graph",
-            runtime.label()
+            "Adding {} to graph",
+            color::muted(node.label())
         );
 
         // Before we install deps, we must ensure the language has been installed
@@ -268,8 +267,8 @@ impl<'ws> DepGraphBuilder<'ws> {
 
         trace!(
             target: LOG_TARGET,
-            "Adding run target {} to graph",
-            color::target(&target.id),
+            "Adding {} to graph",
+            color::muted(node.label())
         );
 
         // We should install deps & sync projects *before* running targets
@@ -355,8 +354,8 @@ impl<'ws> DepGraphBuilder<'ws> {
 
         trace!(
             target: LOG_TARGET,
-            "Adding setup {} tool to graph",
-            runtime.label()
+            "Adding {} to graph",
+            color::muted(node.label())
         );
 
         self.insert_node(&node)
@@ -372,8 +371,8 @@ impl<'ws> DepGraphBuilder<'ws> {
 
         trace!(
             target: LOG_TARGET,
-            "Adding sync project {} to graph",
-            color::id(&project.id),
+            "Adding {} to graph",
+            color::muted(node.label())
         );
 
         // Syncing depends on the language's tool to be installed

--- a/crates/core/test-utils/src/configs.rs
+++ b/crates/core/test-utils/src/configs.rs
@@ -35,6 +35,7 @@ pub fn get_cases_fixture_configs() -> (WorkspaceConfig, ToolchainConfig, Inherit
     let workspace_config = WorkspaceConfig {
         projects: WorkspaceProjects::Sources(FxHashMap::from_iter([
             ("root".to_owned(), ".".to_owned()),
+            ("affected".to_owned(), "affected".to_owned()),
             ("base".to_owned(), "base".to_owned()),
             ("noop".to_owned(), "noop".to_owned()),
             ("files".to_owned(), "files".to_owned()),

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 #### 💥 Breaking
 
-- Toolchain has been moved to `~/.proto` from `~/.moon`. This should be a transparent change but at
-  minimum your tools will be re-downloaded and installed. Feel free to delete the old tools
-  manually!
+- Toolchain has been moved to `~/.proto` from `~/.moon`. This should be a transparent change, but at
+  minimum your tools will be re-downloaded and installed.
 - Targets that generate an empty hash are now considered a failure, as they may be an edge case not
   accounted for.
 
@@ -20,6 +19,7 @@
 #### 🐞 Fixes
 
 - Fixed hashing to avoid including `git status` files when running in CI.
+- Fixed an issue where dependencies of an affected target were not always being ran.
 
 ## 0.25.4
 

--- a/tests/fixtures/cases/affected/affected.js
+++ b/tests/fixtures/cases/affected/affected.js
@@ -1,0 +1,1 @@
+console.log(process.env.MOON_AFFECTED_FILES);

--- a/tests/fixtures/cases/affected/moon.yml
+++ b/tests/fixtures/cases/affected/moon.yml
@@ -1,0 +1,20 @@
+tasks:
+  noop:
+    command: noop
+  dep:
+    command: node ./affected.js
+    platform: node
+    inputs:
+      - 'dep.*'
+  primary:
+    command: node ./affected.js
+    platform: node
+    inputs:
+      - 'primary.*'
+  primaryWithDeps:
+    command: node ./affected.js
+    platform: node
+    inputs:
+      - 'primary.*'
+    deps:
+      - '~:dep'


### PR DESCRIPTION
If A depends on B, and A is affected (via `--affected`), we should always run B. However, we were only running B if it was also affected, triggering an invalid state.