### PR TITLE
new: Implement a moon query language (MQL).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,7 +3080,8 @@ name = "moon_query"
 version = "0.1.0"
 dependencies = [
  "moon_config",
- "nom",
+ "pest",
+ "pest_derive",
 ]
 
 [[package]]
@@ -3615,9 +3616,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
+checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3625,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81186863f3d0a27340815be8f2078dd8050b14cd71913db9fbda795e5f707d7"
+checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3635,22 +3636,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a1ef20bf3193c15ac345acb32e26b3dc3223aff4d77ae4fc5359567683796b"
+checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3b284b1f13a20dc5ebc90aff59a51b8d7137c221131b52a7260c08cbc1cc80"
+checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
 dependencies = [
  "once_cell",
  "pest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3076,6 +3076,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "moon_query"
+version = "0.1.0"
+dependencies = [
+ "moon_config",
+ "nom",
+]
+
+[[package]]
 name = "moon_ruby_lang"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,8 +3080,10 @@ name = "moon_query"
 version = "0.1.0"
 dependencies = [
  "moon_config",
+ "moon_error",
  "pest",
  "pest_derive",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,6 +3081,7 @@ version = "0.1.0"
 dependencies = [
  "moon_config",
  "moon_error",
+ "moon_utils",
  "pest",
  "pest_derive",
  "thiserror",

--- a/crates/core/config/src/project/config.rs
+++ b/crates/core/config/src/project/config.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::str::FromStr;
-use strum::Display;
+use strum::{Display, EnumString};
 use validator::{Validate, ValidationError};
 
 fn deserialize_language<'de, D>(deserializer: D) -> Result<ProjectLanguage, D::Error>
@@ -90,7 +90,17 @@ fn validate_channel(value: &str) -> Result<(), ValidationError> {
 }
 
 #[derive(
-    Clone, Copy, Debug, Default, Deserialize, Display, Eq, JsonSchema, PartialEq, Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Deserialize,
+    Display,
+    EnumString,
+    Eq,
+    JsonSchema,
+    PartialEq,
+    Serialize,
 )]
 #[serde(rename_all = "lowercase")]
 pub enum ProjectType {

--- a/crates/core/config/src/project/language_platform.rs
+++ b/crates/core/config/src/project/language_platform.rs
@@ -3,7 +3,7 @@ use moon_utils::regex::clean_id;
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, str::FromStr};
-use strum::{Display, EnumIter};
+use strum::{Display, EnumIter, EnumString};
 
 #[derive(Clone, Debug, Default, EnumIter, Eq, JsonSchema, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -97,6 +97,7 @@ impl fmt::Display for ProjectLanguage {
     Display,
     Eq,
     EnumIter,
+    EnumString,
     Hash,
     JsonSchema,
     PartialEq,

--- a/crates/core/config/src/project/task.rs
+++ b/crates/core/config/src/project/task.rs
@@ -8,6 +8,7 @@ use moon_utils::regex::ENV_VAR;
 use rustc_hash::FxHashMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString};
 use validator::{Validate, ValidationError};
 
 // These structs utilize optional fields so that we can handle merging effectively,
@@ -44,6 +45,20 @@ fn validate_outputs(list: &[String]) -> Result<(), ValidationError> {
     }
 
     Ok(())
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Display, Eq, EnumString, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TaskType {
+    #[strum(serialize = "build")]
+    Build,
+
+    #[strum(serialize = "run")]
+    Run,
+
+    #[default]
+    #[strum(serialize = "test")]
+    Test,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]

--- a/crates/core/query/Cargo.toml
+++ b/crates/core/query/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "moon_query"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+moon_config = { path = "../config" }
+nom = "7.1.3"

--- a/crates/core/query/Cargo.toml
+++ b/crates/core/query/Cargo.toml
@@ -9,3 +9,6 @@ moon_error = { path = "../error" }
 pest = "2.5.7"
 pest_derive = "2.5.7"
 thiserror = { workspace = true }
+
+[dev-dependencies]
+moon_utils = { path = "../utils" }

--- a/crates/core/query/Cargo.toml
+++ b/crates/core/query/Cargo.toml
@@ -5,5 +5,7 @@ edition = "2021"
 
 [dependencies]
 moon_config = { path = "../config" }
+moon_error = { path = "../error" }
 pest = "2.5.7"
 pest_derive = "2.5.7"
+thiserror = { workspace = true }

--- a/crates/core/query/Cargo.toml
+++ b/crates/core/query/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 
 [dependencies]
 moon_config = { path = "../config" }
-nom = "7.1.3"
+pest = "2.5.7"
+pest_derive = "2.5.7"

--- a/crates/core/query/src/builder.rs
+++ b/crates/core/query/src/builder.rs
@@ -3,6 +3,7 @@ use crate::parser::{parse, AstNode, ComparisonOperator, LogicalOperator};
 use moon_config::{PlatformType, ProjectLanguage, ProjectType, TaskType};
 use std::str::FromStr;
 
+#[derive(Debug, PartialEq)]
 pub enum Field {
     Language(Vec<ProjectLanguage>),
     Project(Vec<String>),
@@ -15,11 +16,13 @@ pub enum Field {
     TaskType(Vec<TaskType>),
 }
 
+#[derive(Debug, PartialEq)]
 pub struct QueryField {
     pub field: Field,
     pub op: ComparisonOperator,
 }
 
+#[derive(Debug, Default, PartialEq)]
 pub struct QueryCriteria {
     pub op: Option<LogicalOperator>,
     pub fields: Vec<QueryField>,
@@ -98,9 +101,17 @@ fn build_criteria(ast: Vec<AstNode>) -> Result<QueryCriteria, QueryError> {
         }
     }
 
+    if criteria.op.is_none() {
+        criteria.op = Some(LogicalOperator::And);
+    }
+
     Ok(criteria)
 }
 
 pub fn build(input: &str) -> Result<QueryCriteria, QueryError> {
+    if input.is_empty() {
+        return Err(QueryError::EmptyInput);
+    }
+
     build_criteria(parse(input).map_err(|e| QueryError::ParseFailure(e.to_string()))?)
 }

