### PR TITLE
new: Support optional messages when new versions are available.

### DIFF
--- a/crates/cli/src/commands/upgrade.rs
+++ b/crates/cli/src/commands/upgrade.rs
@@ -22,8 +22,10 @@ pub async fn upgrade() -> Result<(), AnyError> {
     let version_check = check_version(version, true).await;
 
     let new_version = match version_check {
-        Ok((newer_version, _)) if Version::parse(&newer_version)? > Version::parse(version)? => {
-            newer_version
+        Ok(Some(newer_version))
+            if Version::parse(&newer_version.current_version)? > Version::parse(version)? =>
+        {
+            newer_version.current_version
         }
         Ok(_) => {
             println!("You're already on the latest version of moon!");

--- a/crates/cli/src/helpers.rs
+++ b/crates/cli/src/helpers.rs
@@ -90,12 +90,17 @@ pub async fn check_for_new_version() {
         let prefix = get_checkpoint_prefix(Checkpoint::Announcement);
 
         match check_version(version, false).await {
-            Ok((newer_version, true)) => {
+            Ok(Some(newer_version)) => {
                 println!(
                     "{} There's a new version of moon available, {}!",
                     prefix,
-                    color::success(newer_version)
+                    color::success(newer_version.current_version)
                 );
+
+                if let Some(newer_message) = newer_version.message {
+                    println!("{} {}", prefix, newer_message);
+                }
+
                 println!(
                     "{} Run {} or install from {}",
                     prefix,

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### 🚀 Updates
 
 - Added `hasher.batchSize` to control the number of files to be hashed per batch.
+- Updated new version checks to include an optional message.
 
 #### 🐞 Fixes
 


### PR DESCRIPTION
This allows us to provide more context for what's available in the release. Especially when hotfixes are concerned.