### PR TITLE
fix: Unpack archives in a separate thread.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,6 +2570,7 @@ dependencies = [
  "serial_test",
  "starbase_styles",
  "starbase_utils",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/core/archive/src/tar.rs
+++ b/crates/core/archive/src/tar.rs
@@ -235,6 +235,7 @@ pub fn untar_with_diff<I: AsRef<Path>, O: AsRef<Path>>(
 
     // Unpack the archive into the output dir
     let mut archive = Archive::new(tar);
+    archive.set_overwrite(true);
 
     for entry_result in archive.entries()? {
         let mut entry = entry_result?;

--- a/crates/core/cache/Cargo.toml
+++ b/crates/core/cache/Cargo.toml
@@ -14,6 +14,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 starbase_styles = { workspace = true }
 starbase_utils = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 moon_test_utils = { path = "../test-utils" }


### PR DESCRIPTION
We've received a few reports that hydration (tar unpacking) often results in partially hydrated output, causing a lot of issues. I've scoured our tar implementation and the tar crates themselves, but haven't found anything.

My only thought right now is that the thread is being interrupted while unpacking, resulting in a broken state. This tries to move the unpacking to a separate background thread that wouldn't be aborted.