### PR TITLE
fix: Fix concurrent task running problems.

### DIFF
--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -110,6 +110,12 @@ pub async fn run_target(
         }
     }
 
+    // Pre-populate target hashes with "none" for all primary targets
+    let target_hashes = primary_targets
+        .iter()
+        .map(|t| (t.to_owned(), "none".to_string()))
+        .collect::<FxHashMap<_, _>>();
+
     // Process all tasks in the graph
     let context = ActionContext {
         affected_only: should_run_affected,
@@ -118,7 +124,7 @@ pub async fn run_target(
         passthrough_args: options.passthrough,
         primary_targets: FxHashSet::from_iter(primary_targets),
         profile: options.profile,
-        target_hashes: FxHashMap::default(),
+        target_hashes,
         touched_files,
         workspace_root: workspace.root.clone(),
     };

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -8,7 +8,7 @@ use moon_logger::{color, map_list};
 use moon_project_graph::ProjectGraph;
 use moon_utils::is_ci;
 use moon_workspace::Workspace;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use std::env;
 use std::string::ToString;
 
@@ -110,12 +110,6 @@ pub async fn run_target(
         }
     }
 
-    // Pre-populate target hashes with "none" for all primary targets
-    let target_hashes = primary_targets
-        .iter()
-        .map(|t| (t.to_owned(), "none".to_string()))
-        .collect::<FxHashMap<_, _>>();
-
     // Process all tasks in the graph
     let context = ActionContext {
         affected_only: should_run_affected,
@@ -124,9 +118,9 @@ pub async fn run_target(
         passthrough_args: options.passthrough,
         primary_targets: FxHashSet::from_iter(primary_targets),
         profile: options.profile,
-        target_hashes,
         touched_files,
         workspace_root: workspace.root.clone(),
+        ..ActionContext::default()
     };
 
     let dep_graph = dep_builder.build();

--- a/crates/core/action-context/src/lib.rs
+++ b/crates/core/action-context/src/lib.rs
@@ -25,7 +25,7 @@ pub struct ActionContext {
 
     pub profile: Option<ProfileType>,
 
-    pub target_hashes: FxHashMap<String, String>,
+    pub target_hashes: FxHashMap<Target, String>,
 
     pub touched_files: FxHashSet<PathBuf>,
 

--- a/crates/core/action-context/src/lib.rs
+++ b/crates/core/action-context/src/lib.rs
@@ -10,7 +10,7 @@ pub enum ProfileType {
     Heap,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionContext {
     pub affected_only: bool,

--- a/crates/core/action-pipeline/src/actions/run_target.rs
+++ b/crates/core/action-pipeline/src/actions/run_target.rs
@@ -37,16 +37,6 @@ pub async fn run_target(
         color::id(&task.target)
     );
 
-    // We must give this task a fake hash for it to be considered complete
-    // for other tasks! This case triggers for noop or cache disabled tasks.
-    // {
-    //     context
-    //         .write()
-    //         .await
-    //         .target_hashes
-    //         .insert(task.target.id.clone(), "skipped".into());
-    // }
-
     // Abort early if a no operation
     if runner.is_no_op() {
         debug!(

--- a/crates/core/action-pipeline/src/actions/run_target.rs
+++ b/crates/core/action-pipeline/src/actions/run_target.rs
@@ -39,13 +39,13 @@ pub async fn run_target(
 
     // We must give this task a fake hash for it to be considered complete
     // for other tasks! This case triggers for noop or cache disabled tasks.
-    {
-        context
-            .write()
-            .await
-            .target_hashes
-            .insert(task.target.id.clone(), "skipped".into());
-    }
+    // {
+    //     context
+    //         .write()
+    //         .await
+    //         .target_hashes
+    //         .insert(task.target.id.clone(), "skipped".into());
+    // }
 
     // Abort early if a no operation
     if runner.is_no_op() {

--- a/crates/core/action-pipeline/src/actions/run_target.rs
+++ b/crates/core/action-pipeline/src/actions/run_target.rs
@@ -51,6 +51,7 @@ pub async fn run_target(
         dbg!(&target.id, "WRITE 2");
         ctx.target_hashes.insert(target.clone(), "skipped".into());
         dbg!(&target.id, "WRITE 3");
+        drop(ctx);
     }
 
     // Abort early if a no operation

--- a/crates/core/action-pipeline/src/actions/sync_project.rs
+++ b/crates/core/action-pipeline/src/actions/sync_project.rs
@@ -34,6 +34,9 @@ pub async fn sync_project(
         color::id(&project.id)
     );
 
+    // Create a runfile for tasks to reference
+    workspace.cache.create_runfile(&project.id, project)?;
+
     // Collect all project dependencies so we can pass them along.
     // We can't pass the graph itself because of circuler references between crates!
     let mut dependencies = FxHashMap::default();

--- a/crates/core/runner/src/runner.rs
+++ b/crates/core/runner/src/runner.rs
@@ -338,16 +338,14 @@ impl<'a> Runner<'a> {
             "MOON_WORKING_DIR".to_owned(),
             path::to_string(&self.workspace.working_dir)?,
         );
-
-        // Store runtime data on the file system so that downstream commands can utilize it
-        let runfile = self
-            .workspace
-            .cache
-            .create_runfile(&self.project.id, self.project)?;
-
         env_vars.insert(
             "MOON_PROJECT_RUNFILE".to_owned(),
-            path::to_string(runfile.path)?,
+            path::to_string(
+                self.workspace
+                    .cache
+                    .get_state_path(&self.project.id)
+                    .join("runfile.json"),
+            )?,
         );
 
         Ok(env_vars)

--- a/crates/core/runner/src/runner.rs
+++ b/crates/core/runner/src/runner.rs
@@ -432,7 +432,7 @@ impl<'a> Runner<'a> {
 
         context
             .target_hashes
-            .insert(self.task.target.id.clone(), hash.clone());
+            .insert(self.task.target.clone(), hash.clone());
 
         // Hash is the same as the previous build, so simply abort!
         // However, ensure the outputs also exist, otherwise we should hydrate.

--- a/crates/core/runner/src/runner.rs
+++ b/crates/core/runner/src/runner.rs
@@ -498,11 +498,6 @@ impl<'a> Runner<'a> {
         Ok(None)
     }
 
-    /// Return true if this target is a no-op.
-    pub fn is_no_op(&self) -> bool {
-        self.task.is_no_op()
-    }
-
     /// Run the command as a child process and capture its output. If the process fails
     /// and `retry_count` is greater than 0, attempt the process again in case it passes.
     pub async fn run_command(

--- a/crates/core/runner/src/target_hasher.rs
+++ b/crates/core/runner/src/target_hasher.rs
@@ -1,5 +1,6 @@
 use crate::errors::RunnerError;
 use moon_hasher::{hash_btree, hash_vec, Digest, Hasher, Sha256};
+use moon_target::Target;
 use moon_task::Task;
 use moon_utils::path;
 use rustc_hash::FxHashMap;
@@ -98,12 +99,12 @@ impl TargetHasher {
     pub fn hash_task_deps(
         &mut self,
         task: &Task,
-        hashes: &FxHashMap<String, String>,
+        hashes: &FxHashMap<Target, String>,
     ) -> Result<(), RunnerError> {
         for dep in &task.deps {
             self.deps.insert(
                 dep.id.to_owned(),
-                match hashes.get(&dep.id) {
+                match hashes.get(dep) {
                     Some(hash) => hash.to_owned(),
                     None => {
                         return Err(RunnerError::MissingDependencyHash(

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,7 +12,7 @@
   inputs collection process. For large projects, you'll see improved performance.
 - Fixed an issue where root-level input globs were not matching correctly when `hasher.walkStrategy`
   was "vcs".
-- Fixed an issue where some concurrent tasks via a parent `noop` task would not start or run in
+- Fixed a deadlock where some concurrent tasks via a parent `noop` task would not start or run in
   parallel.
 
 #### ⚙️ Internal

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,6 +12,8 @@
   inputs collection process. For large projects, you'll see improved performance.
 - Fixed an issue where root-level input globs were not matching correctly when `hasher.walkStrategy`
   was "vcs".
+- Fixed an issue where some concurrent tasks via a parent `noop` task would not start or run in
+  parallel.
 
 #### ⚙️ Internal
 


### PR DESCRIPTION
I've noticed and the community has noticed that watcher-type tasks that should run in parallel sometimes don't. Only 1 of the tasks runs, while the others never start. 

It turns out that the context rwlock was forever waiting to acquire a lock for the subsequent tasks.