### PR TITLE
fix: Fix serialization of custom languages.

### DIFF
--- a/.yarn/versions/4745cdf3.yml
+++ b/.yarn/versions/4745cdf3.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/core/config/src/project/language_platform.rs
+++ b/crates/core/config/src/project/language_platform.rs
@@ -181,4 +181,28 @@ mod tests {
             "\"dotnet\""
         );
     }
+
+    #[test]
+    fn deserializes_lang_to_enum() {
+        assert_eq!(
+            serde_json::from_str::<ProjectLanguage>("\"go\"").unwrap(),
+            ProjectLanguage::Go,
+        );
+        assert_eq!(
+            serde_json::from_str::<ProjectLanguage>("\"javascript\"").unwrap(),
+            ProjectLanguage::JavaScript,
+        );
+        assert_eq!(
+            serde_json::from_str::<ProjectLanguage>("\"ruby\"").unwrap(),
+            ProjectLanguage::Ruby,
+        );
+        assert_eq!(
+            serde_json::from_str::<ProjectLanguage>("\"unknown\"").unwrap(),
+            ProjectLanguage::Unknown,
+        );
+        assert_eq!(
+            serde_json::from_str::<ProjectLanguage>("\"dotnet\"").unwrap(),
+            ProjectLanguage::Other("dotnet".into()),
+        );
+    }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where using a custom project language would break the project graph cache.
+
 ## 0.26.5
 
 #### 🐞 Fixes


### PR DESCRIPTION
They were being serialized as `{"other":"lang"}` instead of simply `"lang"`. This would cause issues during deserialization.