### PR TITLE
fix: Filter out gitignored projects while globbing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,6 +2680,7 @@ dependencies = [
  "moon_task",
  "moon_test_utils",
  "moon_utils",
+ "moon_vcs",
  "moon_workspace",
  "petgraph",
  "rustc-hash",

--- a/crates/cli/src/commands/init/node.rs
+++ b/crates/cli/src/commands/init/node.rs
@@ -140,7 +140,7 @@ fn detect_projects(
             if index == 1 {
                 project_globs.extend(globs);
             } else if index == 2 {
-                detect_projects_with_globs(dest_dir, &globs, &mut projects)?;
+                detect_projects_with_globs(dest_dir, &globs, &mut projects, None)?;
             }
         }
     }

--- a/crates/core/project-graph/Cargo.toml
+++ b/crates/core/project-graph/Cargo.toml
@@ -20,6 +20,7 @@ moon_project = { path = "../project" }
 moon_target = { path = "../target" }
 moon_task = { path = "../task" }
 moon_utils = { path = "../utils" }
+moon_vcs = { path = "../vcs" }
 moon_workspace = { path = "../workspace" }
 dotenvy = "0.15.6"
 petgraph = {  workspace = true, features = ["serde"] }

--- a/crates/core/project-graph/src/helpers.rs
+++ b/crates/core/project-graph/src/helpers.rs
@@ -21,10 +21,10 @@ pub fn infer_project_name_and_source(source: &str) -> (String, String) {
 /// for potential projects, and infer their name and source.
 #[track_caller]
 pub fn detect_projects_with_globs(
-    vcs: &BoxedVcs,
     workspace_root: &Path,
     globs: &[String],
     projects: &mut ProjectsSourcesMap,
+    vcs: Option<&BoxedVcs>,
 ) -> Result<(), ProjectGraphError> {
     let root_source = ".".to_owned();
 
@@ -48,14 +48,16 @@ pub fn detect_projects_with_globs(
             let project_source =
                 path::to_virtual_string(project_root.strip_prefix(workspace_root).unwrap())?;
 
-            if vcs.is_ignored(&project_source) {
-                debug!(
-                    target: "moon:project",
-                    "Found a project with source {}, but this path has been ignored by your VCS. Skipping ignored source.",
-                    color::file(&project_source)
-                );
+            if let Some(vcs) = vcs {
+                if vcs.is_ignored(&project_source) {
+                    debug!(
+                        target: "moon:project",
+                        "Found a project with source {}, but this path has been ignored by your VCS. Skipping ignored source.",
+                        color::file(&project_source)
+                    );
 
-                continue;
+                    continue;
+                }
             }
 
             let (id, source) = infer_project_name_and_source(&project_source);

--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -498,7 +498,12 @@ impl<'ws> ProjectGraphBuilder<'ws> {
                 map_list(&globs, |g| color::file(g))
             );
 
-            detect_projects_with_globs(&self.workspace.root, &globs, &mut sources)?;
+            detect_projects_with_globs(
+                &self.workspace.vcs,
+                &self.workspace.root,
+                &globs,
+                &mut sources,
+            )?;
 
             cache.last_glob_time = time::now_millis();
         }

--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -499,10 +499,10 @@ impl<'ws> ProjectGraphBuilder<'ws> {
             );
 
             detect_projects_with_globs(
-                &self.workspace.vcs,
                 &self.workspace.root,
                 &globs,
                 &mut sources,
+                Some(&self.workspace.vcs),
             )?;
 
             cache.last_glob_time = time::now_millis();

--- a/crates/core/runner/src/inputs_collector.rs
+++ b/crates/core/runner/src/inputs_collector.rs
@@ -3,7 +3,7 @@ use moon_config::CONFIG_PROJECT_FILENAME;
 use moon_hasher::convert_paths_to_strings;
 use moon_task::Task;
 use moon_utils::{glob, is_ci, path};
-use moon_vcs::Vcs;
+use moon_vcs::BoxedVcs;
 use rustc_hash::FxHashSet;
 use std::{collections::BTreeMap, path::Path};
 
@@ -43,7 +43,7 @@ fn is_valid_input_source(
 // and moon specific configuration files!
 #[allow(clippy::borrowed_box)]
 pub async fn collect_and_hash_inputs(
-    vcs: &Box<dyn Vcs + Send + Sync>,
+    vcs: &BoxedVcs,
     task: &Task,
     project_source: &str,
     workspace_root: &Path,

--- a/crates/core/vcs/src/git.rs
+++ b/crates/core/vcs/src/git.rs
@@ -113,18 +113,6 @@ impl Git {
         Ok(base.to_owned())
     }
 
-    fn is_file_ignored(&self, file: &str) -> bool {
-        if self.ignore.is_some() {
-            self.ignore
-                .as_ref()
-                .unwrap()
-                .matched(file, false)
-                .is_ignore()
-        } else {
-            false
-        }
-    }
-
     async fn run_command(&self, mut command: Command, trim: bool) -> VcsResult<String> {
         let mut cache = self.cache.write().await;
         let (mut cache_key, _) = command.get_command_line();
@@ -204,9 +192,7 @@ impl Vcs for Git {
             let abs_file = self.root.join(file);
 
             // File must exists or git fails
-            if abs_file.exists()
-                && abs_file.is_file()
-                && (allow_ignored || !self.is_file_ignored(file))
+            if abs_file.exists() && abs_file.is_file() && (allow_ignored || !self.is_ignored(file))
             {
                 objects.push(file.clone());
             }
@@ -502,5 +488,17 @@ impl Vcs for Git {
 
     fn is_enabled(&self) -> bool {
         self.root.join(".git").exists()
+    }
+
+    fn is_ignored(&self, file: &str) -> bool {
+        if self.ignore.is_some() {
+            self.ignore
+                .as_ref()
+                .unwrap()
+                .matched(file, false)
+                .is_ignore()
+        } else {
+            false
+        }
     }
 }

--- a/crates/core/vcs/src/lib.rs
+++ b/crates/core/vcs/src/lib.rs
@@ -13,6 +13,8 @@ pub use loader::*;
 pub use svn::Svn;
 pub use vcs::*;
 
+pub type BoxedVcs = Box<dyn Vcs + Send + Sync + 'static>;
+
 /// Detect the version control system being used and the current branch
 pub async fn detect_vcs(
     dest_dir: &Path,

--- a/crates/core/vcs/src/loader.rs
+++ b/crates/core/vcs/src/loader.rs
@@ -1,7 +1,7 @@
 use crate::errors::VcsError;
 use crate::git::Git;
 use crate::svn::Svn;
-use crate::vcs::Vcs;
+use crate::BoxedVcs;
 use moon_config::{VcsManager, WorkspaceConfig};
 use std::path::Path;
 
@@ -11,7 +11,7 @@ impl VcsLoader {
     pub fn load(
         working_dir: &Path,
         workspace_config: &WorkspaceConfig,
-    ) -> Result<Box<dyn Vcs + Send + Sync>, VcsError> {
+    ) -> Result<BoxedVcs, VcsError> {
         let vcs_config = &workspace_config.vcs;
 
         Ok(match vcs_config.manager {

--- a/crates/core/vcs/src/svn.rs
+++ b/crates/core/vcs/src/svn.rs
@@ -279,4 +279,8 @@ impl Vcs for Svn {
     fn is_enabled(&self) -> bool {
         self.root.join(".svn").exists()
     }
+
+    fn is_ignored(&self, _file: &str) -> bool {
+        false
+    }
 }

--- a/crates/core/vcs/src/vcs.rs
+++ b/crates/core/vcs/src/vcs.rs
@@ -73,4 +73,7 @@ pub trait Vcs {
 
     /// Return true if the repo is currently VCS enabled.
     fn is_enabled(&self) -> bool;
+
+    /// Return true if the provided file path has been ignored.
+    fn is_ignored(&self, file: &str) -> bool;
 }

--- a/crates/core/workspace/src/workspace.rs
+++ b/crates/core/workspace/src/workspace.rs
@@ -8,7 +8,7 @@ use moon_constants as constants;
 use moon_logger::{color, debug, trace};
 use moon_platform::{BoxedPlatform, PlatformManager};
 use moon_utils::{fs, glob, semver};
-use moon_vcs::{Vcs, VcsLoader};
+use moon_vcs::{BoxedVcs, VcsLoader};
 use moonbase::Moonbase;
 use proto::{get_root, Config as ProtoTools, CONFIG_NAME};
 use std::env;
@@ -194,7 +194,7 @@ pub struct Workspace {
     pub toolchain_root: PathBuf,
 
     /// Configured version control system.
-    pub vcs: Box<dyn Vcs + Send + Sync>,
+    pub vcs: BoxedVcs,
 
     /// The current working directory.
     pub working_dir: PathBuf,

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Fixed hashing to avoid including `git status` files when running in CI.
 - Fixed an issue where dependencies of an affected target were not always being ran.
+- Fixed an issue where gitignored folders were being considered projects if the globs matched.
 
 ## 0.25.4
 

--- a/website/blog/2023-03-13_v0.26.mdx
+++ b/website/blog/2023-03-13_v0.26.mdx
@@ -92,7 +92,8 @@ View the
 [official release](https://github.com/moonrepo/moon/releases/tag/%40moonrepo%2Fcli%400.26.0) for a
 full list of changes.
 
-- ???
+- Targets that generate an empty hash are now considered a failure, as they may be an edge case not
+  accounted for.
 
 ## What's next?
 


### PR DESCRIPTION
Because git leaves ignored artifacts around when switching branches, there's a possibility of these ignored paths being considered a project source while globbing, causing issues.

This simply filters out any ignored paths while globbing for projects.