### PR TITLE
new: Add `moon query hash` command.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = ["crates/cli"]
 [workspace.dependencies]
 async-trait = "0.1.61"
 cached = "0.42.0"
-clap = "4.1.8"
+clap = { version = "4.1.8", features = ["derive", "env", "wrap_help"] }
 clap_complete = "4.1.4"
 console = "0.15.5"
 criterion = { version = "0.4.0", features = ["async_tokio"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -43,7 +43,7 @@ moon_vcs = { path = "../core/vcs" }
 moon_workspace = { path = "../core/workspace" }
 atty = "0.2.14"
 bytes = "1.4.0"
-clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
+clap = { workspace = true }
 clap_complete = { workspace = true }
 clap_lex = "0.3.2"
 console = { workspace = true }

--- a/crates/cli/src/app.rs
+++ b/crates/cli/src/app.rs
@@ -79,6 +79,19 @@ pub enum NodeCommands {
 #[derive(Debug, Subcommand)]
 pub enum QueryCommands {
     #[command(
+        name = "hash",
+        about = "Inspect the contents of a generated hash.",
+        long_about = "Inspect the contents of a generated hash, and display all sources and inputs that were used to generate it."
+    )]
+    Hash {
+        #[arg(required = true, help = "Hash to inspect")]
+        hash: String,
+
+        #[arg(long, help = "Print the manifest in JSON format")]
+        json: bool,
+    },
+
+    #[command(
         name = "hash-diff",
         about = "Query the difference between two hashes.",
         long_about = "Query the difference between two hashes. The left differences will be printed in green, while the right in red, and equal lines in white."
@@ -520,7 +533,7 @@ pub enum Commands {
     #[command(
         name = "query",
         about = "Query information about moon, the environment, and pipeline.",
-        long_about = "Query information about moon, the environment, and pipeline. Each operation will output JSON so that it may be consumed easily."
+        long_about = "Query information about moon, the environment, and pipeline. Each operation can output JSON so that it may be consumed easily."
     )]
     Query {
         #[command(subcommand)]

--- a/crates/cli/src/commands/query.rs
+++ b/crates/cli/src/commands/query.rs
@@ -14,8 +14,8 @@ use std::io;
 use std::io::prelude::*;
 
 pub async fn hash(hash: &str, json: bool) -> Result<(), AnyError> {
-    let mut workspace = load_workspace().await?;
-    let result = query_hash(&mut workspace, hash).await?;
+    let workspace = load_workspace().await?;
+    let result = query_hash(&workspace, hash).await?;
 
     if !json {
         println!("Hash: {}\n", color::id(result.0));

--- a/crates/cli/src/commands/query.rs
+++ b/crates/cli/src/commands/query.rs
@@ -1,4 +1,5 @@
 use crate::helpers::AnyError;
+pub use crate::queries::hash::query_hash;
 pub use crate::queries::hash_diff::{query_hash_diff, QueryHashDiffOptions};
 pub use crate::queries::projects::{
     query_projects, QueryProjectsOptions, QueryProjectsResult, QueryTasksResult,
@@ -11,6 +12,19 @@ use moon_logger::color;
 use rustc_hash::FxHashMap;
 use std::io;
 use std::io::prelude::*;
+
+pub async fn hash(hash: &str, json: bool) -> Result<(), AnyError> {
+    let mut workspace = load_workspace().await?;
+    let result = query_hash(&mut workspace, hash).await?;
+
+    if !json {
+        println!("Hash: {}\n", color::id(result.0));
+    }
+
+    println!("{}", result.1);
+
+    Ok(())
+}
 
 pub async fn hash_diff(options: &QueryHashDiffOptions) -> Result<(), AnyError> {
     let mut workspace = load_workspace().await?;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -191,6 +191,7 @@ pub async fn run_cli() {
         Commands::ProjectGraph { id, dot, json } => project_graph(id, dot, json).await,
         Commands::Sync => sync().await,
         Commands::Query { command } => match command {
+            QueryCommands::Hash { hash, json } => query::hash(&hash, json).await,
             QueryCommands::HashDiff { left, right, json } => {
                 query::hash_diff(&QueryHashDiffOptions { json, left, right }).await
             }

--- a/crates/cli/src/queries/hash.rs
+++ b/crates/cli/src/queries/hash.rs
@@ -1,0 +1,37 @@
+use crate::helpers::AnyError;
+use moon_error::MoonError;
+use moon_logger::{color, debug};
+use moon_utils::fs;
+use moon_workspace::Workspace;
+
+const LOG_TARGET: &str = "moon:query:hash";
+
+pub async fn query_hash(workspace: &Workspace, hash: &str) -> Result<(String, String), AnyError> {
+    debug!(
+        target: LOG_TARGET,
+        "Querying for hash manifest with {}",
+        color::hash(hash)
+    );
+
+    for file in fs::read_dir(&workspace.cache.hashes_dir)? {
+        let path = file.path();
+        let name = fs::file_name(&path).replace(".json", "");
+
+        if hash == name || name.starts_with(hash) {
+            debug!(
+                target: LOG_TARGET,
+                "Found hash manifest {} for {}",
+                color::id(&name),
+                color::hash(hash)
+            );
+
+            return Ok((name, fs::read(path)?));
+        }
+    }
+
+    Err(MoonError::Generic(format!(
+        "Unable to find a hash manifest for {}!",
+        color::hash(hash)
+    ))
+    .into())
+}

--- a/crates/cli/src/queries/hash_diff.rs
+++ b/crates/cli/src/queries/hash_diff.rs
@@ -1,10 +1,8 @@
+use super::hash::query_hash;
 use crate::helpers::AnyError;
-use moon_error::MoonError;
-use moon_logger::{color, debug};
-use moon_utils::fs;
+use moon_logger::debug;
 use moon_workspace::Workspace;
 use serde::{Deserialize, Serialize};
-use std::path::Path;
 
 const LOG_TARGET: &str = "moon:query:hash-diff";
 
@@ -25,37 +23,14 @@ pub struct QueryHashDiffResult {
     pub right_diffs: Vec<String>,
 }
 
-fn find_hash(dir: &Path, hash: &str) -> Result<(String, String), MoonError> {
-    for file in fs::read_dir(dir)? {
-        let path = file.path();
-        let name = fs::file_name(&path).replace(".json", "");
-
-        if hash == name || name.starts_with(hash) {
-            debug!(
-                target: LOG_TARGET,
-                "Found manifest {} for hash {}",
-                color::hash(&name),
-                color::id(hash)
-            );
-
-            return Ok((name, fs::read(path)?));
-        }
-    }
-
-    Err(MoonError::Generic(format!(
-        "Unable to find a hash manifest for {}!",
-        color::hash(hash)
-    )))
-}
-
 pub async fn query_hash_diff(
     workspace: &mut Workspace,
     options: &QueryHashDiffOptions,
 ) -> Result<QueryHashDiffResult, AnyError> {
     debug!(target: LOG_TARGET, "Diffing hashes");
 
-    let (left_hash, left) = find_hash(&workspace.cache.hashes_dir, &options.left)?;
-    let (right_hash, right) = find_hash(&workspace.cache.hashes_dir, &options.right)?;
+    let (left_hash, left) = query_hash(&workspace, &options.left).await?;
+    let (right_hash, right) = query_hash(&workspace, &options.right).await?;
 
     Ok(QueryHashDiffResult {
         left,

--- a/crates/cli/src/queries/hash_diff.rs
+++ b/crates/cli/src/queries/hash_diff.rs
@@ -29,8 +29,8 @@ pub async fn query_hash_diff(
 ) -> Result<QueryHashDiffResult, AnyError> {
     debug!(target: LOG_TARGET, "Diffing hashes");
 
-    let (left_hash, left) = query_hash(&workspace, &options.left).await?;
-    let (right_hash, right) = query_hash(&workspace, &options.right).await?;
+    let (left_hash, left) = query_hash(workspace, &options.left).await?;
+    let (right_hash, right) = query_hash(workspace, &options.right).await?;
 
     Ok(QueryHashDiffResult {
         left,

--- a/crates/cli/src/queries/mod.rs
+++ b/crates/cli/src/queries/mod.rs
@@ -1,3 +1,4 @@
+pub mod hash;
 pub mod hash_diff;
 pub mod projects;
 pub mod touched_files;

--- a/crates/cli/tests/query_test.rs
+++ b/crates/cli/tests/query_test.rs
@@ -30,6 +30,76 @@ fn touch_file(sandbox: &Sandbox) {
     }
 }
 
+mod hash {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn errors_if_hash_doesnt_exist() {
+        let sandbox = create_sandbox_with_config("base", None, None, None);
+
+        let assert = sandbox.run_moon(|cmd| {
+            cmd.arg("query").arg("hash").arg("a");
+        });
+
+        let output = assert.output();
+
+        assert!(predicate::str::contains("Unable to find a hash manifest for a!").eval(&output));
+    }
+
+    #[test]
+    fn prints_the_manifest() {
+        let sandbox = create_sandbox_with_config("base", None, None, None);
+
+        fs::create_dir_all(sandbox.path().join(".moon/cache/hashes")).unwrap();
+
+        fs::write(
+            sandbox.path().join(".moon/cache/hashes/a.json"),
+            r#"{
+    "command": "base",
+    "args": [
+        "a",
+        "b",
+        "c"
+    ]
+}"#,
+        )
+        .unwrap();
+
+        let assert = sandbox.run_moon(|cmd| {
+            cmd.arg("query").arg("hash").arg("a");
+        });
+
+        assert_snapshot!(assert.output());
+    }
+
+    #[test]
+    fn prints_the_manifest_in_json() {
+        let sandbox = create_sandbox_with_config("base", None, None, None);
+
+        fs::create_dir_all(sandbox.path().join(".moon/cache/hashes")).unwrap();
+
+        fs::write(
+            sandbox.path().join(".moon/cache/hashes/a.json"),
+            r#"{
+    "command": "base",
+    "args": [
+        "a",
+        "b",
+        "c"
+    ]
+}"#,
+        )
+        .unwrap();
+
+        let assert = sandbox.run_moon(|cmd| {
+            cmd.arg("query").arg("hash").arg("a").arg("--json");
+        });
+
+        assert_snapshot!(assert.output());
+    }
+}
+
 mod hash_diff {
     use super::*;
     use std::fs;

--- a/crates/cli/tests/snapshots/query_test__hash__prints_the_manifest.snap
+++ b/crates/cli/tests/snapshots/query_test__hash__prints_the_manifest.snap
@@ -1,0 +1,16 @@
+---
+source: crates/cli/tests/query_test.rs
+expression: assert.output()
+---
+Hash: a
+
+{
+    "command": "base",
+    "args": [
+        "a",
+        "b",
+        "c"
+    ]
+}
+
+

--- a/crates/cli/tests/snapshots/query_test__hash__prints_the_manifest_in_json.snap
+++ b/crates/cli/tests/snapshots/query_test__hash__prints_the_manifest_in_json.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cli/tests/query_test.rs
+expression: assert.output()
+---
+{
+    "command": "base",
+    "args": [
+        "a",
+        "b",
+        "c"
+    ]
+}
+
+

--- a/crates/core/action-context/Cargo.toml
+++ b/crates/core/action-context/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 moon_target = { path = "../target" }
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### 🚀 Updates
 
 - Added a `moon docker setup` command for efficiently installing project dependencies.
+- Added a `moon query hash` command for inspecting the hash manifest.
 - Added a `moon query hash-diff` command for diffing 2 hashes.
 - Updated moon's toolchain to build upon [proto](https://github.com/moonrepo/proto), our new
   toolchain layer.
@@ -25,7 +26,7 @@
 
 #### ⚙️ Internal
 
-- Updated terminal checkpoint colors for tools to pink.
+- Updated terminal checkpoint colors for tools to pink (to match proto).
 
 ## 0.25.4
 

--- a/website/blog/2023-02-27_v0.25.mdx
+++ b/website/blog/2023-02-27_v0.25.mdx
@@ -181,4 +181,3 @@ Expect the following in the v0.26 release!
 
 - Officially release proto!
 - Improved Deno interoperability.
-- Deno tier 3 support (hopefully).

--- a/website/blog/_2023-03-13_v0.26.mdx
+++ b/website/blog/_2023-03-13_v0.26.mdx
@@ -86,13 +86,34 @@ than before, and you should see improved Docker layer caching!
 +RUN moon docker setup
 ```
 
-## New `moon query hash-diff` command
+## New `moon query hash` command
 
 When moon runs a task, we generate a unique hash representing the state of that run. When something
 goes wrong however, and the hash is different than what you expect, debugging why is rather
 non-trivial and requires a lot of internal knowledge. We're looking to reduce this burden, by
-introducing the new [`moon query hash-diff`](/docs/commands/query/hash-diff) command, which requires
-2 hashes to compare with.
+introducing the new [`moon query hash`](/docs/commands/query/hash) command.
+
+```shell
+$ moon query hash 0b55b234
+```
+
+This command will print the contents of the hash manifest, which is all inputs and sources used to
+generate the unique hash. From here you can use this output to investigate what's actually
+happening.
+
+```json
+{
+  "command": "build",
+  "args": ["./build"]
+  // ...
+}
+```
+
+## New `moon query hash-diff` command
+
+Expanding on the new command above, we're also introducing the
+[`moon query hash-diff`](/docs/commands/query/hash-diff) command, which can be used to compute the
+difference between 2 hashes. Perfect in understanding what has changed between ran tasks.
 
 ```shell
 $ moon query hash-diff 0b55b234 2388552f
@@ -126,3 +147,5 @@ full list of changes.
 Expect the following in the v1 release!
 
 - Officially release a v1!
+- Project tagging and constraints.
+- Deno tier 3 support.

--- a/website/docs/commands/query/hash-diff.mdx
+++ b/website/docs/commands/query/hash-diff.mdx
@@ -24,6 +24,9 @@ left differences printed in green, and right differences printed in red. If you 
 will feel familiar to you.
 
 ```diff
+Left:  0b55b234f1018581c45b00241d7340dc648c63e639fbafdaf85a4cd7e718fdde
+Right: 2388552fee5a02062d0ef402bdc7232f0a447458b058c80ce9c3d0d4d7cfe171
+
 {
 	"command": "build",
 	"args": [
@@ -50,4 +53,4 @@ following structure:
 
 ### Options
 
-- `--json` - Display the diff in JSON format.
+- `--json` - Display the manifest in JSON format.

--- a/website/docs/commands/query/hash.mdx
+++ b/website/docs/commands/query/hash.mdx
@@ -1,0 +1,37 @@
+---
+title: query hash
+sidebar_label: hash
+---
+
+import VersionLabel from '@site/src/components/Docs/VersionLabel';
+
+<VersionLabel header version="0.26" />
+
+Use the `moon query hash` sub-command to inspect the contents and sources of a generated hash, also
+known as the hash manifest. This is extremely useful in debugging task inputs.
+
+```shell
+$ moon query hash 0b55b234f1018581c45b00241d7340dc648c63e639fbafdaf85a4cd7e718fdde
+
+# Query hash using short form
+$ moon query hash 0b55b234
+```
+
+By default, this will output the contents of the hash manifest (which is JSON), and the fully
+qualified resolved hash.
+
+```json
+Hash: 0b55b234f1018581c45b00241d7340dc648c63e639fbafdaf85a4cd7e718fdde
+
+{
+  "command": "build",
+  "args": ["./build"]
+  // ...
+}
+```
+
+The command can also be output raw JSON by passing the `--json` flag.
+
+### Options
+
+- `--json` - Display the diff in JSON format.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -112,6 +112,7 @@ const sidebars = {
 					type: 'category',
 					label: 'query',
 					items: [
+						'commands/query/hash',
 						'commands/query/hash-diff',
 						'commands/query/projects',
 						'commands/query/tasks',


### PR DESCRIPTION
Users can use this command to inspect the hash manifest of a ran task.