### PR TITLE
fix: Cache file group walking.

### DIFF
--- a/.yarn/versions/40bb9d89.yml
+++ b/.yarn/versions/40bb9d89.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,6 +2997,7 @@ dependencies = [
  "moon_target",
  "moon_test_utils",
  "moon_utils",
+ "once_cell",
  "rustc-hash",
  "serde",
  "strum",

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -108,14 +108,19 @@ pub async fn project(id: String, json: bool) -> Result<(), AnyError> {
         term.write_line("")?;
         term.render_label(Label::Default, "File groups")?;
 
-        for group in project.file_groups.keys().sorted() {
+        for group_name in project.file_groups.keys().sorted() {
             let mut files = vec![];
+            let group = project.file_groups.get(group_name).unwrap();
 
-            for file in &project.file_groups.get(group).unwrap().files {
+            for file in &group.files {
                 files.push(color::file(file));
             }
 
-            term.render_entry_list(group, files)?;
+            for file in &group.globs {
+                files.push(color::file(file));
+            }
+
+            term.render_entry_list(group_name, files)?;
         }
     }
 

--- a/crates/core/project-graph/tests/projects_test.rs
+++ b/crates/core/project-graph/tests/projects_test.rs
@@ -99,7 +99,7 @@ mod task_inheritance {
                 .file_groups
                 .get("files_glob")
                 .unwrap()
-                .files,
+                .globs,
             string_vec!["**/*.{ts,tsx}"]
         );
 
@@ -132,7 +132,7 @@ mod task_inheritance {
                 .file_groups
                 .get("files_glob")
                 .unwrap()
-                .files,
+                .globs,
             string_vec!["**/*.{ts,tsx}"]
         );
 

--- a/crates/core/task/Cargo.toml
+++ b/crates/core/task/Cargo.toml
@@ -10,6 +10,7 @@ moon_logger = { path = "../logger" }
 moon_target = { path = "../target" }
 moon_utils = { path = "../utils" }
 common-path = "1.0.0"
+once_cell = "1.17.1"
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }

--- a/crates/core/task/src/file_group.rs
+++ b/crates/core/task/src/file_group.rs
@@ -201,6 +201,6 @@ impl FileGroup {
 
 impl PartialEq for FileGroup {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id && self.files == other.files
+        self.id == other.id && self.files == other.files && self.globs == other.globs
     }
 }

--- a/crates/core/task/tests/file_group_test.rs
+++ b/crates/core/task/tests/file_group_test.rs
@@ -8,11 +8,12 @@ mod merge {
 
     #[test]
     fn overwrites() {
-        let mut file_group = FileGroup::new("id", string_vec!["**/*"]);
+        let mut file_group = FileGroup::new("id", string_vec!["a", "**/*"]);
 
-        file_group.merge(string_vec!["*"]);
+        file_group.merge(string_vec!["b", "*"]);
 
-        assert_eq!(file_group.files, string_vec!["*"]);
+        assert_eq!(file_group.files, string_vec!["b"]);
+        assert_eq!(file_group.globs, string_vec!["*"]);
     }
 }
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed an issue where token function resolving would cause massive performance degradation.
+
 ## 1.1.0
 
 #### 🚀 Updates


### PR DESCRIPTION
If a project defines a file group that's inherited by 50 tasks, _each_ task would walk the file system, causing massive performance issues. This adds caching to solve the problem.

Fixes https://github.com/moonrepo/moon/issues/771