--- a/crates/core/query/src/builder.rs
+++ b/crates/core/query/src/builder.rs
@@ -1,0 +1,106 @@
+use crate::errors::QueryError;
+use crate::parser::{parse, AstNode, ComparisonOperator, LogicalOperator};
+use moon_config::{PlatformType, ProjectLanguage, ProjectType, TaskType};
+use std::str::FromStr;
+
+pub enum Field {
+    Language(Vec<ProjectLanguage>),
+    Project(Vec<String>),
+    ProjectAlias(Vec<String>),
+    ProjectSource(Vec<String>),
+    ProjectType(Vec<ProjectType>),
+    Tag(Vec<String>),
+    Task(Vec<String>),
+    TaskPlatform(Vec<PlatformType>),
+    TaskType(Vec<TaskType>),
+}
+
+pub struct QueryField {
+    pub field: Field,
+    pub op: ComparisonOperator,
+}
+
+pub struct QueryCriteria {
+    pub op: Option<LogicalOperator>,
+    pub fields: Vec<QueryField>,
+    pub criteria: Vec<QueryCriteria>,
+}
+
+fn build_criteria_enum<T: FromStr>(
+    field: &str,
+    op: &ComparisonOperator,
+    values: Vec<String>,
+) -> Result<Vec<T>, QueryError> {
+    if matches!(op, ComparisonOperator::Like | ComparisonOperator::NotLike) {
+        return Err(QueryError::UnsupportedLikeOperator(field.to_owned()));
+    }
+
+    let mut result = vec![];
+
+    for value in values {
+        result.push(
+            value
+                .parse()
+                .map_err(|_| QueryError::UnknownFieldValue(field.to_owned(), value))?,
+        );
+    }
+
+    Ok(result)
+}
+
+fn build_criteria(ast: Vec<AstNode>) -> Result<QueryCriteria, QueryError> {
+    let mut criteria = QueryCriteria {
+        op: None,
+        fields: vec![],
+        criteria: vec![],
+    };
+
+    for node in ast {
+        match node {
+            AstNode::Comparison { field, op, value } => {
+                let field = match field.as_str() {
+                    "language" => {
+                        Field::Language(build_criteria_enum::<ProjectLanguage>(&field, &op, value)?)
+                    }
+                    "project" => Field::Project(value),
+                    "projectAlias" => Field::ProjectAlias(value),
+                    "projectSource" => Field::ProjectSource(value),
+                    "projectType" => {
+                        Field::ProjectType(build_criteria_enum::<ProjectType>(&field, &op, value)?)
+                    }
+                    "tag" => Field::Tag(value),
+                    "task" => Field::Task(value),
+                    "taskPlatform" => Field::TaskPlatform(build_criteria_enum::<PlatformType>(
+                        &field, &op, value,
+                    )?),
+                    "taskType" => {
+                        Field::TaskType(build_criteria_enum::<TaskType>(&field, &op, value)?)
+                    }
+                    _ => {
+                        return Err(QueryError::UnknownField(field));
+                    }
+                };
+
+                criteria.fields.push(QueryField { field, op });
+            }
+            AstNode::Op { op } => {
+                if let Some(current_op) = &criteria.op {
+                    if &op != current_op {
+                        return Err(QueryError::LogicalOperatorMismatch);
+                    }
+                } else {
+                    criteria.op = Some(op);
+                }
+            }
+            AstNode::Group { nodes } => {
+                criteria.criteria.push(build_criteria(nodes)?);
+            }
+        }
+    }
+
+    Ok(criteria)
+}
+
+pub fn build(input: &str) -> Result<QueryCriteria, QueryError> {
+    build_criteria(parse(input).map_err(|e| QueryError::ParseFailure(e.to_string()))?)
+}

--- a/crates/core/query/src/errors.rs
+++ b/crates/core/query/src/errors.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum QueryError {
+    #[error("Cannot use both AND (&&) and OR (||) logical operators in the same group. Wrap in parentheses to create sub-groups.")]
+    LogicalOperatorMismatch,
+
+    #[error("Unknown query field \"{0}\".")]
+    UnknownField(String),
+
+    #[error("Unknown value \"{1}\" for field \"{0}\".")]
+    UnknownFieldValue(String, String),
+
+    #[error("Failed to parse query:\n{0}")]
+    ParseFailure(String),
+}

