### PR TITLE
new: Better handling of Node.js tasks that call `moon`.

### DIFF
--- a/crates/core/tool/src/errors.rs
+++ b/crates/core/tool/src/errors.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ToolError {
-    #[error("Unable to find a binary for <symbol>{0}</symbol>. Have you installed the corresponding dependency?")]
-    MissingBinary(String),
+    #[error("Unable to find a {0} for <symbol>{1}</symbol>. Have you installed the corresponding dependency?")]
+    MissingBinary(String, String),
 
     #[error("{0} has not been configured or installed, unable to proceed.")]
     UnknownTool(String),

--- a/crates/node/platform/src/actions/run_target.rs
+++ b/crates/node/platform/src/actions/run_target.rs
@@ -84,11 +84,22 @@ fn find_package_bin(
     bin_name: &str,
 ) -> Result<Option<Command>, ToolError> {
     let possible_bin_path = match node::find_package_bin(starting_dir, bin_name)? {
-        Some(bin) => Ok(bin),
-        None => Err(ToolError::MissingBinary(bin_name.to_owned())),
+        Some(bin) => bin,
+        None => {
+            // moon isn't installed as a node module, but probably
+            // exists globally, so let's go with that instead of failing
+            if bin_name == "moon" {
+                return Ok(Some(Command::new(bin_name)));
+            }
+
+            return Err(ToolError::MissingBinary(
+                "node module".into(),
+                bin_name.to_owned(),
+            ));
+        }
     };
 
-    match possible_bin_path? {
+    match possible_bin_path {
         // Rust, Go
         BinFile::Binary(bin_path) => {
             return Ok(Some(Command::new(bin_path)));

--- a/crates/node/platform/src/task.rs
+++ b/crates/node/platform/src/task.rs
@@ -26,7 +26,7 @@ lazy_static! {
 
     // This isn't exhaustive but captures very popular tools
     pub static ref DEV_COMMAND: regex::Regex =
-        regex::create_regex(r#"(astro (dev|preview))|(concurrently)|(gatsby (new|dev|develop|serve|repl))|(next (dev|start))|(nuxt (dev|preview))|(packemon watch)|(parcel [^build])|(react-scripts start)|(snowpack dev)|(vite (dev|preview|serve))|(vue-cli-service serve)|(webpack (s|serve|server|w|watch|-))"#)
+        regex::create_regex(r#"(astro (dev|preview))|(concurrently)|(gatsby (new|dev|develop|serve|repl))|(next (dev|start))|(nuxt (dev|preview))|(packemon watch)|(parcel [^build])|(react-scripts start)|(snowpack dev)|(solid-start (dev|start))|(vite (dev|preview|serve))|(vue-cli-service serve)|(webpack (s|serve|server|w|watch|-))"#)
             .unwrap();
 
     pub static ref DEV_COMMAND_SOLO: regex::Regex =

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 #### ⚙️ Internal
 
 - Support pnpm v8's new lockfile format.
+- Better handling for task's that execute the `moon` binary.
 
 ## 1.0.3
 

--- a/website/blog/2023-04-03_moon-v1.1.mdx
+++ b/website/blog/2023-04-03_moon-v1.1.mdx
@@ -78,3 +78,4 @@ View the [official release](https://github.com/moonrepo/moon/releases/tag/v1.1.0
 changes.
 
 - Support pnpm v8's new lockfile format.
+- Better handling for task's that execute the `moon` binary.

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -172,13 +172,7 @@ env:
   NODE_ENV: 'production'
 ```
 
-Variables also support substitution using the syntax `${VAR_NAME}`. When using substitution, only
-variables in the current process can be referenced, and not those currently defined in `env`.
-
-```yaml title="moon.yml" {1,2}
-env:
-  APP_TARGET: '${REGION}-${ENVIRONMENT}'
-```
+> View the task [`env`](#env-1) setting for more usage examples and information.
 
 ## `fileGroups`
 
@@ -364,6 +358,17 @@ tasks:
     command: 'webpack'
     env:
       NODE_ENV: 'production'
+```
+
+Variables also support substitution using the syntax `${VAR_NAME}`. When using substitution, only
+variables in the current process can be referenced, and not those currently defined in `env`.
+
+```yaml title="moon.yml" {4,5}
+tasks:
+  build:
+    command: 'webpack'
+    env:
+      APP_TARGET: '${REGION}-${ENVIRONMENT}'
 ```
 
 ### `inputs`
@@ -565,6 +570,9 @@ A boolean or path to a `.env` file (also know as dotenv file) that defines a col
 [environment variables](#env-1) for the current task. Variables will be loaded on project creation,
 but will _not_ override those defined in [`env`](#env-1).
 
+Variables defined in the file support value substitution/expansion by wrapping the variable name in
+curly brackets, such as `${VAR_NAME}`.
+
 ```yaml title="moon.yml" {6}
 tasks:
   build:
@@ -578,7 +586,13 @@ tasks:
       envFile: '/.env.shared'
 ```
 
-> Variables defined in the file support value substitution using `${VAR_NAME}` syntax.
+:::caution
+
+File parsing is done using the Rust [`dotenvy`](https://crates.io/crates/dotenvy) crate, which is
+_different_ than the Node.js [`dotenv`](https://www.npmjs.com/package/dotenv) package. The biggest
+differences are around quote handling and variable substitution, so be aware of this!
+
+:::
 
 #### `mergeArgs`
 


### PR DESCRIPTION
Our task inference creates tasks with commands like `moon run-script build`, which work when the repo has `moon` installed as a node_module with `@moonrepo/cli`. If they do not have it installed, and use a global moon binary, all of these commands will fail.

To work around this, if a local moon binary is not found, we'll just fallback to the global one.