### PR TITLE
tests: Remove reference from sandbox API.

### DIFF
--- a/crates/cli/src/commands/docker/scaffold.rs
+++ b/crates/cli/src/commands/docker/scaffold.rs
@@ -62,8 +62,6 @@ fn scaffold_workspace(
                     if let Some(cargo_toml) = CargoTomlCache::read(source)? {
                         let manifests = cargo_toml.get_member_manifest_paths(source)?;
 
-                        dbg!(&manifests, &source, &dest);
-
                         for manifest in manifests {
                             files.push(path::to_string(manifest.strip_prefix(source).unwrap())?);
                         }

--- a/crates/cli/tests/bin_test.rs
+++ b/crates/cli/tests/bin_test.rs
@@ -7,9 +7,9 @@ use moon_test_utils::{
 //     let (workspace_config, toolchain_config, tasks_config) = get_cases_fixture_configs();
 //     let sandbox = create_sandbox_with_config(
 //         "cases",
-//         Some(&workspace_config),
-//         Some(&toolchain_config),
-//         Some(&tasks_config),
+//         Some(workspace_config),
+//         Some(toolchain_config),
+//         Some(tasks_config),
 //     );
 
 //     let assert = sandbox.run_moon(|cmd| {
@@ -27,9 +27,9 @@ fn invalid_tool() {
     let (workspace_config, toolchain_config, tasks_config) = get_cases_fixture_configs();
     let sandbox = create_sandbox_with_config(
         "cases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -52,9 +52,9 @@ fn invalid_tool() {
 //     let (workspace_config, toolchain_config, tasks_config) = get_cases_fixture_configs();
 //     let sandbox = create_sandbox_with_config(
 //         "cases",
-//         Some(&workspace_config),
-//         Some(&toolchain_config),
-//         Some(&tasks_config),
+//         Some(workspace_config),
+//         Some(toolchain_config),
+//         Some(tasks_config),
 //     );
 
 //     let assert = sandbox.run_moon(|cmd| {

--- a/crates/cli/tests/check_test.rs
+++ b/crates/cli/tests/check_test.rs
@@ -7,9 +7,9 @@ fn cases_sandbox() -> Sandbox {
 
     create_sandbox_with_config(
         "cases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     )
 }
 

--- a/crates/cli/tests/dep_graph_test.rs
+++ b/crates/cli/tests/dep_graph_test.rs
@@ -9,9 +9,9 @@ fn all_by_default() {
 
     let sandbox = create_sandbox_with_config(
         "tasks",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -30,9 +30,9 @@ fn focused_by_target() {
 
     let sandbox = create_sandbox_with_config(
         "tasks",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -48,9 +48,9 @@ fn includes_dependencies_when_focused() {
 
     let sandbox = create_sandbox_with_config(
         "tasks",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -66,9 +66,9 @@ fn includes_dependents_when_focused() {
 
     let sandbox = create_sandbox_with_config(
         "tasks",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -84,9 +84,9 @@ fn outputs_json() {
 
     let sandbox = create_sandbox_with_config(
         "tasks",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -106,9 +106,9 @@ mod aliases {
 
         let sandbox = create_sandbox_with_config(
             "project-graph/aliases",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -125,9 +125,9 @@ mod aliases {
 
         let sandbox = create_sandbox_with_config(
             "project-graph/aliases",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {

--- a/crates/cli/tests/docker_test.rs
+++ b/crates/cli/tests/docker_test.rs
@@ -28,9 +28,9 @@ mod scaffold_workspace {
 
         let sandbox = create_sandbox_with_config(
             "node",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         sandbox.run_moon(|cmd| {
@@ -52,9 +52,9 @@ mod scaffold_workspace {
 
         let sandbox = create_sandbox_with_config(
             "node",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         // Test inherited configs
@@ -79,9 +79,9 @@ mod scaffold_workspace {
 
         let sandbox = create_sandbox_with_config(
             "node",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         sandbox.run_moon(|cmd| {
@@ -101,9 +101,9 @@ mod scaffold_workspace {
 
         let sandbox = create_sandbox_with_config(
             "node-npm/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         sandbox.run_moon(|cmd| {
@@ -122,9 +122,9 @@ mod scaffold_workspace {
 
         let sandbox = create_sandbox_with_config(
             "node-pnpm/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         sandbox.run_moon(|cmd| {
@@ -144,9 +144,9 @@ mod scaffold_workspace {
 
         let sandbox = create_sandbox_with_config(
             "node-yarn/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         sandbox.run_moon(|cmd| {
@@ -166,9 +166,9 @@ mod scaffold_workspace {
 
         let sandbox = create_sandbox_with_config(
             "node-yarn1/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         sandbox.run_moon(|cmd| {
@@ -191,7 +191,7 @@ mod scaffold_workspace {
         };
 
         let sandbox =
-            create_sandbox_with_config("rust/workspaces", Some(&workspace_config), None, None);
+            create_sandbox_with_config("rust/workspaces", Some(workspace_config), None, None);
 
         sandbox.run_moon(|cmd| {
             cmd.arg("docker").arg("scaffold").arg("rust");
@@ -216,9 +216,9 @@ mod scaffold_sources {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         sandbox.run_moon(|cmd| {
@@ -243,9 +243,9 @@ mod scaffold_sources {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         sandbox.run_moon(|cmd| {
@@ -268,9 +268,9 @@ mod scaffold_sources {
 
         let sandbox = create_sandbox_with_config(
             "cases",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         sandbox.run_moon(|cmd| {
@@ -304,9 +304,9 @@ mod prune {
 
         let sandbox = create_sandbox_with_config(
             "node",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -330,9 +330,9 @@ mod prune_node {
 
         let sandbox = create_sandbox_with_config(
             "node-npm/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         write_manifest(sandbox.path(), "other");
@@ -362,9 +362,9 @@ mod prune_node {
 
         let sandbox = create_sandbox_with_config(
             "node-pnpm/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         write_manifest(sandbox.path(), "other");
@@ -392,9 +392,9 @@ mod prune_node {
 
         let sandbox = create_sandbox_with_config(
             "node-yarn/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         write_manifest(sandbox.path(), "other");
@@ -422,9 +422,9 @@ mod prune_node {
 
         let sandbox = create_sandbox_with_config(
             "node-yarn1/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         write_manifest(sandbox.path(), "other");
@@ -457,9 +457,9 @@ mod setup {
 
         let sandbox = create_sandbox_with_config(
             "node",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -483,9 +483,9 @@ mod setup_node {
 
         let sandbox = create_sandbox_with_config(
             "node-npm/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         write_manifest(sandbox.path(), "other");
@@ -505,9 +505,9 @@ mod setup_node {
 
         let sandbox = create_sandbox_with_config(
             "node-pnpm/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         write_manifest(sandbox.path(), "other");
@@ -527,9 +527,9 @@ mod setup_node {
 
         let sandbox = create_sandbox_with_config(
             "node-yarn/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         write_manifest(sandbox.path(), "other");
@@ -549,9 +549,9 @@ mod setup_node {
 
         let sandbox = create_sandbox_with_config(
             "node-yarn1/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         write_manifest(sandbox.path(), "other");

--- a/crates/cli/tests/migrate_test.rs
+++ b/crates/cli/tests/migrate_test.rs
@@ -16,8 +16,8 @@ fn migrate_sandbox() -> Sandbox {
 
     create_sandbox_with_config(
         "migrate",
-        Some(&workspace_config),
-        Some(&toolchain_config),
+        Some(workspace_config),
+        Some(toolchain_config),
         None,
     )
 }

--- a/crates/cli/tests/misc_test.rs
+++ b/crates/cli/tests/misc_test.rs
@@ -8,7 +8,7 @@ fn fails_on_version_constraint() {
 
     workspace_config.version_constraint = Some(">=1000.0.0".into());
 
-    let sandbox = create_sandbox_with_config("cases", Some(&workspace_config), None, None);
+    let sandbox = create_sandbox_with_config("cases", Some(workspace_config), None, None);
 
     let assert = sandbox.run_moon(|cmd| {
         cmd.arg("sync");

--- a/crates/cli/tests/node_test.rs
+++ b/crates/cli/tests/node_test.rs
@@ -15,9 +15,9 @@ mod run_script {
 
         let sandbox = create_sandbox_with_config(
             "node-npm/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -37,9 +37,9 @@ mod run_script {
 
         let sandbox = create_sandbox_with_config(
             "node-npm/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -59,9 +59,9 @@ mod run_script {
 
         let sandbox = create_sandbox_with_config(
             "node-npm/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -79,9 +79,9 @@ mod run_script {
 
         let sandbox = create_sandbox_with_config(
             "node-npm/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -102,9 +102,9 @@ mod run_script {
 
         let sandbox = create_sandbox_with_config(
             "node-pnpm/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -122,9 +122,9 @@ mod run_script {
 
         let sandbox = create_sandbox_with_config(
             "node-yarn/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -142,9 +142,9 @@ mod run_script {
 
         let sandbox = create_sandbox_with_config(
             "node-yarn1/workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {

--- a/crates/cli/tests/project_graph_test.rs
+++ b/crates/cli/tests/project_graph_test.rs
@@ -20,9 +20,9 @@ fn many_projects() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -38,9 +38,9 @@ fn single_project_with_dependencies() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -56,9 +56,9 @@ fn single_project_no_dependencies() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -74,9 +74,9 @@ fn outputs_json() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -96,9 +96,9 @@ mod aliases {
 
         let sandbox = create_sandbox_with_config(
             "project-graph/aliases",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -115,9 +115,9 @@ mod aliases {
 
         let sandbox = create_sandbox_with_config(
             "project-graph/aliases",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -134,9 +134,9 @@ mod aliases {
 
         let sandbox = create_sandbox_with_config(
             "project-graph/aliases",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {

--- a/crates/cli/tests/project_test.rs
+++ b/crates/cli/tests/project_test.rs
@@ -9,9 +9,9 @@ fn unknown_project() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -29,9 +29,9 @@ fn empty_config() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -47,9 +47,9 @@ fn no_config() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -66,9 +66,9 @@ fn basic_config() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -85,9 +85,9 @@ fn advanced_config() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -104,9 +104,9 @@ fn depends_on_paths() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -122,9 +122,9 @@ fn with_tasks() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -140,9 +140,9 @@ fn root_level() {
 
     let sandbox = create_sandbox_with_config(
         "cases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {

--- a/crates/cli/tests/query_test.rs
+++ b/crates/cli/tests/query_test.rs
@@ -238,9 +238,9 @@ mod projects {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -256,9 +256,9 @@ mod projects {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -292,9 +292,9 @@ mod projects {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
         sandbox.enable_git();
 
@@ -320,9 +320,9 @@ mod projects {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
         sandbox.enable_git();
 
@@ -355,9 +355,9 @@ mod projects {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
         sandbox.enable_git();
 
@@ -392,9 +392,9 @@ mod projects {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -417,9 +417,9 @@ mod projects {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -442,9 +442,9 @@ mod projects {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -481,9 +481,9 @@ mod projects {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -506,9 +506,9 @@ mod projects {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -531,9 +531,9 @@ mod projects {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -559,9 +559,9 @@ mod projects {
 
             let sandbox = create_sandbox_with_config(
                 "projects",
-                Some(&workspace_config),
-                Some(&toolchain_config),
-                Some(&tasks_config),
+                Some(workspace_config),
+                Some(toolchain_config),
+                Some(tasks_config),
             );
 
             let assert = sandbox.run_moon(|cmd| {
@@ -584,9 +584,9 @@ mod projects {
 
             let sandbox = create_sandbox_with_config(
                 "projects",
-                Some(&workspace_config),
-                Some(&toolchain_config),
-                Some(&tasks_config),
+                Some(workspace_config),
+                Some(toolchain_config),
+                Some(tasks_config),
             );
             sandbox.enable_git();
 
@@ -618,9 +618,9 @@ mod tasks {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -636,9 +636,9 @@ mod tasks {
 
         let sandbox = create_sandbox_with_config(
             "projects",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {
@@ -684,9 +684,9 @@ mod touched_files {
 
         let sandbox = create_sandbox_with_config(
             "cases",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
         sandbox.enable_git();
 
@@ -712,9 +712,9 @@ mod touched_files {
 
         let sandbox = create_sandbox_with_config(
             "cases",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
         sandbox.enable_git();
 

--- a/crates/cli/tests/run_node_test.rs
+++ b/crates/cli/tests/run_node_test.rs
@@ -12,9 +12,9 @@ fn node_sandbox() -> Sandbox {
 
     let sandbox = create_sandbox_with_config(
         "node",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     sandbox.enable_git();
@@ -33,9 +33,9 @@ where
 
     let sandbox = create_sandbox_with_config(
         "node",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     sandbox.enable_git();
@@ -48,9 +48,9 @@ fn depman_sandbox(depman: &str) -> Sandbox {
 
     let sandbox = create_sandbox_with_config(
         format!("node-{depman}/workspaces"),
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     sandbox.enable_git();
@@ -66,9 +66,9 @@ fn depman_non_workspaces_sandbox(depman: &str) -> Sandbox {
 
     let sandbox = create_sandbox_with_config(
         format!("node-{depman}/project"),
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     sandbox.enable_git();
@@ -432,9 +432,9 @@ mod install_deps {
 
         let sandbox = create_sandbox_with_config(
             "node-non-workspaces",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         sandbox.enable_git();
@@ -1061,9 +1061,9 @@ mod aliases {
 
         let sandbox = create_sandbox_with_config(
             "project-graph/aliases",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let assert = sandbox.run_moon(|cmd| {

--- a/crates/cli/tests/run_rust_test.rs
+++ b/crates/cli/tests/run_rust_test.rs
@@ -20,8 +20,8 @@ fn rust_sandbox() -> Sandbox {
 
     let sandbox = create_sandbox_with_config(
         "rust/cases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
+        Some(workspace_config),
+        Some(toolchain_config),
         None,
     );
     sandbox.enable_git();

--- a/crates/cli/tests/run_system_test.rs
+++ b/crates/cli/tests/run_system_test.rs
@@ -21,7 +21,7 @@ fn system_sandbox() -> Sandbox {
     };
 
     let sandbox =
-        create_sandbox_with_config("system", Some(&workspace_config), None, Some(&tasks_config));
+        create_sandbox_with_config("system", Some(workspace_config), None, Some(tasks_config));
 
     sandbox.enable_git();
     sandbox

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -13,9 +13,9 @@ fn cases_sandbox() -> Sandbox {
 
     create_sandbox_with_config(
         "cases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     )
 }
 
@@ -29,9 +29,9 @@ where
 
     create_sandbox_with_config(
         "cases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     )
 }
 

--- a/crates/cli/tests/run_typescript_test.rs
+++ b/crates/cli/tests/run_typescript_test.rs
@@ -16,9 +16,9 @@ where
 
     let sandbox = create_sandbox_with_config(
         "typescript",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     sandbox.enable_git();

--- a/crates/cli/tests/run_webhooks_test.rs
+++ b/crates/cli/tests/run_webhooks_test.rs
@@ -11,9 +11,9 @@ fn sandbox(uri: String) -> Sandbox {
 
     let sandbox = create_sandbox_with_config(
         "node",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     sandbox.enable_git();

--- a/crates/cli/tests/setup_teardown_test.rs
+++ b/crates/cli/tests/setup_teardown_test.rs
@@ -21,9 +21,9 @@ fn sets_up_and_tears_down() {
 
     let sandbox = create_sandbox_with_config(
         "cases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let setup = sandbox.run_moon(|cmd| {

--- a/crates/cli/tests/sync_test.rs
+++ b/crates/cli/tests/sync_test.rs
@@ -16,7 +16,7 @@ fn syncs_all_projects() {
 
     let sandbox = create_sandbox_with_config(
         "project-graph/dependencies",
-        Some(&workspace_config),
+        Some(workspace_config),
         None,
         None,
     );

--- a/crates/cli/tests/task_test.rs
+++ b/crates/cli/tests/task_test.rs
@@ -9,9 +9,9 @@ fn unknown_task() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -29,9 +29,9 @@ fn shows_inputs() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {
@@ -47,9 +47,9 @@ fn shows_outputs() {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let assert = sandbox.run_moon(|cmd| {

--- a/crates/core/action-pipeline/benches/pipeline_benchmark.rs
+++ b/crates/core/action-pipeline/benches/pipeline_benchmark.rs
@@ -38,9 +38,9 @@ pub fn pipeline_benchmark(c: &mut Criterion) {
 
     let sandbox = create_sandbox_with_config(
         "cases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     c.bench_function("pipeline", |b| {

--- a/crates/core/dep-graph/benches/dep_graph_benchmark.rs
+++ b/crates/core/dep-graph/benches/dep_graph_benchmark.rs
@@ -8,9 +8,9 @@ pub fn build_benchmark(c: &mut Criterion) {
 
     let sandbox = create_sandbox_with_config(
         "cases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     c.bench_function("dep_graph_build", |b| {

--- a/crates/core/dep-graph/tests/dep_graph_test.rs
+++ b/crates/core/dep-graph/tests/dep_graph_test.rs
@@ -380,10 +380,10 @@ mod run_target_if_touched {
 
         let mut graph = build_dep_graph(&workspace, &projects);
         graph
-            .run_target(&Target::new("inputA", "a").unwrap(), Some(touched_files))
+            .run_target(&Target::new("inputA", "a").unwrap(), Some(&touched_files))
             .unwrap();
         graph
-            .run_target(&Target::new("inputB", "b").unwrap(), Some(touched_files))
+            .run_target(&Target::new("inputB", "b").unwrap(), Some(&touched_files))
             .unwrap();
         let graph = graph.build();
 
@@ -401,13 +401,13 @@ mod run_target_if_touched {
 
         let mut graph = build_dep_graph(&workspace, &projects);
         graph
-            .run_target(&Target::new("inputA", "a").unwrap(), Some(touched_files))
+            .run_target(&Target::new("inputA", "a").unwrap(), Some(&touched_files))
             .unwrap();
         graph
-            .run_target(&Target::new("inputB", "b2").unwrap(), Some(touched_files))
+            .run_target(&Target::new("inputB", "b2").unwrap(), Some(&touched_files))
             .unwrap();
         graph
-            .run_target(&Target::new("inputC", "c").unwrap(), Some(touched_files))
+            .run_target(&Target::new("inputC", "c").unwrap(), Some(&touched_files))
             .unwrap();
         let graph = graph.build();
 

--- a/crates/core/dep-graph/tests/dep_graph_test.rs
+++ b/crates/core/dep-graph/tests/dep_graph_test.rs
@@ -47,9 +47,9 @@ async fn create_project_graph() -> (Workspace, ProjectGraph, Sandbox) {
 
     let sandbox = create_sandbox_with_config(
         "projects",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
@@ -95,9 +95,9 @@ async fn create_tasks_project_graph() -> (Workspace, ProjectGraph, Sandbox) {
 
     let sandbox = create_sandbox_with_config(
         "tasks",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
@@ -380,10 +380,10 @@ mod run_target_if_touched {
 
         let mut graph = build_dep_graph(&workspace, &projects);
         graph
-            .run_target(&Target::new("inputA", "a").unwrap(), Some(&touched_files))
+            .run_target(&Target::new("inputA", "a").unwrap(), Some(touched_files))
             .unwrap();
         graph
-            .run_target(&Target::new("inputB", "b").unwrap(), Some(&touched_files))
+            .run_target(&Target::new("inputB", "b").unwrap(), Some(touched_files))
             .unwrap();
         let graph = graph.build();
 
@@ -401,13 +401,13 @@ mod run_target_if_touched {
 
         let mut graph = build_dep_graph(&workspace, &projects);
         graph
-            .run_target(&Target::new("inputA", "a").unwrap(), Some(&touched_files))
+            .run_target(&Target::new("inputA", "a").unwrap(), Some(touched_files))
             .unwrap();
         graph
-            .run_target(&Target::new("inputB", "b2").unwrap(), Some(&touched_files))
+            .run_target(&Target::new("inputB", "b2").unwrap(), Some(touched_files))
             .unwrap();
         graph
-            .run_target(&Target::new("inputC", "c").unwrap(), Some(&touched_files))
+            .run_target(&Target::new("inputC", "c").unwrap(), Some(touched_files))
             .unwrap();
         let graph = graph.build();
 

--- a/crates/core/project-graph/benches/project_graph_benchmark.rs
+++ b/crates/core/project-graph/benches/project_graph_benchmark.rs
@@ -7,9 +7,9 @@ pub fn get_benchmark(c: &mut Criterion) {
 
     let sandbox = create_sandbox_with_config(
         "cases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     c.bench_function("project_graph_get", |b| {
@@ -30,9 +30,9 @@ pub fn get_all_benchmark(c: &mut Criterion) {
 
     let sandbox = create_sandbox_with_config(
         "cases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     c.bench_function("project_graph_get_all", |b| {

--- a/crates/core/project-graph/tests/project_graph_test.rs
+++ b/crates/core/project-graph/tests/project_graph_test.rs
@@ -27,9 +27,9 @@ async fn get_aliases_graph() -> (ProjectGraph, Sandbox) {
 
     let sandbox = create_sandbox_with_config(
         "project-graph/aliases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
@@ -51,7 +51,7 @@ async fn get_dependencies_graph(enable_git: bool) -> (ProjectGraph, Sandbox) {
 
     let sandbox = create_sandbox_with_config(
         "project-graph/dependencies",
-        Some(&workspace_config),
+        Some(workspace_config),
         None,
         None,
     );
@@ -79,7 +79,7 @@ async fn get_dependents_graph() -> (ProjectGraph, Sandbox) {
 
     let sandbox = create_sandbox_with_config(
         "project-graph/dependents",
-        Some(&workspace_config),
+        Some(workspace_config),
         None,
         None,
     );
@@ -109,7 +109,7 @@ where
 
     let sandbox = create_sandbox_with_config(
         "project-graph/tag-constraints",
-        Some(&workspace_config),
+        Some(workspace_config),
         None,
         None,
     );
@@ -137,7 +137,7 @@ where
 
     let sandbox = create_sandbox_with_config(
         "project-graph/type-constraints",
-        Some(&workspace_config),
+        Some(workspace_config),
         None,
         None,
     );
@@ -157,7 +157,7 @@ async fn get_queries_graph() -> (ProjectGraph, Sandbox) {
     };
 
     let sandbox =
-        create_sandbox_with_config("project-graph/query", Some(&workspace_config), None, None);
+        create_sandbox_with_config("project-graph/query", Some(workspace_config), None, None);
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
     let graph = generate_project_graph(&mut workspace).await.unwrap();
@@ -178,7 +178,7 @@ async fn can_use_map_and_globs_setting() {
         ..WorkspaceConfig::default()
     };
 
-    let sandbox = create_sandbox_with_config("projects", Some(&workspace_config), None, None);
+    let sandbox = create_sandbox_with_config("projects", Some(workspace_config), None, None);
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
     let graph = generate_project_graph(&mut workspace).await.unwrap();
@@ -216,7 +216,7 @@ async fn can_generate_with_deps_cycles() {
     };
 
     let sandbox =
-        create_sandbox_with_config("project-graph/cycle", Some(&workspace_config), None, None);
+        create_sandbox_with_config("project-graph/cycle", Some(workspace_config), None, None);
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
     let graph = generate_project_graph(&mut workspace).await.unwrap();
@@ -299,7 +299,7 @@ mod globs {
 
         // Use git so we can test against the .git folder
         let sandbox =
-            create_sandbox_with_config("project-graph/langs", Some(&workspace_config), None, None);
+            create_sandbox_with_config("project-graph/langs", Some(workspace_config), None, None);
         sandbox.enable_git();
         sandbox.create_file(".foo/moon.yml", "{}");
         sandbox.create_file("node_modules/moon/package.json", "{}");
@@ -323,7 +323,7 @@ mod globs {
 
         // Use git so we can test against the .git folder
         let sandbox =
-            create_sandbox_with_config("project-graph/langs", Some(&workspace_config), None, None);
+            create_sandbox_with_config("project-graph/langs", Some(workspace_config), None, None);
         sandbox.enable_git();
         sandbox.create_file(".gitignore", "*-config");
 
@@ -347,7 +347,7 @@ mod globs {
         };
 
         let sandbox =
-            create_sandbox_with_config("project-graph/ids", Some(&workspace_config), None, None);
+            create_sandbox_with_config("project-graph/ids", Some(workspace_config), None, None);
 
         let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
         let graph = generate_project_graph(&mut workspace).await.unwrap();
@@ -435,7 +435,7 @@ mod to_dot {
 
         let sandbox = create_sandbox_with_config(
             "project-graph/dependencies",
-            Some(&workspace_config),
+            Some(workspace_config),
             None,
             None,
         );

--- a/crates/core/project-graph/tests/projects_test.rs
+++ b/crates/core/project-graph/tests/projects_test.rs
@@ -48,9 +48,9 @@ where
 
     let sandbox = create_sandbox_with_config(
         "tasks",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     box_callback(&sandbox);
@@ -371,9 +371,9 @@ tasks:
 
             let sandbox = create_sandbox_with_config(
                 "task-inheritance",
-                Some(&workspace_config),
+                Some(workspace_config),
                 None,
-                Some(&tasks_config),
+                Some(tasks_config),
             );
 
             let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
@@ -1432,9 +1432,9 @@ mod detection {
 
         let sandbox = create_sandbox_with_config(
             "project-graph/langs",
-            Some(&workspace_config),
+            Some(workspace_config),
             None,
-            Some(&tasks_config),
+            Some(tasks_config),
         );
 
         let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();

--- a/crates/core/runner/tests/inputs_collector_test.rs
+++ b/crates/core/runner/tests/inputs_collector_test.rs
@@ -11,9 +11,9 @@ fn cases_sandbox() -> Sandbox {
 
     create_sandbox_with_config(
         "cases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     )
 }
 

--- a/crates/core/test-utils/src/sandbox.rs
+++ b/crates/core/test-utils/src/sandbox.rs
@@ -133,22 +133,12 @@ pub fn create_sandbox_with_config<T: AsRef<str>>(
 
     sandbox.create_file(
         ".moon/workspace.yml",
-        serde_yaml::to_string(
-            &workspace_config
-                .map(|c| c.to_owned())
-                .unwrap_or_else(WorkspaceConfig::default),
-        )
-        .unwrap(),
+        serde_yaml::to_string(&workspace_config.unwrap_or_default()).unwrap(),
     );
 
     sandbox.create_file(
         ".moon/toolchain.yml",
-        serde_yaml::to_string(
-            &toolchain_config
-                .map(|c| c.to_owned())
-                .unwrap_or_else(ToolchainConfig::default),
-        )
-        .unwrap(),
+        serde_yaml::to_string(&toolchain_config.unwrap_or_default()).unwrap(),
     );
 
     if let Some(config) = tasks_config {

--- a/crates/core/test-utils/src/sandbox.rs
+++ b/crates/core/test-utils/src/sandbox.rs
@@ -125,9 +125,9 @@ pub fn create_sandbox<T: AsRef<str>>(fixture: T) -> Sandbox {
 
 pub fn create_sandbox_with_config<T: AsRef<str>>(
     fixture: T,
-    workspace_config: Option<&WorkspaceConfig>,
-    toolchain_config: Option<&ToolchainConfig>,
-    tasks_config: Option<&InheritedTasksConfig>,
+    workspace_config: Option<WorkspaceConfig>,
+    toolchain_config: Option<ToolchainConfig>,
+    tasks_config: Option<InheritedTasksConfig>,
 ) -> Sandbox {
     let sandbox = create_sandbox(fixture);
 
@@ -177,9 +177,9 @@ pub fn create_sandbox_with_factory<
 
     create_sandbox_with_config(
         fixture,
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     )
 }
 

--- a/crates/node/platform/tests/project_aliases_test.rs
+++ b/crates/node/platform/tests/project_aliases_test.rs
@@ -11,9 +11,9 @@ async fn get_aliases_graph() -> (ProjectGraph, Sandbox) {
 
     let sandbox = create_sandbox_with_config(
         "project-graph/aliases",
-        Some(&workspace_config),
-        Some(&toolchain_config),
-        Some(&tasks_config),
+        Some(workspace_config),
+        Some(toolchain_config),
+        Some(tasks_config),
     );
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();

--- a/crates/typescript/platform/tests/sync_project_test.rs
+++ b/crates/typescript/platform/tests/sync_project_test.rs
@@ -14,9 +14,9 @@ mod missing_tsconfig {
         let (workspace_config, toolchain_config, tasks_config) = get_node_fixture_configs();
         let sandbox = create_sandbox_with_config(
             "node",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let project = Project::new(
@@ -58,9 +58,9 @@ mod missing_tsconfig {
         let (workspace_config, toolchain_config, tasks_config) = get_node_fixture_configs();
         let sandbox = create_sandbox_with_config(
             "node",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let project = Project::new(
@@ -102,9 +102,9 @@ mod missing_tsconfig {
         let (workspace_config, toolchain_config, tasks_config) = get_node_fixture_configs();
         let sandbox = create_sandbox_with_config(
             "node",
-            Some(&workspace_config),
-            Some(&toolchain_config),
-            Some(&tasks_config),
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
         );
 
         let project = Project::new(


### PR DESCRIPTION
It's not necessary and was constantly causing rust-analyzer issues.