--- a/crates/core/query/src/errors.rs
+++ b/crates/core/query/src/errors.rs
@@ -2,13 +2,16 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum QueryError {
+    #[error("Encountered an empty query. Did you forget to add a query?")]
+    EmptyInput,
+
     #[error("Cannot use both AND (&&) and OR (||) logical operators in the same group. Wrap in parentheses to create sub-groups.")]
     LogicalOperatorMismatch,
 
     #[error("Unknown query field \"{0}\".")]
     UnknownField(String),
 
-    #[error("Unknown value \"{1}\" for field \"{0}\".")]
+    #[error("Unknown query value \"{1}\" for field \"{0}\".")]
     UnknownFieldValue(String, String),
 
     #[error("Like operators (~ and !~) are not supported for field \"{0}\".")]

--- a/crates/core/query/src/errors.rs
+++ b/crates/core/query/src/errors.rs
@@ -11,6 +11,9 @@ pub enum QueryError {
     #[error("Unknown value \"{1}\" for field \"{0}\".")]
     UnknownFieldValue(String, String),
 
+    #[error("Like operators (~ and !~) are not supported for field \"{0}\".")]
+    UnsupportedLikeOperator(String),
+
     #[error("Failed to parse query:\n{0}")]
     ParseFailure(String),
 }

--- a/crates/core/query/src/lib.rs
+++ b/crates/core/query/src/lib.rs
@@ -1,3 +1,4 @@
+mod errors;
 mod parser;
 
 pub use parser::*;

--- a/crates/core/query/src/lib.rs
+++ b/crates/core/query/src/lib.rs
@@ -1,13 +1,3 @@
-use moon_config::ProjectType;
+mod parser;
 
-pub enum Operator {
-    Equal,    // =
-    NotEqual, // !=
-    Like,     // ~
-    NotLike,  // !~
-}
-
-#[derive(Debug, PartialEq)]
-pub struct ProjectQuery {
-    pub type_of: ProjectType,
-}
+pub use parser::*;

--- a/crates/core/query/src/lib.rs
+++ b/crates/core/query/src/lib.rs
@@ -1,4 +1,7 @@
+mod builder;
 mod errors;
 mod parser;
 
+pub use builder::*;
+pub use errors::QueryError;
 pub use parser::*;

--- a/crates/core/query/src/lib.rs
+++ b/crates/core/query/src/lib.rs
@@ -1,0 +1,13 @@
+use moon_config::ProjectType;
+
+pub enum Operator {
+    Equal,    // =
+    NotEqual, // !=
+    Like,     // ~
+    NotLike,  // !~
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ProjectQuery {
+    pub type_of: ProjectType,
+}

--- a/crates/core/query/src/mql.pest
+++ b/crates/core/query/src/mql.pest
@@ -1,7 +1,7 @@
 WHITESPACE = _{ " " }
 
 key        = @{ ASCII_ALPHANUMERIC+ }
-value      = @{ (ASCII_ALPHANUMERIC | "-" | "_")+ }
+value      = @{ (ASCII_ALPHANUMERIC | "-" | "_" | "/")+ }
 value_glob = @{ (ASCII_ALPHANUMERIC | "-" | "_" | "*" | "!" | "." | "," | "/" | "{" | "}" | "[" | "]" | "?")+ }
 value_list =  { "[" ~ value ~ ("," ~ value)* ~ "]" }
 

--- a/crates/core/query/src/mql.pest
+++ b/crates/core/query/src/mql.pest
@@ -1,22 +1,29 @@
 WHITESPACE = _{ " " }
 
 key        = @{ ASCII_ALPHANUMERIC+ }
-value      = @{ ASCII_ALPHANUMERIC+ | "-" | "_" }
+value      = @{ (ASCII_ALPHANUMERIC | "-" | "_")+ }
+value_glob = @{ (ASCII_ALPHANUMERIC | "-" | "_" | "*" | "!" | "." | "," | "/" | "{" | "}" | "[" | "]" | "?")+ }
 value_list =  { "[" ~ value ~ ("," ~ value)* ~ "]" }
 
 // Operators
 
-and = { "&&" | "AND" }
-or  = { "||" | "OR" }
-eq  = { "=" }
-neq = { "!=" }
+and   = { "&&" | "AND" }
+or    = { "||" | "OR" }
+eq    = { "=" }
+neq   = { "!=" }
+like  = { "~" }
+nlike = { "!~" }
 
 logic_op = _{ and | or }
 cmp_op   = _{ eq | neq }
+like_op  = _{ like | nlike }
 
 // Expression
 
-comparison =  { key ~ cmp_op ~ (value | value_list) }
+comparison_literal  = _{ key ~ cmp_op ~ (value_list | value) }
+comparison_wildcard = _{ key ~ like_op ~ value_glob }
+comparison          =  { comparison_wildcard | comparison_literal }
+
 expr       = _{ comparison ~ (logic_op ~ (comparison | expr_group))* }
 expr_group =  { "(" ~ expr ~ ")" }
 

--- a/crates/core/query/src/mql.pest
+++ b/crates/core/query/src/mql.pest
@@ -1,8 +1,8 @@
 WHITESPACE = _{ " " }
 
 key        = @{ ASCII_ALPHANUMERIC+ }
-value      = @{ (ASCII_ALPHANUMERIC | "-" | "_" | "/")+ }
-value_glob = @{ (ASCII_ALPHANUMERIC | "-" | "_" | "*" | "!" | "." | "," | "/" | "{" | "}" | "[" | "]" | "?")+ }
+value      = @{ (ASCII_ALPHANUMERIC | "-" | "_" | "/" | "@")+ }
+value_glob = @{ (ASCII_ALPHANUMERIC | "-" | "_" | "*" | "!" | "." | "," | "/" | "\\" | "{" | "}" | "<" | ">" | "[" | "]" | "?" | "$" | ":" | "@")+ }
 value_list =  { "[" ~ value ~ ("," ~ value)* ~ "]" }
 
 // Operators

--- a/crates/core/query/src/mql.pest
+++ b/crates/core/query/src/mql.pest
@@ -16,9 +16,10 @@ cmp_op   = _{ eq | neq }
 
 // Expression
 
-comparison = { key ~ cmp_op ~ (value | value_list) }
-// expression = { comparison ~ (logic_op ~ comparison)* }
+comparison =  { key ~ cmp_op ~ (value | value_list) }
+expr       = _{ comparison ~ (logic_op ~ (comparison | expr_group))* }
+expr_group =  { "(" ~ expr ~ ")" }
 
 query = _{
-    SOI ~ (comparison ~ (logic_op ~ comparison)*) ~ EOI
+    SOI ~ expr ~ EOI
 }

--- a/crates/core/query/src/mql.pest
+++ b/crates/core/query/src/mql.pest
@@ -18,7 +18,7 @@ logic_op = _{ and | or }
 cmp_op   = _{ eq | neq }
 like_op  = _{ like | nlike }
 
-// Expression
+// Expressions
 
 comparison_literal  = _{ key ~ cmp_op ~ (value_list | value) }
 comparison_wildcard = _{ key ~ like_op ~ value_glob }

--- a/crates/core/query/src/mql.pest
+++ b/crates/core/query/src/mql.pest
@@ -1,0 +1,24 @@
+WHITESPACE = _{ " " }
+
+key        = @{ ASCII_ALPHANUMERIC+ }
+value      = @{ ASCII_ALPHANUMERIC+ | "-" | "_" }
+value_list =  { "[" ~ value ~ ("," ~ value)* ~ "]" }
+
+// Operators
+
+and = { "&&" | "AND" }
+or  = { "||" | "OR" }
+eq  = { "=" }
+neq = { "!=" }
+
+logic_op = _{ and | or }
+cmp_op   = _{ eq | neq }
+
+// Expression
+
+comparison = { key ~ cmp_op ~ (value | value_list) }
+// expression = { comparison ~ (logic_op ~ comparison)* }
+
+query = _{
+    SOI ~ (comparison ~ (logic_op ~ comparison)*) ~ EOI
+}

--- a/crates/core/query/src/parser.rs
+++ b/crates/core/query/src/parser.rs
@@ -1,0 +1,115 @@
+use moon_config::{ProjectLanguage, ProjectType};
+use pest::{error::Error, Parser};
+use pest_derive::Parser;
+
+// pub enum Operator {
+//     Equal,    // =
+//     NotEqual, // !=
+//     Like,     // ~
+//     NotLike,  // !~
+// }
+
+// #[derive(Debug, PartialEq)]
+// pub struct ProjectQuery {
+//     pub type_of: ProjectType,
+// }
+
+#[derive(Parser)]
+#[grammar = "mql.pest"]
+struct MqlParser;
+
+pub enum Condition {
+    All,
+    Any,
+}
+
+pub struct ConditionGroup {
+    pub condition: Condition,
+    pub criteria: Vec<Condition>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum LogicalOperator {
+    And, // &&
+    Or,  // ||
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ComparisonOperator {
+    Equal,    // =
+    NotEqual, // !=
+}
+
+pub enum FieldComparison {
+    Language(ComparisonOperator, ProjectLanguage),
+    Project(ComparisonOperator, String),
+    ProjectAlias(ComparisonOperator, String),
+    ProjectSource(ComparisonOperator, String),
+    ProjectType(ComparisonOperator, ProjectType),
+}
+
+pub fn parse(input: &str) -> Result<Vec<AstNode>, Error<Rule>> {
+    let mut ast = vec![];
+    let pairs = MqlParser::parse(Rule::query, input)?;
+
+    dbg!(&pairs);
+
+    for pair in pairs {
+        match pair.as_rule() {
+            Rule::comparison => {
+                let mut inner = pair.into_inner();
+                let field = inner.next().expect("Missing field name.");
+                let op = inner.next().expect("Missing comparison operator.");
+                let value = inner.next().expect("Missing field value.");
+
+                dbg!("INNER", &inner);
+
+                ast.push(AstNode::Comparison {
+                    field: match field.as_rule() {
+                        Rule::key => field.as_str().to_string(),
+                        _ => unreachable!(),
+                    },
+                    op: match op.as_rule() {
+                        Rule::eq => ComparisonOperator::Equal,
+                        Rule::neq => ComparisonOperator::NotEqual,
+                        _ => unreachable!(),
+                    },
+                    value: match value.as_rule() {
+                        Rule::value => vec![value.as_str().to_string()],
+                        Rule::value_list => value
+                            .into_inner()
+                            .map(|pair| pair.as_str().to_string())
+                            .collect(),
+                        _ => unreachable!(),
+                    },
+                });
+            }
+            Rule::and => {
+                ast.push(AstNode::LogicalOp {
+                    op: LogicalOperator::And,
+                });
+            }
+            Rule::or => {
+                ast.push(AstNode::LogicalOp {
+                    op: LogicalOperator::Or,
+                });
+            }
+            Rule::WHITESPACE | Rule::EOI => {}
+            _ => unreachable!(),
+        }
+    }
+
+    Ok(ast)
+}
+
+#[derive(Debug, PartialEq)]
+pub enum AstNode {
+    Comparison {
+        field: String,
+        op: ComparisonOperator,
+        value: Vec<String>,
+    },
+    LogicalOp {
+        op: LogicalOperator,
+    },
+}

--- a/crates/core/query/src/parser.rs
+++ b/crates/core/query/src/parser.rs
@@ -1,32 +1,17 @@
+use std::str::FromStr;
+
+use crate::errors::QueryError;
 use moon_config::{ProjectLanguage, ProjectType};
-use pest::{error::Error, Parser};
+use pest::{
+    error::Error,
+    iterators::{Pair, Pairs},
+    Parser,
+};
 use pest_derive::Parser;
-
-// pub enum Operator {
-//     Equal,    // =
-//     NotEqual, // !=
-//     Like,     // ~
-//     NotLike,  // !~
-// }
-
-// #[derive(Debug, PartialEq)]
-// pub struct ProjectQuery {
-//     pub type_of: ProjectType,
-// }
 
 #[derive(Parser)]
 #[grammar = "mql.pest"]
 struct MqlParser;
-
-pub enum Condition {
-    All,
-    Any,
-}
-
-pub struct ConditionGroup {
-    pub condition: Condition,
-    pub criteria: Vec<Condition>,
-}
 
 #[derive(Debug, PartialEq)]
 pub enum LogicalOperator {
@@ -40,68 +25,6 @@ pub enum ComparisonOperator {
     NotEqual, // !=
 }
 
-pub enum FieldComparison {
-    Language(ComparisonOperator, ProjectLanguage),
-    Project(ComparisonOperator, String),
-    ProjectAlias(ComparisonOperator, String),
-    ProjectSource(ComparisonOperator, String),
-    ProjectType(ComparisonOperator, ProjectType),
-}
-
-pub fn parse(input: &str) -> Result<Vec<AstNode>, Error<Rule>> {
-    let mut ast = vec![];
-    let pairs = MqlParser::parse(Rule::query, input)?;
-
-    dbg!(&pairs);
-
-    for pair in pairs {
-        match pair.as_rule() {
-            Rule::comparison => {
-                let mut inner = pair.into_inner();
-                let field = inner.next().expect("Missing field name.");
-                let op = inner.next().expect("Missing comparison operator.");
-                let value = inner.next().expect("Missing field value.");
-
-                dbg!("INNER", &inner);
-
-                ast.push(AstNode::Comparison {
-                    field: match field.as_rule() {
-                        Rule::key => field.as_str().to_string(),
-                        _ => unreachable!(),
-                    },
-                    op: match op.as_rule() {
-                        Rule::eq => ComparisonOperator::Equal,
-                        Rule::neq => ComparisonOperator::NotEqual,
-                        _ => unreachable!(),
-                    },
-                    value: match value.as_rule() {
-                        Rule::value => vec![value.as_str().to_string()],
-                        Rule::value_list => value
-                            .into_inner()
-                            .map(|pair| pair.as_str().to_string())
-                            .collect(),
-                        _ => unreachable!(),
-                    },
-                });
-            }
-            Rule::and => {
-                ast.push(AstNode::LogicalOp {
-                    op: LogicalOperator::And,
-                });
-            }
-            Rule::or => {
-                ast.push(AstNode::LogicalOp {
-                    op: LogicalOperator::Or,
-                });
-            }
-            Rule::WHITESPACE | Rule::EOI => {}
-            _ => unreachable!(),
-        }
-    }
-
-    Ok(ast)
-}
-
 #[derive(Debug, PartialEq)]
 pub enum AstNode {
     Comparison {
@@ -109,7 +32,155 @@ pub enum AstNode {
         op: ComparisonOperator,
         value: Vec<String>,
     },
-    LogicalOp {
+    Op {
         op: LogicalOperator,
     },
+    Group {
+        nodes: Vec<AstNode>,
+    },
+}
+
+fn build_ast_node(pair: Pair<Rule>) -> Result<Option<AstNode>, Error<Rule>> {
+    Ok(match pair.as_rule() {
+        Rule::comparison => {
+            let mut inner = pair.into_inner();
+            let field = inner.next().expect("Missing field name.");
+            let op = inner.next().expect("Missing comparison operator.");
+            let value = inner.next().expect("Missing field value.");
+
+            Some(AstNode::Comparison {
+                field: match field.as_rule() {
+                    Rule::key => field.as_str().to_string(),
+                    _ => unreachable!(),
+                },
+                op: match op.as_rule() {
+                    Rule::eq => ComparisonOperator::Equal,
+                    Rule::neq => ComparisonOperator::NotEqual,
+                    _ => unreachable!(),
+                },
+                value: match value.as_rule() {
+                    Rule::value => vec![value.as_str().to_string()],
+                    Rule::value_list => value
+                        .into_inner()
+                        .map(|pair| pair.as_str().to_string())
+                        .collect(),
+                    _ => unreachable!(),
+                },
+            })
+        }
+        Rule::expr_group => Some(AstNode::Group {
+            nodes: build_ast(pair.into_inner())?,
+        }),
+        Rule::and => Some(AstNode::Op {
+            op: LogicalOperator::And,
+        }),
+        Rule::or => Some(AstNode::Op {
+            op: LogicalOperator::Or,
+        }),
+        Rule::WHITESPACE | Rule::EOI => None,
+        _ => unreachable!(),
+    })
+}
+
+fn build_ast(pairs: Pairs<Rule>) -> Result<Vec<AstNode>, Error<Rule>> {
+    let mut ast = vec![];
+
+    for pair in pairs {
+        if let Some(node) = build_ast_node(pair)? {
+            ast.push(node);
+        }
+    }
+
+    Ok(ast)
+}
+
+pub fn parse(input: &str) -> Result<Vec<AstNode>, Error<Rule>> {
+    Ok(build_ast(MqlParser::parse(Rule::query, input)?)?)
+}
+
+pub enum Field {
+    Language(Vec<ProjectLanguage>),
+    Project(Vec<String>),
+    ProjectAlias(Vec<String>),
+    ProjectSource(Vec<String>),
+    ProjectType(Vec<ProjectType>),
+}
+
+pub struct QueryField {
+    pub field: Field,
+    pub op: ComparisonOperator,
+}
+
+pub struct QueryCriteria {
+    pub op: Option<LogicalOperator>,
+    pub fields: Vec<QueryField>,
+    pub criteria: Vec<QueryCriteria>,
+}
+
+fn build_criteria_values<T: FromStr>(
+    field: &str,
+    values: Vec<String>,
+) -> Result<Vec<T>, QueryError> {
+    let mut result = vec![];
+
+    for value in values {
+        result.push(
+            value
+                .parse()
+                .map_err(|_| QueryError::UnknownFieldValue(field.to_owned(), value))?,
+        );
+    }
+
+    Ok(result)
+}
+
+fn build_criteria(ast: Vec<AstNode>) -> Result<QueryCriteria, QueryError> {
+    let mut criteria = QueryCriteria {
+        op: None,
+        fields: vec![],
+        criteria: vec![],
+    };
+
+    for node in ast {
+        match node {
+            AstNode::Comparison { field, op, value } => {
+                let field = match field.as_str() {
+                    "language" => {
+                        Field::Language(build_criteria_values::<ProjectLanguage>(&field, value)?)
+                    }
+                    "project" => Field::Project(value),
+                    "projectAlias" => Field::ProjectAlias(value),
+                    "projectSource" => Field::ProjectSource(value),
+                    "projectType" => {
+                        Field::ProjectType(build_criteria_values::<ProjectType>(&field, value)?)
+                    }
+                    _ => {
+                        return Err(QueryError::UnknownField(field));
+                    }
+                };
+
+                criteria.fields.push(QueryField { field, op });
+            }
+            AstNode::Op { op } => {
+                if let Some(current_op) = &criteria.op {
+                    if &op != current_op {
+                        return Err(QueryError::LogicalOperatorMismatch);
+                    }
+                } else {
+                    criteria.op = Some(op);
+                }
+            }
+            AstNode::Group { nodes } => {
+                criteria.criteria.push(build_criteria(nodes)?);
+            }
+        }
+    }
+
+    Ok(criteria)
+}
+
+pub fn build(input: &str) -> Result<QueryCriteria, QueryError> {
+    let ast = parse(input).map_err(|e| QueryError::ParseFailure(e.to_string()))?;
+
+    Ok(build_criteria(ast)?)
 }

--- a/crates/core/query/src/parser.rs
+++ b/crates/core/query/src/parser.rs
@@ -1,12 +1,9 @@
-use crate::errors::QueryError;
-use moon_config::{PlatformType, ProjectLanguage, ProjectType, TaskType};
 use pest::{
     error::Error,
     iterators::{Pair, Pairs},
     Parser,
 };
 use pest_derive::Parser;
-use std::str::FromStr;
 
 #[derive(Parser)]
 #[grammar = "mql.pest"]
@@ -100,106 +97,4 @@ fn parse_ast(pairs: Pairs<Rule>) -> Result<Vec<AstNode>, Box<Error<Rule>>> {
 
 pub fn parse(input: &str) -> Result<Vec<AstNode>, Box<Error<Rule>>> {
     parse_ast(MqlParser::parse(Rule::query, input)?)
-}
-
-pub enum Field {
-    Language(Vec<ProjectLanguage>),
-    Project(Vec<String>),
-    ProjectAlias(Vec<String>),
-    ProjectSource(Vec<String>),
-    ProjectType(Vec<ProjectType>),
-    Tag(Vec<String>),
-    Task(Vec<String>),
-    TaskPlatform(Vec<PlatformType>),
-    TaskType(Vec<TaskType>),
-}
-
-pub struct QueryField {
-    pub field: Field,
-    pub op: ComparisonOperator,
-}
-
-pub struct QueryCriteria {
-    pub op: Option<LogicalOperator>,
-    pub fields: Vec<QueryField>,
-    pub criteria: Vec<QueryCriteria>,
-}
-
-fn build_criteria_enum<T: FromStr>(
-    field: &str,
-    op: &ComparisonOperator,
-    values: Vec<String>,
-) -> Result<Vec<T>, QueryError> {
-    if matches!(op, ComparisonOperator::Like | ComparisonOperator::NotLike) {
-        return Err(QueryError::UnsupportedLikeOperator(field.to_owned()));
-    }
-
-    let mut result = vec![];
-
-    for value in values {
-        result.push(
-            value
-                .parse()
-                .map_err(|_| QueryError::UnknownFieldValue(field.to_owned(), value))?,
-        );
-    }
-
-    Ok(result)
-}
-
-fn build_criteria(ast: Vec<AstNode>) -> Result<QueryCriteria, QueryError> {
-    let mut criteria = QueryCriteria {
-        op: None,
-        fields: vec![],
-        criteria: vec![],
-    };
-
-    for node in ast {
-        match node {
-            AstNode::Comparison { field, op, value } => {
-                let field = match field.as_str() {
-                    "language" => {
-                        Field::Language(build_criteria_enum::<ProjectLanguage>(&field, &op, value)?)
-                    }
-                    "project" => Field::Project(value),
-                    "projectAlias" => Field::ProjectAlias(value),
-                    "projectSource" => Field::ProjectSource(value),
-                    "projectType" => {
-                        Field::ProjectType(build_criteria_enum::<ProjectType>(&field, &op, value)?)
-                    }
-                    "tag" => Field::Tag(value),
-                    "task" => Field::Task(value),
-                    "taskPlatform" => Field::TaskPlatform(build_criteria_enum::<PlatformType>(
-                        &field, &op, value,
-                    )?),
-                    "taskType" => {
-                        Field::TaskType(build_criteria_enum::<TaskType>(&field, &op, value)?)
-                    }
-                    _ => {
-                        return Err(QueryError::UnknownField(field));
-                    }
-                };
-
-                criteria.fields.push(QueryField { field, op });
-            }
-            AstNode::Op { op } => {
-                if let Some(current_op) = &criteria.op {
-                    if &op != current_op {
-                        return Err(QueryError::LogicalOperatorMismatch);
-                    }
-                } else {
-                    criteria.op = Some(op);
-                }
-            }
-            AstNode::Group { nodes } => {
-                criteria.criteria.push(build_criteria(nodes)?);
-            }
-        }
-    }
-
-    Ok(criteria)
-}
-
-pub fn build(input: &str) -> Result<QueryCriteria, QueryError> {
-    build_criteria(parse(input).map_err(|e| QueryError::ParseFailure(e.to_string()))?)
 }

--- a/crates/core/query/tests/builder_test.rs
+++ b/crates/core/query/tests/builder_test.rs
@@ -176,6 +176,52 @@ mod mql_build {
                 }
             );
         }
+
+        // #[test]
+        // fn depth_2_siblings() {
+        //     assert_eq!(
+        //         build("language=javascript && ((taskType=test && task~lint*) || (taskType=build && task~build*))")
+        //             .unwrap(),
+        //         QueryCriteria {
+        //             op: Some(LogicalOperator::And),
+        //             fields: vec![QueryField {
+        //                 field: Field::Language(vec![ProjectLanguage::JavaScript]),
+        //                 op: ComparisonOperator::Equal,
+        //             },],
+        //             criteria: vec![QueryCriteria {
+        //                 op: Some(LogicalOperator::Or),
+        //                 fields: vec![],
+        //                 criteria: vec![QueryCriteria {
+        //                     op: Some(LogicalOperator::And),
+        //                     fields: vec![
+        //                         QueryField {
+        //                             field: Field::TaskType(vec![TaskType::Test]),
+        //                             op: ComparisonOperator::Equal,
+        //                         },
+        //                         QueryField {
+        //                             field: Field::Task(string_vec!["lint*"]),
+        //                             op: ComparisonOperator::Like,
+        //                         },
+        //                     ],
+        //                     criteria: vec![],
+        //                 }, QueryCriteria {
+        //                     op: Some(LogicalOperator::And),
+        //                     fields: vec![
+        //                         QueryField {
+        //                             field: Field::TaskType(vec![TaskType::Build]),
+        //                             op: ComparisonOperator::Equal,
+        //                         },
+        //                         QueryField {
+        //                             field: Field::Task(string_vec!["build*"]),
+        //                             op: ComparisonOperator::Like,
+        //                         },
+        //                     ],
+        //                     criteria: vec![],
+        //                 }],
+        //             }],
+        //         }
+        //     );
+        // }
     }
 
     mod language {
@@ -285,6 +331,21 @@ mod mql_build {
                     fields: vec![QueryField {
                         field: Field::ProjectAlias(string_vec!["foo*"]),
                         op: ComparisonOperator::NotLike,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        fn alias_like_scope() {
+            assert_eq!(
+                build("projectAlias~@scope/*").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::ProjectAlias(string_vec!["@scope/*"]),
+                        op: ComparisonOperator::Like,
                     }],
                     criteria: vec![],
                 }

--- a/crates/core/query/tests/builder_test.rs
+++ b/crates/core/query/tests/builder_test.rs
@@ -1,0 +1,552 @@
+use moon_config::{PlatformType, ProjectLanguage, ProjectType, TaskType};
+use moon_query::{build, ComparisonOperator, Field, LogicalOperator, QueryCriteria, QueryField};
+use moon_utils::string_vec;
+
+mod mql_build {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "EmptyInput")]
+    fn errors_if_empty() {
+        build("").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "UnknownField(\"key\")")]
+    fn errors_unknown_field() {
+        build("key=value").unwrap();
+    }
+
+    #[test]
+    fn handles_and() {
+        assert_eq!(
+            build("language=javascript AND language!=typescript").unwrap(),
+            QueryCriteria {
+                op: Some(LogicalOperator::And),
+                fields: vec![
+                    QueryField {
+                        field: Field::Language(vec![ProjectLanguage::JavaScript]),
+                        op: ComparisonOperator::Equal,
+                    },
+                    QueryField {
+                        field: Field::Language(vec![ProjectLanguage::TypeScript]),
+                        op: ComparisonOperator::NotEqual,
+                    }
+                ],
+                criteria: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn handles_or() {
+        assert_eq!(
+            build("language=javascript || language!=typescript").unwrap(),
+            QueryCriteria {
+                op: Some(LogicalOperator::Or),
+                fields: vec![
+                    QueryField {
+                        field: Field::Language(vec![ProjectLanguage::JavaScript]),
+                        op: ComparisonOperator::Equal,
+                    },
+                    QueryField {
+                        field: Field::Language(vec![ProjectLanguage::TypeScript]),
+                        op: ComparisonOperator::NotEqual,
+                    }
+                ],
+                criteria: vec![],
+            }
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "LogicalOperatorMismatch")]
+    fn errors_when_mixing_ops() {
+        build("language=javascript || language!=typescript && language=ruby").unwrap();
+    }
+
+    mod nested {
+        use super::*;
+
+        #[test]
+        fn depth_1() {
+            assert_eq!(
+                build("language=javascript AND (task=foo || task!=bar OR task~baz)").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::Language(vec![ProjectLanguage::JavaScript]),
+                        op: ComparisonOperator::Equal,
+                    },],
+                    criteria: vec![QueryCriteria {
+                        op: Some(LogicalOperator::Or),
+                        fields: vec![
+                            QueryField {
+                                field: Field::Task(string_vec!["foo"]),
+                                op: ComparisonOperator::Equal,
+                            },
+                            QueryField {
+                                field: Field::Task(string_vec!["bar"]),
+                                op: ComparisonOperator::NotEqual,
+                            },
+                            QueryField {
+                                field: Field::Task(string_vec!["baz"]),
+                                op: ComparisonOperator::Like,
+                            }
+                        ],
+                        criteria: vec![],
+                    }],
+                }
+            );
+        }
+
+        #[test]
+        fn depth_1_siblings() {
+            assert_eq!(
+                build("language=javascript AND (task=foo || task!=bar) && (taskType=build AND taskType=run)").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::Language(vec![ProjectLanguage::JavaScript]),
+                        op: ComparisonOperator::Equal,
+                    }],
+                    criteria: vec![QueryCriteria {
+                        op: Some(LogicalOperator::Or),
+                        fields: vec![
+                            QueryField {
+                                field: Field::Task(string_vec!["foo"]),
+                                op: ComparisonOperator::Equal,
+                            },
+                            QueryField {
+                                field: Field::Task(string_vec!["bar"]),
+                                op: ComparisonOperator::NotEqual,
+                            },
+                        ],
+                        criteria: vec![],
+                    }, QueryCriteria {
+                        op: Some(LogicalOperator::And),
+                        fields: vec![
+                            QueryField {
+                                field: Field::TaskType(vec![TaskType::Build]),
+                                op: ComparisonOperator::Equal,
+                            },
+                            QueryField {
+                                field: Field::TaskType(vec![TaskType::Run]),
+                                op: ComparisonOperator::Equal,
+                            },
+                        ],
+                        criteria: vec![],
+                    }],
+                }
+            );
+        }
+
+        #[test]
+        fn depth_2() {
+            assert_eq!(
+                build("language=javascript AND (task=foo || (taskType=build AND taskType=run))")
+                    .unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::Language(vec![ProjectLanguage::JavaScript]),
+                        op: ComparisonOperator::Equal,
+                    },],
+                    criteria: vec![QueryCriteria {
+                        op: Some(LogicalOperator::Or),
+                        fields: vec![QueryField {
+                            field: Field::Task(string_vec!["foo"]),
+                            op: ComparisonOperator::Equal,
+                        },],
+                        criteria: vec![QueryCriteria {
+                            op: Some(LogicalOperator::And),
+                            fields: vec![
+                                QueryField {
+                                    field: Field::TaskType(vec![TaskType::Build]),
+                                    op: ComparisonOperator::Equal,
+                                },
+                                QueryField {
+                                    field: Field::TaskType(vec![TaskType::Run]),
+                                    op: ComparisonOperator::Equal,
+                                },
+                            ],
+                            criteria: vec![],
+                        }],
+                    }],
+                }
+            );
+        }
+    }
+
+    mod language {
+        use super::*;
+
+        #[test]
+        fn valid_value() {
+            assert_eq!(
+                build("language=javascript").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::Language(vec![ProjectLanguage::JavaScript]),
+                        op: ComparisonOperator::Equal,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        fn other_value() {
+            assert_eq!(
+                build("language!=other").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::Language(vec![ProjectLanguage::Other("other".into())]),
+                        op: ComparisonOperator::NotEqual,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        #[should_panic(expected = "UnsupportedLikeOperator(\"language\")")]
+        fn errors_for_like() {
+            build("language~javascript").unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "UnsupportedLikeOperator(\"language\")")]
+        fn errors_for_not_like() {
+            build("language!~javascript").unwrap();
+        }
+    }
+
+    mod project {
+        use super::*;
+
+        #[test]
+        fn name_eq() {
+            assert_eq!(
+                build("project!=foo").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::Project(string_vec!["foo"]),
+                        op: ComparisonOperator::NotEqual,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        fn name_like() {
+            assert_eq!(
+                build("project~foo*").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::Project(string_vec!["foo*"]),
+                        op: ComparisonOperator::Like,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+    }
+
+    mod project_alias {
+        use super::*;
+
+        #[test]
+        fn alias_eq() {
+            assert_eq!(
+                build("projectAlias=foo").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::ProjectAlias(string_vec!["foo"]),
+                        op: ComparisonOperator::Equal,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        fn alias_like() {
+            assert_eq!(
+                build("projectAlias!~foo*").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::ProjectAlias(string_vec!["foo*"]),
+                        op: ComparisonOperator::NotLike,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+    }
+
+    mod project_source {
+        use super::*;
+
+        #[test]
+        fn source_eq() {
+            assert_eq!(
+                build("projectSource!=packages/foo").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::ProjectSource(string_vec!["packages/foo"]),
+                        op: ComparisonOperator::NotEqual,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        fn source_like() {
+            assert_eq!(
+                build("projectSource!~packages/*").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::ProjectSource(string_vec!["packages/*"]),
+                        op: ComparisonOperator::NotLike,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+    }
+
+    mod project_type {
+        use super::*;
+
+        #[test]
+        fn valid_value() {
+            assert_eq!(
+                build("projectType=library").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::ProjectType(vec![ProjectType::Library]),
+                        op: ComparisonOperator::Equal,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        fn valid_value_list() {
+            assert_eq!(
+                build("projectType!=[tool, library]").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::ProjectType(vec![ProjectType::Tool, ProjectType::Library]),
+                        op: ComparisonOperator::NotEqual,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        #[should_panic(expected = "UnknownFieldValue(\"projectType\", \"app\")")]
+        fn invalid_value() {
+            build("projectType=app").unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "UnsupportedLikeOperator(\"projectType\")")]
+        fn errors_for_like() {
+            build("projectType~library").unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "UnsupportedLikeOperator(\"projectType\")")]
+        fn errors_for_not_like() {
+            build("projectType!~tool").unwrap();
+        }
+    }
+
+    mod tag {
+        use super::*;
+
+        #[test]
+        fn tag_eq() {
+            assert_eq!(
+                build("tag=lib").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::Tag(string_vec!["lib"]),
+                        op: ComparisonOperator::Equal,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        fn tag_neq_list() {
+            assert_eq!(
+                build("tag!=[foo,bar]").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::Tag(string_vec!["foo", "bar"]),
+                        op: ComparisonOperator::NotEqual,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        fn tag_like() {
+            assert_eq!(
+                build("tag~app-*").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::Tag(string_vec!["app-*"]),
+                        op: ComparisonOperator::Like,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+    }
+
+    mod task {
+        use super::*;
+
+        #[test]
+        fn task_eq() {
+            assert_eq!(
+                build("task!=foo").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::Task(string_vec!["foo"]),
+                        op: ComparisonOperator::NotEqual,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        fn task_like() {
+            assert_eq!(
+                build("task~foo*").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::Task(string_vec!["foo*"]),
+                        op: ComparisonOperator::Like,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+    }
+
+    mod task_platform {
+        use super::*;
+
+        #[test]
+        fn valid_value() {
+            assert_eq!(
+                build("taskPlatform=node").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::TaskPlatform(vec![PlatformType::Node]),
+                        op: ComparisonOperator::Equal,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        fn valid_value_list() {
+            assert_eq!(
+                build("taskPlatform!=[node, system]").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::TaskPlatform(vec![PlatformType::Node, PlatformType::System]),
+                        op: ComparisonOperator::NotEqual,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        #[should_panic(expected = "UnknownFieldValue(\"taskPlatform\", \"kotlin\")")]
+        fn invalid_value() {
+            build("taskPlatform=kotlin").unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "UnsupportedLikeOperator(\"taskPlatform\")")]
+        fn errors_for_like() {
+            build("taskPlatform~node").unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "UnsupportedLikeOperator(\"taskPlatform\")")]
+        fn errors_for_not_like() {
+            build("taskPlatform!~node").unwrap();
+        }
+    }
+
+    mod task_type {
+        use super::*;
+
+        #[test]
+        fn valid_value() {
+            assert_eq!(
+                build("taskType=build").unwrap(),
+                QueryCriteria {
+                    op: Some(LogicalOperator::And),
+                    fields: vec![QueryField {
+                        field: Field::TaskType(vec![TaskType::Build]),
+                        op: ComparisonOperator::Equal,
+                    }],
+                    criteria: vec![],
+                }
+            );
+        }
+
+        #[test]
+        #[should_panic(expected = "UnknownFieldValue(\"taskType\", \"kotlin\")")]
+        fn invalid_value() {
+            build("taskType=kotlin").unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "UnsupportedLikeOperator(\"taskType\")")]
+        fn errors_for_like() {
+            build("taskType~node").unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "UnsupportedLikeOperator(\"taskType\")")]
+        fn errors_for_not_like() {
+            build("taskType!~node").unwrap();
+        }
+    }
+}

--- a/crates/core/query/tests/parser_test.rs
+++ b/crates/core/query/tests/parser_test.rs
@@ -5,6 +5,12 @@ mod mql_parse {
 
     #[test]
     #[should_panic]
+    fn errors_if_empty() {
+        parse("").unwrap();
+    }
+
+    #[test]
+    #[should_panic]
     fn errors_no_logic_op() {
         parse("k1=v1 k2=v2").unwrap();
     }

--- a/crates/core/query/tests/parser_test.rs
+++ b/crates/core/query/tests/parser_test.rs
@@ -76,6 +76,30 @@ mod mql_parse {
     }
 
     #[test]
+    fn comp_like() {
+        assert_eq!(
+            parse("key~value").unwrap(),
+            vec![AstNode::Comparison {
+                field: "key".into(),
+                op: ComparisonOperator::Like,
+                value: vec!["value".into()],
+            }],
+        );
+    }
+
+    #[test]
+    fn comp_nlike() {
+        assert_eq!(
+            parse("key!~value").unwrap(),
+            vec![AstNode::Comparison {
+                field: "key".into(),
+                op: ComparisonOperator::NotLike,
+                value: vec!["value".into()],
+            }],
+        );
+    }
+
+    #[test]
     fn multi_and_comp() {
         assert_eq!(
             parse("k1=v1 && k2!=v2 AND k3=[1,2,3]").unwrap(),
@@ -308,6 +332,42 @@ mod mql_parse {
                     ]
                 },
             ],
+        );
+    }
+
+    #[test]
+    fn like_glob_patterns() {
+        assert_eq!(
+            parse("key~value{foo,bar}").unwrap(),
+            vec![AstNode::Comparison {
+                field: "key".into(),
+                op: ComparisonOperator::Like,
+                value: vec!["value{foo,bar}".into()],
+            }],
+        );
+        assert_eq!(
+            parse("key !~ value[a-z]?").unwrap(),
+            vec![AstNode::Comparison {
+                field: "key".into(),
+                op: ComparisonOperator::NotLike,
+                value: vec!["value[a-z]?".into()],
+            }],
+        );
+        assert_eq!(
+            parse("key~value.*").unwrap(),
+            vec![AstNode::Comparison {
+                field: "key".into(),
+                op: ComparisonOperator::Like,
+                value: vec!["value.*".into()],
+            }],
+        );
+        assert_eq!(
+            parse("key!~value/**/*").unwrap(),
+            vec![AstNode::Comparison {
+                field: "key".into(),
+                op: ComparisonOperator::NotLike,
+                value: vec!["value/**/*".into()],
+            }],
         );
     }
 }

--- a/crates/core/query/tests/parser_test.rs
+++ b/crates/core/query/tests/parser_test.rs
@@ -1,0 +1,153 @@
+use moon_query::{parse, AstNode, ComparisonOperator, LogicalOperator};
+
+mod mql {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn errors_no_logic_op() {
+        parse("k1=v1 k2=v2").unwrap();
+    }
+
+    #[test]
+    fn comp_eq() {
+        assert_eq!(
+            parse("key=value").unwrap(),
+            vec![AstNode::Comparison {
+                field: "key".into(),
+                op: ComparisonOperator::Equal,
+                value: vec!["value".into()],
+            }],
+        );
+    }
+
+    #[test]
+    fn comp_eq_list() {
+        assert_eq!(
+            parse("key=[v1, v2, v3]").unwrap(),
+            vec![AstNode::Comparison {
+                field: "key".into(),
+                op: ComparisonOperator::Equal,
+                value: vec!["v1".into(), "v2".into(), "v3".into()],
+            }],
+        );
+    }
+
+    #[test]
+    fn comp_neq() {
+        assert_eq!(
+            parse("key!=value").unwrap(),
+            vec![AstNode::Comparison {
+                field: "key".into(),
+                op: ComparisonOperator::NotEqual,
+                value: vec!["value".into()],
+            }],
+        );
+    }
+
+    #[test]
+    fn comp_neq_list() {
+        assert_eq!(
+            parse("key!=[v1,v2,v3]").unwrap(),
+            vec![AstNode::Comparison {
+                field: "key".into(),
+                op: ComparisonOperator::NotEqual,
+                value: vec!["v1".into(), "v2".into(), "v3".into()],
+            }],
+        );
+    }
+
+    #[test]
+    fn multi_and_comp() {
+        assert_eq!(
+            parse("k1=v1 && k2!=v2 AND k3=[1,2,3]").unwrap(),
+            vec![
+                AstNode::Comparison {
+                    field: "k1".into(),
+                    op: ComparisonOperator::Equal,
+                    value: vec!["v1".into()],
+                },
+                AstNode::LogicalOp {
+                    op: LogicalOperator::And,
+                },
+                AstNode::Comparison {
+                    field: "k2".into(),
+                    op: ComparisonOperator::NotEqual,
+                    value: vec!["v2".into()],
+                },
+                AstNode::LogicalOp {
+                    op: LogicalOperator::And,
+                },
+                AstNode::Comparison {
+                    field: "k3".into(),
+                    op: ComparisonOperator::Equal,
+                    value: vec!["1".into(), "2".into(), "3".into()],
+                }
+            ],
+        );
+    }
+
+    #[test]
+    fn multi_or_comp() {
+        assert_eq!(
+            parse("k1=v1 || k2!=v2 OR k3=[1,2,3]").unwrap(),
+            vec![
+                AstNode::Comparison {
+                    field: "k1".into(),
+                    op: ComparisonOperator::Equal,
+                    value: vec!["v1".into()],
+                },
+                AstNode::LogicalOp {
+                    op: LogicalOperator::Or,
+                },
+                AstNode::Comparison {
+                    field: "k2".into(),
+                    op: ComparisonOperator::NotEqual,
+                    value: vec!["v2".into()],
+                },
+                AstNode::LogicalOp {
+                    op: LogicalOperator::Or,
+                },
+                AstNode::Comparison {
+                    field: "k3".into(),
+                    op: ComparisonOperator::Equal,
+                    value: vec!["1".into(), "2".into(), "3".into()],
+                }
+            ],
+        );
+    }
+
+    #[test]
+    fn cmp_op_space() {
+        assert_eq!(
+            parse("key =  value").unwrap(),
+            vec![AstNode::Comparison {
+                field: "key".into(),
+                op: ComparisonOperator::Equal,
+                value: vec!["value".into()],
+            }],
+        );
+    }
+
+    #[test]
+    fn lgc_op_space() {
+        assert_eq!(
+            parse("k1=v1&&      k2!=v2").unwrap(),
+            vec![
+                AstNode::Comparison {
+                    field: "k1".into(),
+                    op: ComparisonOperator::Equal,
+                    value: vec!["v1".into()],
+                },
+                AstNode::LogicalOp {
+                    op: LogicalOperator::And,
+                },
+                AstNode::Comparison {
+                    field: "k2".into(),
+                    op: ComparisonOperator::NotEqual,
+                    value: vec!["v2".into()],
+                }
+            ],
+        );
+    }
+}

--- a/crates/core/task/src/task.rs
+++ b/crates/core/task/src/task.rs
@@ -3,6 +3,7 @@ use crate::task_options::TaskOptions;
 use crate::types::TouchedFilePaths;
 use moon_config::{
     FileGlob, FilePath, InputValue, PlatformType, TaskCommandArgs, TaskConfig, TaskMergeStrategy,
+    TaskType,
 };
 use moon_error::MoonError;
 use moon_logger::{debug, trace, Logable};
@@ -21,20 +22,6 @@ type EnvVars = FxHashMap<String, String>;
 #[serde(rename_all = "kebab-case")]
 pub enum TaskFlag {
     NoInputs,
-}
-
-#[derive(Clone, Debug, Default, Deserialize, Display, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum TaskType {
-    #[strum(serialize = "build")]
-    Build,
-
-    #[strum(serialize = "run")]
-    Run,
-
-    #[default]
-    #[strum(serialize = "test")]
-    Test,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### 🚀 Updates
+
+- Introducing MQL, a custom query language for running advanced commands and functionality.
+
 #### ⚙️ Internal
 
 - Updated Rust to v1.69.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-#### 🐞 Fixes
-
-- Fixed an issue where running tasks were not killed, resulting in background zombie processes.
-
 #### ⚙️ Internal
 
 - Updated Rust to v1.69.

--- a/website/docs/concepts/query-lang.mdx
+++ b/website/docs/concepts/query-lang.mdx
@@ -1,0 +1,148 @@
+---
+title: Query language
+toc_max_heading_level: 4
+tags: [query, lang, mql]
+---
+
+moon supports an integrated query language, known as MQL, that can be used to filter and select
+projects from the project graph, using an SQL-like syntax.
+
+## Syntax
+
+### Comparisons
+
+A comparison (also known as an assignment) is an expression that defines a piece of criteria, and is
+a building block of a query. This criteria maps a [field](#field) to a value, with an explicit
+comparison operator.
+
+#### Equals, Not equals
+
+The equals (`=`) and not equals (`!=`) comparison operators can be used for _exact_ value matching.
+
+```
+projectType=library && language!=javascript
+```
+
+You can also define a list of values using square bracket syntax, that will match against one of the
+values.
+
+```
+language=[javascript, typescript]
+```
+
+#### Like, Not like
+
+The like (`~`) and not like (`!~`) comparison operators can be used for _wildcard_ value matching,
+using [glob syntax](./file-pattern#globs).
+
+```
+projectSource~packages/* && tag!~*-app
+```
+
+> Like comparisons can only be used on non-enum fields.
+
+### Conditions
+
+The `&&` and `||` logical operators can be used to combine multiple comparisons into a condition.
+The `&&` operator is used to combine comparisons into a logical AND, and the `||` operator is used
+for logical OR.
+
+```
+taskPlatform=system || taskPlatform=node
+```
+
+For readability concerns, you can also use `AND` or `OR`.
+
+```
+taskPlatform=system OR taskPlatform=node
+```
+
+> Mixing both operators in the same condition is not supported.
+
+### Grouping
+
+For advanced queries and complex conditions, you can group comparisons using parentheses to create
+logical groupings. Groups can also be nested within other groups.
+
+```
+language=javascript && (taskType=test || taskType=build)
+```
+
+## Fields
+
+The following fields can be used as criteria, and are related to [task tokens](./token#variables).
+
+### `language`
+
+Programming language the project is written in, as defined in
+[`moon.yml`](../config/project#language).
+
+```
+language=rust
+```
+
+### `project`
+
+ID/name of the project, as defined in [`.moon/workspace.yml`](../config/workspace).
+
+```
+project=server
+```
+
+### `projectAlias`
+
+Alias of the project. Requires aliasing to be enabled with
+[`node.aliasPackageNames`](../config/toolchain#aliaspackagenames).
+
+```
+projectAlias~@scope/*
+```
+
+### `projectSource`
+
+Relative file path from the workspace root to the project root, as defined in
+[`.moon/workspace.yml`](../config/workspace).
+
+```
+projectSource~packages/*
+```
+
+### `projectType`
+
+The type of project, as defined in [`moon.yml`](../config/project#type).
+
+```
+projectType=application
+```
+
+### `tag`
+
+A tag within the project, as defined in [`moon.yml`](../config/project#tags).
+
+```
+tag~react-*
+```
+
+### `task`
+
+ID/name of a task within the project.
+
+```
+task=[build,test]
+```
+
+### `taskPlatform`
+
+The platform a task will run against, as defined in [`moon.yml`](../config/project#platform-1).
+
+```
+taskPlatform=node
+```
+
+### `taskType`
+
+The [type of task](./task#types), based on its configured settings.
+
+```
+taskType=build
+```

--- a/website/docs/concepts/token.mdx
+++ b/website/docs/concepts/token.mdx
@@ -310,9 +310,10 @@ tasks:
 
 ### `$language`
 
-Programming language the project is written in, as defined in [`moon.yml`](../config/project). If
-the project has not defined the [`language`](../config/project#language) setting, or does not have a
-config, this defaults to "unknown".
+Programming language the project is written in, as defined in
+[`moon.yml`](../config/project#language). If the project has not defined the
+[`language`](../config/project#language) setting, or does not have a config, this defaults to
+"unknown".
 
 ```yaml
 # Configured as
@@ -414,8 +415,9 @@ tasks:
 
 ### `$projectType`
 
-The type of project, as defined in [`moon.yml`](../config/project). If the project has not defined
-the [`type`](../config/project#type) setting, or does not have a config, this defaults to "unknown".
+The type of project, as defined in [`moon.yml`](../config/project#type). If the project has not
+defined the [`type`](../config/project#type) setting, or does not have a config, this defaults to
+"unknown".
 
 ```yaml
 # Configured as
@@ -472,7 +474,7 @@ tasks:
 
 ### `$taskPlatform`
 
-The platform that task will run against.
+The platform that task will run against, as defined in [`moon.yml`](../config/project#platform-1).
 
 ```yaml
 # Configured as

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -48,6 +48,7 @@ const sidebars = {
 				'concepts/cache',
 				'concepts/file-group',
 				'concepts/file-pattern',
+				'concepts/query-lang',
 				'concepts/project',
 				'concepts/target',
 				'concepts/task',


### PR DESCRIPTION
This PR adds a new feature that I'm calling MQL, that allows for advanced searching/filtering/etc through an SQL-like syntax. This is a much better approach instead of supporting ad-hoc CLI args everywhere. For example:

```
moon run "projectType=library && task=build && language=javascript"
```

To do:
- [x] Parse into AST
- [x] Build into criteria
- [ ] Integrate into project graph

Fields:
- [x] project type
- [x] project alias
- [x] project name
- [x] language
- [x] platform
- [x] task
- [x] task type
- [ ] affected since

Operators:
- [x] equals
- [x] not equals
- [x] like
- [x] not like
- [x] in list