### PR TITLE
fix: Fix moon hanging when running outside of workspace root.

### DIFF
--- a/.yarn/versions/3e50ed09.yml
+++ b/.yarn/versions/3e50ed09.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/core/moon/src/lib.rs
+++ b/crates/core/moon/src/lib.rs
@@ -51,9 +51,9 @@ pub fn register_platforms(workspace: &mut Workspace) -> Result<(), WorkspaceErro
 
 /// Loads the workspace from the current working directory.
 pub async fn load_workspace() -> Result<Workspace, WorkspaceError> {
-    let current_dir = env::current_dir().expect("Failed to get current directory.");
+    let current_dir = env::current_dir().map_err(|_| WorkspaceError::MissingWorkingDir)?;
 
-    Ok(load_workspace_from(&current_dir).await?)
+    load_workspace_from(&current_dir).await
 }
 
 /// Loads the workspace from a provided directory.

--- a/crates/core/workspace/src/errors.rs
+++ b/crates/core/workspace/src/errors.rs
@@ -17,6 +17,9 @@ pub enum WorkspaceError {
     #[error("Unable to determine your home directory.")]
     MissingHomeDir,
 
+    #[error("Unable to determine your current working directory.")]
+    MissingWorkingDir,
+
     #[error(
         "Unable to locate <file>{}/{}</file> configuration file.",
         constants::CONFIG_DIRNAME,

--- a/crates/core/workspace/src/workspace.rs
+++ b/crates/core/workspace/src/workspace.rs
@@ -208,10 +208,6 @@ pub struct Workspace {
 impl Workspace {
     /// Create a new workspace instance starting from the current working directory.
     /// Will locate the workspace root and load available configuration files.
-    pub fn load() -> Result<Workspace, WorkspaceError> {
-        Workspace::load_from(env::current_dir().unwrap())
-    }
-
     pub fn load_from<P: AsRef<Path>>(working_dir: P) -> Result<Workspace, WorkspaceError> {
         let working_dir = working_dir.as_ref();
         let Some(root_dir) = find_workspace_root(working_dir) else {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where workspace root finding will locate `~/.moon`.
+
 ## 1.0.1
 
 #### 🐞 Fixes

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### 🐞 Fixes
 
+- Fixed an issue where `moon run` or `moon check` would hang when not running in a workspace.
 - Fixed an issue where workspace root finding will locate `~/.moon`.
 
 ## 1.0.1


### PR DESCRIPTION
Fixes https://github.com/moonrepo/moon/issues/757

So this only happened for `moon run/check`, which lead me to believe that it was the telemetry logic, and I was right. When the workspace is found, we mark the telemetry atomic as ready, but when it's not found we never set it to ready, causing an atomic deadlock and it hangs.