### PR TITLE
ci: Migrate to `moonrepo/setup-rust` action.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,7 @@ jobs:
           submodules: false
           ref: ${{ steps.sha.outputs.result }}
           # ref: ${{ github.event.pull_request.head.sha }}
-      - uses: dtolnay/rust-toolchain@1.68.1
+      - uses: moonrepo/setup-rust@v0
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: benchmark

--- a/.github/workflows/moon.yml
+++ b/.github/workflows/moon.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-      - uses: dtolnay/rust-toolchain@1.68.1
+      - uses: moonrepo/setup-rust@v0
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: moon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ${{ matrix.host }}
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.68.1
+      - uses: moonrepo/setup-rust@v0
         if: ${{ !matrix.docker-target }}
         with:
           target: ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.68.1
+      - uses: moonrepo/setup-rust@v0
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.68.1
+      - uses: moonrepo/setup-rust@v0
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.68.1
+      - uses: moonrepo/setup-rust@v0
         with:
           components: llvm-tools-preview
       - name: Cache cargo

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-channel = "1.68.1"
+channel = "1.68.2"


### PR DESCRIPTION
Let's own this.