### PR TITLE
new: Warn when an input doesn't exist while hashing.

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+#### 🚀 Updates
+
+- Task `inputs` declared as literal file paths will now be logged to the console as a warning when
+  they do not exist during hashing.
+
 #### 🐞 Fixes
 
 - Fixed an issue when project dependencies that form a cycle would recurse indefinitely and panic.


### PR DESCRIPTION
Only applies to literal file paths, not globs, and helps to bubble up misconfigurations.