### PR TITLE
new: Add `moon query hash-diff` command.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,6 +2332,7 @@ dependencies = [
  "clap_lex 0.3.2",
  "console",
  "dialoguer",
+ "diff",
  "futures-util",
  "httpmock",
  "indicatif",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -49,6 +49,7 @@ clap_lex = "0.3.0"
 console = { workspace = true }
 # console-subscriber = "0.1.8"
 dialoguer = "0.10.2"
+diff = "0.1.13"
 futures-util = "0.3.26"
 indicatif = "0.17.2"
 itertools = "0.10.5"

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -78,12 +78,16 @@ pub enum NodeCommands {
 
 #[derive(Debug, Subcommand)]
 pub enum QueryCommands {
-    #[command(name = "hash-diff", about = "Query the difference between two hashes.")]
+    #[command(
+        name = "hash-diff",
+        about = "Query the difference between two hashes.",
+        long_about = "Query the difference between two hashes. The left differences will be printed in green, while the right in red, and equal lines in white."
+    )]
     HashDiff {
         #[arg(required = true, help = "Base hash to compare against")]
         left: String,
 
-        #[arg(required = true, help = "Hash to compare with")]
+        #[arg(required = true, help = "Other hash to compare with")]
         right: String,
 
         #[arg(long, help = "Print the diff in JSON format")]

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -78,6 +78,18 @@ pub enum NodeCommands {
 
 #[derive(Debug, Subcommand)]
 pub enum QueryCommands {
+    #[command(name = "hash-diff", about = "Query the difference between two hashes.")]
+    HashDiff {
+        #[arg(required = true, help = "Base hash to compare against")]
+        left: String,
+
+        #[arg(required = true, help = "Hash to compare with")]
+        right: String,
+
+        #[arg(long, help = "Print the diff in JSON format")]
+        json: bool,
+    },
+
     #[command(
         name = "projects",
         about = "Query for projects within the project graph.",

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -30,6 +30,7 @@ use enums::{CacheMode, LogLevel};
 use moon_launchpad::check_version;
 use moon_logger::{color, debug, LevelFilter, Logger};
 use moon_terminal::ExtendedTerm;
+use query::QueryHashDiffOptions;
 use std::env;
 use std::path::PathBuf;
 
@@ -190,6 +191,9 @@ pub async fn run_cli() {
         Commands::ProjectGraph { id, dot, json } => project_graph(id, dot, json).await,
         Commands::Sync => sync().await,
         Commands::Query { command } => match command {
+            QueryCommands::HashDiff { left, right, json } => {
+                query::hash_diff(&QueryHashDiffOptions { json, left, right }).await
+            }
             QueryCommands::Projects {
                 alias,
                 affected,

--- a/crates/cli/src/queries/hash_diff.rs
+++ b/crates/cli/src/queries/hash_diff.rs
@@ -15,6 +15,14 @@ pub struct QueryHashDiffOptions {
     pub right: String,
 }
 
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct QueryHashDiffResult {
+    pub left: String,
+    pub left_diffs: Vec<String>,
+    pub right: String,
+    pub right_diffs: Vec<String>,
+}
+
 fn find_hash(dir: &Path, hash: &str) -> Result<String, MoonError> {
     for file in fs::read_dir(dir)? {
         let path = file.path();

--- a/crates/cli/src/queries/hash_diff.rs
+++ b/crates/cli/src/queries/hash_diff.rs
@@ -31,6 +31,13 @@ fn find_hash(dir: &Path, hash: &str) -> Result<(String, String), MoonError> {
         let name = fs::file_name(&path).replace(".json", "");
 
         if hash == name || name.starts_with(hash) {
+            debug!(
+                target: LOG_TARGET,
+                "Found manifest {} for hash {}",
+                color::hash(&name),
+                color::id(&hash)
+            );
+
             return Ok((name, fs::read(path)?));
         }
     }

--- a/crates/cli/src/queries/hash_diff.rs
+++ b/crates/cli/src/queries/hash_diff.rs
@@ -1,0 +1,42 @@
+use crate::helpers::AnyError;
+use moon_error::MoonError;
+use moon_logger::{color, debug};
+use moon_utils::fs;
+use moon_workspace::Workspace;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+const LOG_TARGET: &str = "moon:query:hash-diff";
+
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct QueryHashDiffOptions {
+    pub left: String,
+    pub right: String,
+}
+
+fn find_hash(dir: &Path, hash: &str) -> Result<String, MoonError> {
+    for file in fs::read_dir(dir)? {
+        let path = file.path();
+
+        if fs::file_name(&path).starts_with(hash) {
+            return Ok(fs::read(path)?);
+        }
+    }
+
+    Err(MoonError::Generic(format!(
+        "Unable to find a hash manifest for {}!",
+        color::hash(hash)
+    )))
+}
+
+pub async fn query_hash_diff(
+    workspace: &mut Workspace,
+    options: &QueryHashDiffOptions,
+) -> Result<(String, String), AnyError> {
+    debug!(target: LOG_TARGET, "Diffing hashes");
+
+    let hash_left = find_hash(&workspace.cache.hashes_dir, &options.left)?;
+    let hash_right = find_hash(&workspace.cache.hashes_dir, &options.right)?;
+
+    Ok((hash_left, hash_right))
+}

--- a/crates/cli/src/queries/hash_diff.rs
+++ b/crates/cli/src/queries/hash_diff.rs
@@ -10,6 +10,7 @@ const LOG_TARGET: &str = "moon:query:hash-diff";
 
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct QueryHashDiffOptions {
+    pub json: bool,
     pub left: String,
     pub right: String,
 }

--- a/crates/cli/src/queries/mod.rs
+++ b/crates/cli/src/queries/mod.rs
@@ -1,2 +1,3 @@
+pub mod hash_diff;
 pub mod projects;
 pub mod touched_files;

--- a/crates/cli/tests/query_test.rs
+++ b/crates/cli/tests/query_test.rs
@@ -44,7 +44,7 @@ mod hash_diff {
 
         let output = assert.output();
 
-        assert!(!predicate::str::contains("Unable to find a hash manifest for {}!").eval(&output));
+        assert!(predicate::str::contains("Unable to find a hash manifest for a!").eval(&output));
     }
 
     #[test]
@@ -72,7 +72,7 @@ mod hash_diff {
 
         let output = assert.output();
 
-        assert!(!predicate::str::contains("Unable to find a hash manifest for {}!").eval(&output));
+        assert!(predicate::str::contains("Unable to find a hash manifest for b!").eval(&output));
     }
 
     #[test]

--- a/crates/cli/tests/snapshots/query_test__hash_diff__prints_a_diff.snap
+++ b/crates/cli/tests/snapshots/query_test__hash_diff__prints_a_diff.snap
@@ -1,0 +1,19 @@
+---
+source: crates/cli/tests/query_test.rs
+expression: output
+---
+Left:  a
+Right: b
+
+ {
++    "command": "base",
+-    "command": "other",
+     "args": [
+         "a",
++        "b",
+-        "123",
+         "c"
+     ]
+ }
+
+

--- a/crates/cli/tests/snapshots/query_test__hash_diff__prints_a_diff_in_json.snap
+++ b/crates/cli/tests/snapshots/query_test__hash_diff__prints_a_diff_in_json.snap
@@ -1,0 +1,20 @@
+---
+source: crates/cli/tests/query_test.rs
+expression: output
+---
+{
+  "left": "{\n    \"command\": \"base\",\n    \"args\": [\n        \"a\",\n        \"b\",\n        \"c\"\n    ]\n}",
+  "left_hash": "a",
+  "left_diffs": [
+    "\"command\": \"base\",",
+    "\"b\","
+  ],
+  "right": "{\n    \"command\": \"other\",\n    \"args\": [\n        \"a\",\n        \"123\",\n        \"c\"\n    ]\n}",
+  "right_hash": "b",
+  "right_diffs": [
+    "\"command\": \"other\",",
+    "\"123\","
+  ]
+}
+
+

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### 🚀 Updates
 
 - Added a `moon docker setup` command for efficiently installing project dependencies.
+- Added a `moon query hash-diff` command for diffing 2 hashes.
 - Updated moon's toolchain to build upon [proto](https://github.com/moonrepo/proto), our new
   toolchain layer.
 - Updated our toolchain and configuration to take `.prototools` into account.

--- a/website/blog/_2023-03-13_v0.26.mdx
+++ b/website/blog/_2023-03-13_v0.26.mdx
@@ -86,6 +86,32 @@ than before, and you should see improved Docker layer caching!
 +RUN moon docker setup
 ```
 
+## New `moon query hash-diff` command
+
+When moon runs a task, we generate a unique hash representing the state of that run. When something
+goes wrong however, and the hash is different than what you expect, debugging why is rather
+non-trivial and requires a lot of internal knowledge. We're looking to reduce this burden, by
+introducing the new [`moon query hash-diff`](/docs/commands/query/hash-diff) command, which requires
+2 hashes to compare with.
+
+```shell
+$ moon query hash-diff 0b55b234 2388552f
+```
+
+When ran, the command will print out the differences as highlighted lines. If you use `git diff`,
+this will feel familiar to you.
+
+```diff
+{
+	"command": "build",
+	"args": [
++		"./dist"
+-		"./build"
+	],
+	...
+}
+```
+
 ## Other changes
 
 View the

--- a/website/docs/commands/query/hash-diff.mdx
+++ b/website/docs/commands/query/hash-diff.mdx
@@ -40,8 +40,10 @@ following structure:
 ```ts
 {
 	left: string,
+	left_hash: string,
 	left_diffs: string[],
 	right: string,
+	right_hash: string,
 	right_diffs: string[],
 }
 ```

--- a/website/docs/commands/query/hash-diff.mdx
+++ b/website/docs/commands/query/hash-diff.mdx
@@ -1,0 +1,51 @@
+---
+title: query hash-diff
+sidebar_label: hash-diff
+---
+
+import VersionLabel from '@site/src/components/Docs/VersionLabel';
+
+<VersionLabel header version="0.26" />
+
+Use the `moon query hash-diff` sub-command to query the content and source differences between 2
+generated hashes. This is extremely useful in debugging task inputs.
+
+```shell
+# Diff between 2 hashes
+$ moon query hash-diff 0b55b234f1018581c45b00241d7340dc648c63e639fbafdaf85a4cd7e718fdde 2388552fee5a02062d0ef402bdc7232f0a447458b058c80ce9c3d0d4d7cfe171
+
+# Diff between 2 hashes using short form
+$ moon query hash-diff 0b55b234 2388552f
+```
+
+By default, this will output the contents of a hash file (which is JSON), highlighting the
+differences between the left and right hashes. Lines that match will be printed in white, while the
+left differences printed in green, and right differences printed in red. If you use `git diff`, this
+will feel familiar to you.
+
+```diff
+{
+	"command": "build",
+	"args": [
++		"./dist"
+-		"./build"
+	],
+	...
+}
+```
+
+The differences can also be output in JSON by passing the `--json` flag. The output has the
+following structure:
+
+```ts
+{
+	left: string,
+	left_diffs: string[],
+	right: string,
+	right_diffs: string[],
+}
+```
+
+### Options
+
+- `--json` - Display the diff in JSON format.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -112,6 +112,7 @@ const sidebars = {
 					type: 'category',
 					label: 'query',
 					items: [
+						'commands/query/hash-diff',
 						'commands/query/projects',
 						'commands/query/tasks',
 						'commands/query/touched-files',


### PR DESCRIPTION
This command provides a way for users to debug hashes generated from running tasks, especially when comparing across runs.