### PR TITLE
fix: Fix task type detection.

### DIFF
--- a/crates/core/task/src/task.rs
+++ b/crates/core/task/src/task.rs
@@ -115,7 +115,11 @@ impl Task {
             output_paths: FxHashSet::default(),
             platform: cloned_config.platform,
             target,
-            type_of: TaskType::Test,
+            type_of: if is_local {
+                TaskType::Run
+            } else {
+                TaskType::Test
+            },
         };
 
         if config
@@ -187,12 +191,8 @@ impl Task {
 
     /// Determine the type of task after inheritance and expansion.
     pub fn determine_type(&mut self) {
-        if !self.options.run_in_ci {
-            self.type_of = TaskType::Run;
-        } else if !self.outputs.is_empty() {
+        if !self.outputs.is_empty() {
             self.type_of = TaskType::Build;
-        } else {
-            self.type_of = TaskType::Test;
         }
     }
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,6 +12,10 @@
   - Updated `moon init` and `moon bin` commands to support Rust.
   - Updated `moon docker prune` command to delete the `target` directory.
 
+#### 🐞 Fixes
+
+- Fixed an issue where task type was `run` when it should be `test`.
+
 #### ⚙️ Internal
 
 - Reworked `moon init --yes` to not enable all tools, and instead enable based on file detection.

--- a/website/docs/concepts/task.mdx
+++ b/website/docs/concepts/task.mdx
@@ -23,9 +23,9 @@ Tasks are categorized into 1 of the following types based on their configured pa
 - **Build** - Task generates one or many artifacts, and is derived from the
   [`outputs`](../config/project#outputs) setting.
 - **Run** - Task runs a one-off, long-running, or never-ending process, and is derived from the
-  [`local`](../config/project#local) or [`runInCI`](../config/project#runinci) settings.
+  [`local`](../config/project#local) setting.
 - **Test** - Task asserts code is correct and behaves as expected. This includes linting,
-  typechecking, unit tests, and any other form of testing.
+  typechecking, unit tests, and any other form of testing. Is the default.
 
 ## Configuration
 


### PR DESCRIPTION
If `runInCI` was false, it would set a task to `run` and not be found during `moon check`, which is incorrect.