### PR TITLE
fix: Fix Docker scaffolding not including tasks configs.

### DIFF
--- a/.yarn/versions/25d43247.yml
+++ b/.yarn/versions/25d43247.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/cli/src/commands/docker/scaffold.rs
+++ b/crates/cli/src/commands/docker/scaffold.rs
@@ -80,7 +80,10 @@ fn scaffold_workspace(
     copy_files(&files, &workspace.root, &docker_workspace_root)?;
 
     // Copy moon configuration
-    let moon_configs = glob::walk(workspace.root.join(CONFIG_DIRNAME), ["*.yml"])?;
+    let moon_configs = glob::walk(
+        workspace.root.join(CONFIG_DIRNAME),
+        ["*.yml", "tasks/*.yml"],
+    )?;
     let moon_configs = moon_configs
         .iter()
         .map(|f| path::to_string(f.strip_prefix(&workspace.root).unwrap()))

--- a/crates/cli/tests/docker_test.rs
+++ b/crates/cli/tests/docker_test.rs
@@ -56,6 +56,10 @@ mod scaffold_workspace {
             Some(&tasks_config),
         );
 
+        // Test inherited configs
+        fs::create_dir(sandbox.path().join(".moon/tasks")).unwrap();
+        fs::write(sandbox.path().join(".moon/tasks/node.yml"), "{}").unwrap();
+
         sandbox.run_moon(|cmd| {
             cmd.arg("docker").arg("scaffold").arg("lifecycles");
         });
@@ -63,6 +67,7 @@ mod scaffold_workspace {
         let docker = sandbox.path().join(".moon/docker/workspace");
 
         assert!(docker.join(".moon/tasks.yml").exists());
+        assert!(docker.join(".moon/tasks/node.yml").exists());
         assert!(docker.join(".moon/toolchain.yml").exists());
         assert!(docker.join(".moon/workspace.yml").exists());
     }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where `.moon/tasks/*.yml` were not scaffolded into `Dockerfile`s.
+
 ## 1.0.0
 
 #### 💥 Breaking


### PR DESCRIPTION
I ran into this myself. Looks like Docker scaffolding was completely ignoring configs in `.moon/tasks/*.yml`, causing tasks to be no-ops.