### PR TITLE
fix: Improve `envFile` implementation and ergonomics.

### DIFF
--- a/crates/cli/tests/dep_graph_test.rs
+++ b/crates/cli/tests/dep_graph_test.rs
@@ -21,7 +21,7 @@ fn all_by_default() {
     let dot = assert.output();
 
     // Snapshot is not deterministic
-    assert_eq!(dot.split('\n').count(), 507);
+    assert_eq!(dot.split('\n').count(), 510);
 }
 
 #[test]

--- a/crates/core/config/src/project/task_options.rs
+++ b/crates/core/config/src/project/task_options.rs
@@ -1,4 +1,4 @@
-use crate::{errors::create_validation_error, validators::validate_child_relative_path};
+use crate::{errors::create_validation_error, validators::validate_child_or_root_path};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationError};
@@ -19,7 +19,7 @@ fn validate_affected_files(file: &TaskOptionAffectedFilesConfig) -> Result<(), V
 
 fn validate_env_file(file: &TaskOptionEnvFileConfig) -> Result<(), ValidationError> {
     if let TaskOptionEnvFileConfig::File(path) = file {
-        validate_child_relative_path("options.envFile", path)?;
+        validate_child_or_root_path("options.envFile", path)?;
     }
 
     Ok(())
@@ -33,10 +33,7 @@ pub enum TaskOptionAffectedFilesConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
-#[serde(
-    untagged,
-    expecting = "expected a boolean or a relative file system path"
-)]
+#[serde(untagged, expecting = "expected a boolean or a file system path")]
 pub enum TaskOptionEnvFileConfig {
     Enabled(bool),
     File(String),

--- a/crates/core/config/tests/tasks_test.rs
+++ b/crates/core/config/tests/tasks_test.rs
@@ -653,7 +653,7 @@ options:
 
     #[test]
     #[should_panic(
-        expected = "expected a boolean or a relative file system path for key \"default.options.envFile\""
+        expected = "expected a boolean or a file system path for key \"default.options.envFile\""
     )]
     fn invalid_env_file_type() {
         figment::Jail::expect_with(|jail| {
@@ -694,7 +694,6 @@ options:
     //         }
 
     mod affected_files {
-
         #[test]
         #[should_panic(
             expected = "expected `args`, `env`, or a boolean for key \"default.options.affectedFiles\""

--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -15,6 +15,7 @@ use moon_platform_detector::{detect_project_language, detect_task_platform};
 use moon_project::{Project, ProjectDependency, ProjectDependencySource, ProjectError};
 use moon_target::{Target, TargetError, TargetProjectScope};
 use moon_task::{Task, TaskError, TaskFlag};
+use moon_utils::path::expand_to_workspace_relative;
 use moon_utils::regex::{ENV_VAR, ENV_VAR_SUBSTITUTE};
 use moon_utils::{glob, path, time};
 use moon_workspace::Workspace;
@@ -354,7 +355,12 @@ impl<'ws> ProjectGraphBuilder<'ws> {
     ) -> Result<(), ProjectGraphError> {
         // Load from env file first
         if let Some(env_file) = &task.options.env_file {
-            let env_path = project.root.join(env_file);
+            let env_path = self.workspace.root.join(expand_to_workspace_relative(
+                env_file,
+                &self.workspace.root,
+                &project.root,
+            ));
+
             let error_handler =
                 |e: dotenvy::Error| TaskError::InvalidEnvFile(env_path.clone(), e.to_string());
 

--- a/crates/core/project-graph/tests/projects_test.rs
+++ b/crates/core/project-graph/tests/projects_test.rs
@@ -883,22 +883,6 @@ mod task_expansion {
         }
 
         #[tokio::test]
-        // Windows = "The system cannot find the file specified"
-        // Unix = "No such file or directory"
-        #[should_panic(expected = "InvalidEnvFile")]
-        async fn errors_on_missing_file() {
-            // `expand_env` has a CI check that avoids this from crashing, so emulate it
-            if moon_utils::is_ci() {
-                panic!("InvalidEnvFile");
-            } else {
-                tasks_sandbox_with_setup(|sandbox| {
-                    std::fs::remove_file(sandbox.path().join("expand-env/.env")).unwrap();
-                })
-                .await;
-            }
-        }
-
-        #[tokio::test]
         async fn loads_using_bool() {
             let (_sandbox, project_graph) = tasks_sandbox().await;
 

--- a/crates/core/project-graph/tests/projects_test.rs
+++ b/crates/core/project-graph/tests/projects_test.rs
@@ -925,6 +925,24 @@ mod task_expansion {
         }
 
         #[tokio::test]
+        async fn loads_from_workspace_root() {
+            let (_sandbox, project_graph) = tasks_sandbox().await;
+
+            let project = project_graph.get("expandEnv").unwrap();
+            let task = project.get_task("envFileWorkspace").unwrap();
+
+            assert_eq!(
+                task.env,
+                FxHashMap::from_iter([("SOURCE".to_owned(), "workspace-level".to_owned()),])
+            );
+
+            dbg!(&task);
+
+            assert!(task.inputs.contains(&"/.env".to_owned()));
+            assert!(task.input_paths.contains(&PathBuf::from(".env")));
+        }
+
+        #[tokio::test]
         async fn doesnt_override_other_env() {
             let (_sandbox, project_graph) = tasks_sandbox().await;
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### 🐞 Fixes
 
+- Updated `envFile` to log a warning instead of triggering an error when `.env.` is missing.
 - Fixed an issue where `.moon/tasks/*.yml` were not scaffolded into `Dockerfile`s.
 
 ## 1.0.0

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### 🐞 Fixes
 
 - Updated `envFile` to log a warning instead of triggering an error when `.env.` is missing.
+- Updated `envFile` to support workspace relative paths when prefixed with `/`.
 - Fixed an issue where `.moon/tasks/*.yml` were not scaffolded into `Dockerfile`s.
 
 ## 1.0.0

--- a/tests/fixtures/tasks/.env
+++ b/tests/fixtures/tasks/.env
@@ -1,0 +1,1 @@
+SOURCE=workspace-level

--- a/tests/fixtures/tasks/expand-env/moon.yml
+++ b/tests/fixtures/tasks/expand-env/moon.yml
@@ -5,6 +5,9 @@ tasks:
   envFileNamed:
     options:
       envFile: '.env.production'
+  envFileWorkspace:
+    options:
+      envFile: '/.env'
   mergeWithEnv:
     env:
       FOO: original

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -561,7 +561,7 @@ tasks:
 
 <HeadingApiLink to="/api/types/interface/TaskOptionsConfig#envFile" />
 
-A boolean or path to a project relative file (also know as dotenv file) that defines a collection of
+A boolean or path to a `.env` file (also know as dotenv file) that defines a collection of
 [environment variables](#env-1) for the current task. Variables will be loaded on project creation,
 but will _not_ override those defined in [`env`](#env-1).
 
@@ -574,6 +574,8 @@ tasks:
       envFile: true
       # Or
       envFile: '.env.production'
+      # Or from the workspace root
+      envFile: '/.env.shared'
 ```
 
 > Variables defined in the file support value substitution using `${VAR_NAME}` syntax.


### PR DESCRIPTION
This PR does 2 things:

- Logs a warning instead of triggering an error.
- Supports workspace relative paths.

Fixes: https://github.com/moonrepo/moon/issues/748