### PR TITLE
fix: Fix project graph cache when running from a sub-dir.

### DIFF
--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -8,7 +8,7 @@ use moon_config::{
     CONFIG_PROJECT_FILENAME,
 };
 use moon_error::MoonError;
-use moon_hasher::{convert_paths_to_strings, to_hash};
+use moon_hasher::to_hash;
 use moon_logger::{color, debug, map_list, trace, warn, Logable};
 use moon_platform_detector::{detect_project_language, detect_task_platform};
 use moon_project::{Project, ProjectDependency, ProjectDependencySource, ProjectError};
@@ -597,14 +597,17 @@ impl<'ws> ProjectGraphBuilder<'ws> {
         // Hash all project-oriented config files, as a single change in any of
         // these files would invalidate the entire project graph cache!
         // TODO: handle extended config files?
-        let configs = convert_paths_to_strings(
-            &FxHashSet::from_iter(
-                sources
-                    .values()
-                    .map(|source| PathBuf::from(source).join(CONFIG_PROJECT_FILENAME)),
-            ),
-            &self.workspace.root,
-        )?;
+        let mut configs = vec![];
+
+        for source in sources.values() {
+            if source == "." {
+                configs.push(CONFIG_PROJECT_FILENAME.to_owned());
+            } else {
+                configs.push(path::to_string(
+                    PathBuf::from(source).join(CONFIG_PROJECT_FILENAME),
+                )?);
+            }
+        }
 
         // Hash project-level config (moon.yml)
         let config_hashes = self

--- a/crates/core/project-graph/tests/project_graph_test.rs
+++ b/crates/core/project-graph/tests/project_graph_test.rs
@@ -164,7 +164,7 @@ mod caching {
         assert_eq!(state.last_glob_time, 0);
         assert_eq!(
             state.last_hash,
-            "f142a8f9dc18b06a35a5c01a78b8e62ca36d23fd306530631ebab648e481fe35"
+            "10fd6ac2077508f6b72809de3cb0e94936e3a9ea685a8fc9e7b032be6aee6ee0"
         );
         assert_eq!(
             state.projects,

--- a/crates/node/lang/src/pnpm/dependency_path.rs
+++ b/crates/node/lang/src/pnpm/dependency_path.rs
@@ -60,11 +60,9 @@ impl PnpmDependencyPath {
                     peers_suffix = Some(ver[index..].to_string());
                     ver = ver[0..index].to_string();
                 }
-            } else {
-                if let Some(index) = ver.find('_') {
-                    peers_suffix = Some(ver[index + 1..].to_string());
-                    ver = ver[0..index].to_string();
-                }
+            } else if let Some(index) = ver.find('_') {
+                peers_suffix = Some(ver[index + 1..].to_string());
+                ver = ver[0..index].to_string();
             }
 
             if Version::parse(&ver).is_ok() {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@
 #### 🐞 Fixes
 
 - Fixed an issue with pnpm lockfile parsing.
+- Fixed an issue where the project graph cache wouldn't be invalidated if moon was ran from a
+  sub-directory.
 
 ## 0.26.4
 


### PR DESCRIPTION
The project config paths were missing from the hash manifest when running in a sub-directory, causing weird issues.

This updates them to be absolute instead of use cwd.