### PR TITLE
new: Deprecate `node.aliasPackageNames` setting.

### DIFF
--- a/.yarn/versions/c9305e0b.yml
+++ b/.yarn/versions/c9305e0b.yml
@@ -7,4 +7,5 @@ releases:
   '@moonrepo/core-macos-arm64': minor
   '@moonrepo/core-macos-x64': minor
   '@moonrepo/core-windows-x64-msvc': minor
+  '@moonrepo/types': patch
   '@moonrepo/visualizer': patch

--- a/.yarn/versions/c9305e0b.yml
+++ b/.yarn/versions/c9305e0b.yml
@@ -7,5 +7,10 @@ releases:
   '@moonrepo/core-macos-arm64': minor
   '@moonrepo/core-macos-x64': minor
   '@moonrepo/core-windows-x64-msvc': minor
+  '@moonrepo/report': patch
+  '@moonrepo/runtime': patch
   '@moonrepo/types': patch
   '@moonrepo/visualizer': patch
+
+declined:
+  - website

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -28,15 +28,8 @@ pub async fn project(id: String, json: bool) -> Result<(), AnyError> {
     term.render_label(Label::Brand, &project.id)?;
     term.render_entry("Project", color::id(&project.id))?;
 
-    if !project.aliases.is_empty() {
-        term.render_entry(
-            if project.aliases.len() == 1 {
-                "Alias"
-            } else {
-                "Aliases"
-            },
-            map_list(&project.aliases, |alias| color::id(alias)),
-        )?;
+    if let Some(alias) = &project.alias {
+        term.render_entry("Alias", color::id(alias))?;
     }
 
     term.render_entry("Source", color::file(&project.source))?;

--- a/crates/cli/src/queries/projects.rs
+++ b/crates/cli/src/queries/projects.rs
@@ -138,10 +138,10 @@ pub async fn query_projects(
         }
 
         if let Some(regex) = &alias_regex {
-            if !project.aliases.is_empty()
-                && project.aliases.iter().all(|alias| !regex.is_match(alias))
-            {
-                continue;
+            if let Some(alias) = &project.alias {
+                if !regex.is_match(alias) {
+                    continue;
+                }
             }
         }
 

--- a/crates/cli/tests/migrate_test.rs
+++ b/crates/cli/tests/migrate_test.rs
@@ -1,4 +1,4 @@
-use moon_config::{NodeProjectAliasFormat, WorkspaceConfig, WorkspaceProjects};
+use moon_config::{WorkspaceConfig, WorkspaceProjects};
 use moon_test_utils::{
     assert_snapshot, create_sandbox_with_config, get_default_toolchain, predicates::str::contains,
     Sandbox,
@@ -12,10 +12,7 @@ fn migrate_sandbox() -> Sandbox {
         ..WorkspaceConfig::default()
     };
 
-    let mut toolchain_config = get_default_toolchain();
-
-    toolchain_config.node.as_mut().unwrap().alias_package_names =
-        Some(NodeProjectAliasFormat::NameAndScope);
+    let toolchain_config = get_default_toolchain();
 
     create_sandbox_with_config(
         "migrate",

--- a/crates/cli/tests/snapshots/project_test__root_level.snap
+++ b/crates/cli/tests/snapshots/project_test__root_level.snap
@@ -6,6 +6,7 @@ expression: assert.output()
  ROOT 
 
 Project: root
+Alias: test-cases
 Source: .
 Language: typescript
 Type: unknown

--- a/crates/core/config/src/toolchain/node.rs
+++ b/crates/core/config/src/toolchain/node.rs
@@ -105,6 +105,7 @@ pub struct NodeConfig {
     #[serde(skip_serializing_if = "is_default_true")]
     pub add_engines_constraint: bool,
 
+    #[deprecated]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alias_package_names: Option<NodeProjectAliasFormat>,
 
@@ -148,6 +149,7 @@ pub struct NodeConfig {
 
 impl Default for NodeConfig {
     fn default() -> Self {
+        #[allow(deprecated)]
         NodeConfig {
             add_engines_constraint: true,
             alias_package_names: None,

--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -115,7 +115,7 @@ impl<'ws> ProjectGraphBuilder<'ws> {
         // Collect all aliases for the current project ID
         for (alias, project_id) in &self.aliases {
             if project_id == id {
-                project.aliases.push(alias.to_owned());
+                project.alias = Some(alias.to_owned());
             }
         }
 

--- a/crates/core/project-graph/src/token_resolver.rs
+++ b/crates/core/project-graph/src/token_resolver.rs
@@ -264,11 +264,7 @@ impl<'task> TokenResolver<'task> {
             // Project
             "language" => project.language.to_string(),
             "project" => project.id.to_string(),
-            "projectAlias" => project
-                .aliases
-                .first()
-                .map(|a| a.to_string())
-                .unwrap_or_default(),
+            "projectAlias" => project.alias.clone().unwrap_or_default(),
             "projectRoot" => path::to_string(&project.root)?,
             "projectSource" => project.source.to_string(),
             "projectType" => project.type_of.to_string(),

--- a/crates/core/project-graph/tests/token_resolver_test.rs
+++ b/crates/core/project-graph/tests/token_resolver_test.rs
@@ -450,7 +450,7 @@ mod resolve_args {
         let mut project = create_project(&workspace_root);
         project.language = ProjectLanguage::JavaScript;
         project.type_of = ProjectType::Tool;
-        project.aliases = string_vec!["some-alias", "another-alias"];
+        project.alias = Some("some-alias".into());
 
         let resolver = TokenResolver::new(TokenContext::Args, &project, &workspace_root);
 

--- a/crates/core/project/src/project.rs
+++ b/crates/core/project/src/project.rs
@@ -271,9 +271,9 @@ impl ProjectDependency {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Project {
-    /// Unique aliases of the project, alongside its official ID.
+    /// Unique alias of the project, alongside its official ID.
     /// This is typically reserved for language specific semantics, like `name` from `package.json`.
-    pub aliases: Vec<String>,
+    pub alias: Option<String>,
 
     /// Project configuration loaded from "moon.yml", if it exists.
     pub config: ProjectConfig,
@@ -381,7 +381,7 @@ impl Project {
         let tasks = create_tasks_from_config(&log_target, id, &config, &global_tasks)?;
 
         Ok(Project {
-            aliases: vec![],
+            alias: None,
             dependencies,
             file_groups,
             id: id.to_owned(),
@@ -434,7 +434,11 @@ impl Queryable for Project {
                         Field::Language(langs) => condition.matches_enum(langs, &self.language),
                         Field::Project(ids) => condition.matches(ids, &self.id),
                         Field::ProjectAlias(aliases) => {
-                            condition.matches_list(aliases, &self.aliases)
+                            if let Some(alias) = &self.alias {
+                                condition.matches(aliases, alias)
+                            } else {
+                                Ok(false)
+                            }
                         }
                         Field::ProjectSource(sources) => condition.matches(sources, &self.source),
                         Field::ProjectType(types) => condition.matches_enum(types, &self.type_of),

--- a/crates/core/test-utils/src/configs.rs
+++ b/crates/core/test-utils/src/configs.rs
@@ -1,7 +1,6 @@
 use moon_config::{
-    InheritedTasksConfig, NodeConfig, NodePackageManager, NodeProjectAliasFormat, NpmConfig,
-    PnpmConfig, TaskCommandArgs, TaskConfig, ToolchainConfig, TypeScriptConfig, WorkspaceConfig,
-    WorkspaceProjects, YarnConfig,
+    InheritedTasksConfig, NodeConfig, NodePackageManager, NpmConfig, PnpmConfig, TaskCommandArgs,
+    TaskConfig, ToolchainConfig, TypeScriptConfig, WorkspaceConfig, WorkspaceProjects, YarnConfig,
 };
 use rustc_hash::FxHashMap;
 use std::collections::BTreeMap;
@@ -134,7 +133,6 @@ pub fn get_project_graph_aliases_fixture_configs(
         node: Some(NodeConfig {
             version: Some("18.0.0".into()),
             add_engines_constraint: false,
-            alias_package_names: Some(NodeProjectAliasFormat::NameAndScope),
             dedupe_on_lockfile_change: false,
             npm: NpmConfig {
                 version: Some("8.19.0".into()),

--- a/crates/node/platform/tests/project_aliases_test.rs
+++ b/crates/node/platform/tests/project_aliases_test.rs
@@ -1,21 +1,13 @@
 use moon::{generate_project_graph, load_workspace_from};
-use moon_config::{NodeConfig, NodeProjectAliasFormat};
 use moon_project_graph::ProjectGraph;
 use moon_test_utils::{
     assert_snapshot, create_sandbox_with_config, get_project_graph_aliases_fixture_configs, Sandbox,
 };
 use rustc_hash::FxHashMap;
 
-async fn get_aliases_graph<C>(callback: C) -> (ProjectGraph, Sandbox)
-where
-    C: FnOnce(&mut NodeConfig),
-{
-    let (workspace_config, mut toolchain_config, tasks_config) =
+async fn get_aliases_graph() -> (ProjectGraph, Sandbox) {
+    let (workspace_config, toolchain_config, tasks_config) =
         get_project_graph_aliases_fixture_configs();
-
-    if let Some(node_config) = &mut toolchain_config.node {
-        callback(node_config);
-    }
 
     let sandbox = create_sandbox_with_config(
         "project-graph/aliases",
@@ -31,41 +23,8 @@ where
 }
 
 #[tokio::test]
-async fn loads_node_aliases_name_only() {
-    let (graph, _sandbox) = get_aliases_graph(|cfg| {
-        cfg.alias_package_names = Some(NodeProjectAliasFormat::NameOnly);
-    })
-    .await;
-
-    assert_eq!(
-        graph.aliases,
-        FxHashMap::from_iter([
-            (
-                "project-graph-aliases-explicit".to_owned(),
-                "explicit".to_owned()
-            ),
-            (
-                "project-graph-aliases-explicit-and-implicit".to_owned(),
-                "explicitAndImplicit".to_owned()
-            ),
-            (
-                "project-graph-aliases-implicit".to_owned(),
-                "implicit".to_owned()
-            ),
-            ("project-graph-aliases-node".to_owned(), "node".to_owned()),
-            ("pkg-bar".to_owned(), "nodeNameOnly".to_owned()),
-            ("pkg-foo".to_owned(), "nodeNameScope".to_owned()),
-            ("@scope/pkg-foo".to_owned(), "nodeNameScope".to_owned())
-        ])
-    );
-}
-
-#[tokio::test]
 async fn loads_node_aliases_name_scopes() {
-    let (graph, _sandbox) = get_aliases_graph(|cfg| {
-        cfg.alias_package_names = Some(NodeProjectAliasFormat::NameAndScope);
-    })
-    .await;
+    let (graph, _sandbox) = get_aliases_graph().await;
 
     assert_eq!(
         graph.aliases,
@@ -91,10 +50,7 @@ async fn loads_node_aliases_name_scopes() {
 
 #[tokio::test]
 async fn returns_project_using_alias() {
-    let (graph, _sandbox) = get_aliases_graph(|cfg| {
-        cfg.alias_package_names = Some(NodeProjectAliasFormat::NameAndScope);
-    })
-    .await;
+    let (graph, _sandbox) = get_aliases_graph().await;
 
     assert_eq!(
         graph.get("@scope/pkg-foo").unwrap().id,
@@ -104,10 +60,7 @@ async fn returns_project_using_alias() {
 
 #[tokio::test]
 async fn graph_uses_id_for_nodes() {
-    let (graph, _sandbox) = get_aliases_graph(|cfg| {
-        cfg.alias_package_names = Some(NodeProjectAliasFormat::NameAndScope);
-    })
-    .await;
+    let (graph, _sandbox) = get_aliases_graph().await;
 
     graph.get("pkg-bar").unwrap();
     graph.get("@scope/pkg-foo").unwrap();

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+#### 🚀 Updates
+
+- Deprecated `node.aliasPackageNames` setting. Aliases will always be loaded now.
+
 #### ⚙️ Internal
 
 - Upgraded to proto v0.8.

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -57,7 +57,7 @@ export interface ProjectDependency extends DependencyConfig {
 }
 
 export interface Project {
-	aliases: string[];
+	alias: string | null;
 	config: ProjectConfig;
 	dependencies: Record<string, ProjectDependency>;
 	fileGroups: Record<string, FileGroup>;

--- a/website/docs/__partials__/create-project/node/aliases.mdx
+++ b/website/docs/__partials__/create-project/node/aliases.mdx
@@ -1,6 +1,0 @@
-:::info
-
-Want to use `package.json` names? Enable the
-[`node.aliasPackageNames`](./config/toolchain#aliaspackagenames) setting!
-
-:::

--- a/website/docs/commands/migrate/from-turborepo.mdx
+++ b/website/docs/commands/migrate/from-turborepo.mdx
@@ -18,9 +18,7 @@ $ moon migrate from-turborepo
 :::caution
 
 moon must be [initialized](../init) and [`node`](../../config/toolchain#node) must be configured in
-the toolchain before this command is ran! We also suggest enabling the
-[`node.aliasPackageNames`](../../config/toolchain#aliaspackagenames) setting to ensure projects are
-resolved correctly.
+the toolchain before this command is ran!
 
 Furthermore, this process does not change existing `package.json` scripts, so if you're looking to
 migrate them as well, use the [`moon migrate from-package-json`](./from-package-json) command.

--- a/website/docs/concepts/query-lang.mdx
+++ b/website/docs/concepts/query-lang.mdx
@@ -96,8 +96,7 @@ project=server
 
 ### `projectAlias`
 
-Alias of the project. Requires aliasing to be enabled with
-[`node.aliasPackageNames`](../config/toolchain#aliaspackagenames).
+Alias of the project. For example, the `package.json` name.
 
 ```
 projectAlias~@scope/*

--- a/website/docs/concepts/token.mdx
+++ b/website/docs/concepts/token.mdx
@@ -352,9 +352,8 @@ tasks:
 
 ### `$projectAlias`
 
-Alias of the project that owns the currently running task. Requires aliasing to be enabled with
-[`node.aliasPackageNames`](../config/toolchain#aliaspackagenames). If not enabled, or no alias
-exists for the project, this will return an empty string.
+Alias of the project that owns the currently running task. If not enabled, or no alias exists for
+the project, this will return an empty string.
 
 ```yaml
 # Configured as

--- a/website/docs/config/toolchain.mdx
+++ b/website/docs/config/toolchain.mdx
@@ -174,28 +174,6 @@ ensure other Node.js processes outside of our toolchain are utilizing the same v
 }
 ```
 
-### `aliasPackageNames`
-
-<HeadingApiLink to="/api/types/interface/NodeConfig#aliasPackageNames" />
-
-When enabled, will assign [aliases](../concepts/project#aliases) to configured [projects](#projects)
-based on the `name` field in the project's `package.json`. Aliases can be used as a substitute for
-project names, allowing for the familiar package name to be used within
-[targets](../concepts/target) or configuration.
-
-This setting accepts one of the following values, which determines how to parse and assign the
-alias.
-
-- `name-and-scope` - Will use the package name as-is, including any scope. For example,
-  `@scope/example` or `example`.
-- `name-only` - Will only use the name and disregard any scope. For example, `@scope/example` will
-  become `example`.
-
-```yaml title=".moon/toolchain.yml" {2}
-node:
-  aliasPackageNames: 'name-only'
-```
-
 ### `binExecArgs`
 
 <HeadingApiLink to="/api/types/interface/NodeConfig#binExecArgs" />

--- a/website/docs/create-project.mdx
+++ b/website/docs/create-project.mdx
@@ -41,12 +41,6 @@ to not manually curate the projects list!
 
 :::
 
-import AliasesNode from './__partials__/create-project/node/aliases.mdx';
-
-<LangPartials noError>
-  <AliasesNode key="node" />
-</LangPartials>
-
 ## Configuring a project
 
 A project can be configured in 1 of 2 ways:

--- a/website/docs/guides/javascript/node-handbook.mdx
+++ b/website/docs/guides/javascript/node-handbook.mdx
@@ -78,7 +78,7 @@ node:
 
 > Versions can also be defined with [`.prototools`](../../proto/config).
 
-### Using `package.json` names and scripts
+### Using `package.json` scripts
 
 If you're looking to prototype moon, or reduce the migration effort to moon tasks, you can configure
 moon to inherit `package.json` scripts, and internally convert them to moon tasks. This can be
@@ -89,18 +89,6 @@ setting.
 node:
 	inferTasksFromScripts: true
 ```
-
-Furthermore, if you'd like to reference projects by their package name (both in configuration and on
-the command line), instead of the moon project name, enable the
-[`node.aliasPackageNames`](../../config/toolchain#aliaspackagenames) setting.
-
-```yaml title=".moon/toolchain.yml"
-node:
-	aliasPackageNames: 'name-and-scope'
-```
-
-> These are not enabled by default as we want to encourage the
-> [use of moon tasks](../../faq#can-we-use-packagejson-scripts).
 
 ## Repository structure
 


### PR DESCRIPTION
We don't really need this setting anymore. It also makes Node.js adoption harder.