### PR TITLE
internal: Switch to a semaphore.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,9 +2338,9 @@ dependencies = [
  "moon_utils",
  "moon_workspace",
  "moonbase",
+ "num_cpus",
  "proto_cli",
  "rustc-hash",
- "rusty_pool",
  "serde",
  "thiserror",
  "tokio",
@@ -3975,19 +3975,6 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
-
-[[package]]
-name = "rusty_pool"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed36cdb20de66d89a17ea04b8883fc7a386f2cf877aaedca5005583ce4876ff"
-dependencies = [
- "crossbeam-channel",
- "futures",
- "futures-channel",
- "futures-executor",
- "num_cpus",
-]
 
 [[package]]
 name = "ryu"

--- a/crates/core/action-pipeline/Cargo.toml
+++ b/crates/core/action-pipeline/Cargo.toml
@@ -32,9 +32,9 @@ moon_workspace = { path = "../workspace" }
 moonbase = { path = "../moonbase" }
 ci_env = { workspace = true }
 console = { workspace = true }
+num_cpus = "1.15.0"
 proto_cli = { workspace = true }
 rustc-hash = { workspace = true }
-rusty_pool = "0.7.0"
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/core/action-pipeline/src/pipeline.rs
+++ b/crates/core/action-pipeline/src/pipeline.rs
@@ -131,15 +131,11 @@ impl Pipeline {
                     let mut action = Action::new(node.to_owned());
                     action.log_target = format!("{batch_target_name}:{action_index}");
 
-                    // let semaphore_clone = semaphore.clone();
-                    let permit = semaphore.clone().acquire_owned().await.unwrap();
+                    let Ok(permit) = semaphore.clone().acquire_owned().await else {
+                        break; // Should error?
+                    };
 
                     action_handles.push(tokio::spawn(async move {
-                        // let permit = semaphore_clone
-                        //     .acquire()
-                        //     .await
-                        //     .expect("Failed to acquire semaphore!");
-
                         let result = process_action(
                             action,
                             context_clone,

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 #### ⚙️ Internal
 
 - Upgraded to proto v0.4.
+- Switched to a semaphore for restricting task concurrency.
 
 ## 1.0.2
 


### PR DESCRIPTION
`rusty_pool` has far too much overhead, so let's try a semaphore.