### PR TITLE
fix: Fix project graph generation crashing on circular dependencies.

### DIFF
--- a/crates/cli/tests/snapshots/dep_graph_test__includes_dependents_when_focused.snap
+++ b/crates/cli/tests/snapshots/dep_graph_test__includes_dependents_when_focused.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/dep_graph_test.rs
-assertion_line: 78
 expression: assert.output()
 ---
 digraph {

--- a/crates/cli/tests/snapshots/project_graph_test__aliases__uses_ids_in_graph.snap
+++ b/crates/cli/tests/snapshots/project_graph_test__aliases__uses_ids_in_graph.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/project_graph_test.rs
-assertion_line: 90
 expression: assert.output()
 ---
 digraph {

--- a/crates/cli/tests/snapshots/project_graph_test__many_projects.snap
+++ b/crates/cli/tests/snapshots/project_graph_test__many_projects.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/project_graph_test.rs
-assertion_line: 32
 expression: assert.output()
 ---
 digraph {

--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -30,6 +30,9 @@ pub struct ProjectGraphBuilder<'ws> {
     graph: GraphType,
     indices: IndicesType,
     sources: ProjectsSourcesMap,
+
+    // Project and its dependencies being created.
+    // We use this to prevent circular dependencies.
     created: FxHashSet<String>,
 
     pub is_cached: bool,
@@ -479,6 +482,9 @@ impl<'ws> ProjectGraphBuilder<'ws> {
         for dep_index in dep_indices {
             self.graph.add_edge(index, dep_index, ());
         }
+
+        // Reset for the next project
+        self.created.clear();
 
         Ok(index)
     }

--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -9,7 +9,7 @@ use moon_config::{
 };
 use moon_error::MoonError;
 use moon_hasher::{convert_paths_to_strings, to_hash};
-use moon_logger::{color, debug, map_list, trace, Logable};
+use moon_logger::{color, debug, map_list, trace, warn, Logable};
 use moon_platform_detector::{detect_project_language, detect_task_platform};
 use moon_project::{Project, ProjectDependency, ProjectDependencySource, ProjectError};
 use moon_target::{Target, TargetError, TargetProjectScope};
@@ -456,7 +456,14 @@ impl<'ws> ProjectGraphBuilder<'ws> {
         let mut dep_indices = FxHashSet::default();
 
         for dep_id in project.get_dependency_ids() {
-            if !self.created.contains(dep_id) {
+            if self.created.contains(dep_id) {
+                warn!(
+                    target: LOG_TARGET,
+                    "Found a cycle between {} and {}, and will disconnect nodes to avoid recursion",
+                    color::id(&id),
+                    color::id(dep_id),
+                );
+            } else {
                 dep_indices.insert(self.internal_load(dep_id)?);
             }
         }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue when project dependencies that form a cycle would recurse indefinitely and panic.
+
 ## 0.26.2
 
 #### 🐞 Fixes

--- a/tests/fixtures/project-graph/cycle/a/moon.yml
+++ b/tests/fixtures/project-graph/cycle/a/moon.yml
@@ -1,0 +1,2 @@
+dependsOn:
+  - b

--- a/tests/fixtures/project-graph/cycle/b/moon.yml
+++ b/tests/fixtures/project-graph/cycle/b/moon.yml
@@ -1,0 +1,2 @@
+dependsOn:
+  - a

--- a/tests/fixtures/project-graph/cycle/package.json
+++ b/tests/fixtures/project-graph/cycle/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "project-graph-dependencies",
+  "private": true,
+  "workspaces": ["*"]
+}

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -28,7 +28,7 @@ must be an HTTPS URL _or_ relative file system path that points to a valid YAML 
 extends: 'https://raw.githubusercontent.com/organization/repository/master/.moon/workspace.yml'
 ```
 
-:::caution
+:::info
 
 Settings will be merged recursively for blocks, with values defined in the local configuration
 taking precedence over those defined in the extended configuration. However, the `projects` setting
@@ -43,6 +43,14 @@ _does not merge_!
 Defines the location of all [projects](../concepts/project) within the workspace. Supports either a
 manual map of projects (default), a list of globs in which to automatically locate projects, _or_
 both.
+
+:::caution
+
+Projects that depend on each other and form a cycle must be avoided! While we do our best to avoid
+an infinite loop and disconnect nodes from each other, there's no guarantee that tasks will run in
+the correct order.
+
+:::
 
 ### Using a map
 


### PR DESCRIPTION
This is simply a hack for the project graph to be created when it encounters a cycle. It achieves this by decoupling the leaf node from it's previous node, instead of depending on it. 

While this works, it also means that the task graph is no longer accurate, and may not build things in the correct order.