### PR TITLE
new: Add `rust.cargoBins` setting.

### DIFF
--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -2,6 +2,9 @@ $schema: '../website/static/schemas/toolchain.json'
 
 rust:
   version: '1.69.0'
+  cargoBins:
+    - 'make'
+    - 'nextest'
   syncToolchainConfig: true
 
 node:

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -3,8 +3,9 @@
 $schema: '../website/static/schemas/workspace.json'
 
 projects:
-  sources:
-    moon: '.'
+  # sources:
+  #   moon: '.'
+  sources: {}
   globs:
     - 'packages/*'
     - '!packages/cli'

--- a/crates/cli/tests/snapshots/run_rust_test__handles_process_exit_nonzero.snap
+++ b/crates/cli/tests/snapshots/run_rust_test__handles_process_exit_nonzero.snap
@@ -2,6 +2,7 @@
 source: crates/cli/tests/run_rust_test.rs
 expression: assert.output()
 ---
+▪▪▪▪ cargo generate-lockfile
 ▪▪▪▪ rust:exitNonZero
 stdout
 ▪▪▪▪ rust:exitNonZero (100ms)

--- a/crates/cli/tests/snapshots/run_rust_test__handles_process_exit_zero.snap
+++ b/crates/cli/tests/snapshots/run_rust_test__handles_process_exit_zero.snap
@@ -2,6 +2,7 @@
 source: crates/cli/tests/run_rust_test.rs
 expression: assert.output()
 ---
+▪▪▪▪ cargo generate-lockfile
 ▪▪▪▪ rust:exitZero
 stdout
 ▪▪▪▪ rust:exitZero (100ms)

--- a/crates/cli/tests/snapshots/run_rust_test__inherits_moon_env_vars.snap
+++ b/crates/cli/tests/snapshots/run_rust_test__inherits_moon_env_vars.snap
@@ -2,6 +2,7 @@
 source: crates/cli/tests/run_rust_test.rs
 expression: assert.output()
 ---
+▪▪▪▪ cargo generate-lockfile
 ▪▪▪▪ rust:envVarsMoon
 MOON_CACHE=read-write
 MOON_CACHE_DIR=<WORKSPACE>/.moon/cache

--- a/crates/cli/tests/snapshots/run_rust_test__runs_from_project_root.snap
+++ b/crates/cli/tests/snapshots/run_rust_test__runs_from_project_root.snap
@@ -2,6 +2,7 @@
 source: crates/cli/tests/run_rust_test.rs
 expression: assert.output()
 ---
+▪▪▪▪ cargo generate-lockfile
 ▪▪▪▪ rust:runFromProject
 <WORKSPACE>
 ▪▪▪▪ rust:runFromProject (100ms)

--- a/crates/cli/tests/snapshots/run_rust_test__runs_from_workspace_root.snap
+++ b/crates/cli/tests/snapshots/run_rust_test__runs_from_workspace_root.snap
@@ -2,6 +2,7 @@
 source: crates/cli/tests/run_rust_test.rs
 expression: assert.output()
 ---
+▪▪▪▪ cargo generate-lockfile
 ▪▪▪▪ rust:runFromWorkspace
 <WORKSPACE>
 ▪▪▪▪ rust:runFromWorkspace (100ms)

--- a/crates/cli/tests/snapshots/run_rust_test__runs_standard_script.snap
+++ b/crates/cli/tests/snapshots/run_rust_test__runs_standard_script.snap
@@ -2,6 +2,7 @@
 source: crates/cli/tests/run_rust_test.rs
 expression: assert.output()
 ---
+▪▪▪▪ cargo generate-lockfile
 ▪▪▪▪ rust:standard
 stdout
 ▪▪▪▪ rust:standard (100ms)

--- a/crates/cli/tests/snapshots/run_rust_test__sets_env_vars.snap
+++ b/crates/cli/tests/snapshots/run_rust_test__sets_env_vars.snap
@@ -2,6 +2,7 @@
 source: crates/cli/tests/run_rust_test.rs
 expression: assert.output()
 ---
+▪▪▪▪ cargo generate-lockfile
 ▪▪▪▪ rust:envVars
 MOON_FOO=abc
 MOON_BAR=123

--- a/crates/core/config/src/toolchain/rust.rs
+++ b/crates/core/config/src/toolchain/rust.rs
@@ -12,6 +12,9 @@ fn validate_rust_version(value: &str) -> Result<(), ValidationError> {
 #[serde(default, deny_unknown_fields, rename_all = "camelCase")]
 pub struct RustConfig {
     #[serde(skip_serializing_if = "is_default")]
+    pub cargo_bins: Vec<String>,
+
+    #[serde(skip_serializing_if = "is_default")]
     pub sync_toolchain_config: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/rust/platform/src/bins_hasher.rs
+++ b/crates/rust/platform/src/bins_hasher.rs
@@ -1,0 +1,18 @@
+use moon_hasher::{hash_vec, Hasher, Sha256};
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RustBinsHasher {
+    pub bins: Vec<String>,
+}
+
+impl Hasher for RustBinsHasher {
+    fn hash(&self, sha: &mut Sha256) {
+        hash_vec(&self.bins, sha);
+    }
+
+    fn serialize(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+}

--- a/crates/rust/platform/src/lib.rs
+++ b/crates/rust/platform/src/lib.rs
@@ -1,3 +1,4 @@
+mod bins_hasher;
 mod manifest_hasher;
 mod rust_platform;
 mod target_hasher;

--- a/crates/rust/platform/src/rust_platform.rs
+++ b/crates/rust/platform/src/rust_platform.rs
@@ -199,19 +199,16 @@ impl Platform for RustPlatform {
         runtime: &Runtime,
         working_dir: &Path,
     ) -> Result<(), ToolError> {
+        let tool = self.toolchain.get_for_version(runtime.version())?;
         let lockfile_path = working_dir.join(CARGO.lockfile);
 
         if !lockfile_path.exists() {
-            let tool = self.toolchain.get_for_version(runtime.version())?;
-
             print_checkpoint("cargo generate-lockfile", Checkpoint::Setup);
 
             tool.exec_cargo(["generate-lockfile"], working_dir).await?;
         }
 
         if !self.config.cargo_bins.is_empty() {
-            let tool = self.toolchain.get_for_version(runtime.version())?;
-
             print_checkpoint("cargo binstall", Checkpoint::Setup);
 
             // Install cargo-binstall if it does not exist
@@ -235,7 +232,7 @@ impl Platform for RustPlatform {
             debug!(
                 target: LOG_TARGET,
                 "Installing Cargo binaries: {}",
-                map_list(&self.config.cargo_bins, |b| color::shell(b))
+                map_list(&self.config.cargo_bins, |b| color::label(b))
             );
 
             let mut args = string_vec!["binstall", "--no-confirm", "--log-level", "info"];

--- a/crates/rust/platform/src/rust_platform.rs
+++ b/crates/rust/platform/src/rust_platform.rs
@@ -1,11 +1,11 @@
-use crate::target_hasher::RustTargetHasher;
+use crate::{bins_hasher::RustBinsHasher, target_hasher::RustTargetHasher};
 use moon_action_context::ActionContext;
 use moon_config::{
     HasherConfig, PlatformType, ProjectConfig, ProjectsAliasesMap, ProjectsSourcesMap, RustConfig,
 };
 use moon_error::MoonError;
 use moon_hasher::HashSet;
-use moon_logger::debug;
+use moon_logger::{debug, map_list};
 use moon_platform::{Platform, Runtime, Version};
 use moon_project::{Project, ProjectError};
 use moon_rust_lang::{
@@ -16,6 +16,7 @@ use moon_rust_lang::{
 };
 use moon_rust_tool::RustTool;
 use moon_task::Task;
+use moon_terminal::{print_checkpoint, Checkpoint};
 use moon_tool::{Tool, ToolError, ToolManager};
 use moon_utils::{async_trait, process::Command};
 use proto::{rust::RustLanguage, Executable, Proto};
@@ -203,7 +204,47 @@ impl Platform for RustPlatform {
         if !lockfile_path.exists() {
             let tool = self.toolchain.get_for_version(runtime.version())?;
 
+            print_checkpoint("cargo generate-lockfile", Checkpoint::Setup);
+
             tool.exec_cargo(&["generate-lockfile"], working_dir).await?;
+        }
+
+        if !self.config.cargo_bins.is_empty() {
+            let tool = self.toolchain.get_for_version(runtime.version())?;
+
+            print_checkpoint("cargo binstall", Checkpoint::Setup);
+
+            // Install cargo-binstall if it does not exist
+            if !tool
+                .tool
+                .get_globals_bin_dir()?
+                .join("cargo-binstall")
+                .exists()
+            {
+                debug!(
+                    target: LOG_TARGET,
+                    "{} does not exist, installing",
+                    color::shell("cargo-binstall")
+                );
+
+                tool.exec_cargo(&["install", "cargo-binstall"], working_dir)
+                    .await?;
+            }
+
+            // Then attempt to install binaries
+            debug!(
+                target: LOG_TARGET,
+                "Installing Cargo binaries: {}",
+                map_list(&self.config.cargo_bins, |b| color::shell(b))
+            );
+
+            let mut args = vec!["binstall", "--no-confirm", "--log-level", "info"];
+
+            for bin in &self.config.cargo_bins {
+                args.push(bin.as_str());
+            }
+
+            tool.exec_cargo(&args, working_dir).await?;
         }
 
         Ok(())
@@ -289,10 +330,17 @@ impl Platform for RustPlatform {
     async fn hash_manifest_deps(
         &self,
         _manifest_path: &Path,
-        _hashset: &mut HashSet,
+        hashset: &mut HashSet,
         _hasher_config: &HasherConfig,
     ) -> Result<(), ToolError> {
+        if !self.config.cargo_bins.is_empty() {
+            hashset.hash(RustBinsHasher {
+                bins: self.config.cargo_bins.clone(),
+            });
+        }
+
         // NOTE: Since Cargo has no way to install dependencies, we don't actually need this!
+        // However, will leave it around incase a new cargo command is added in the future.
 
         // let mut hasher = RustManifestHasher::default();
         // let root_cargo_toml = CargoTomlCache::read(&self.workspace_root)?;

--- a/crates/rust/platform/tests/rust_platform_test.rs
+++ b/crates/rust/platform/tests/rust_platform_test.rs
@@ -104,6 +104,7 @@ mod sync_project {
             platform.config = RustConfig {
                 sync_toolchain_config: false,
                 version: Some("1.70.0".into()),
+                ..RustConfig::default()
             };
 
             let project = Project {
@@ -132,6 +133,7 @@ mod sync_project {
             platform.config = RustConfig {
                 sync_toolchain_config: true,
                 version: None,
+                ..RustConfig::default()
             };
 
             let project = Project {
@@ -160,6 +162,7 @@ mod sync_project {
             platform.config = RustConfig {
                 sync_toolchain_config: true,
                 version: Some("1.70.0".into()),
+                ..RustConfig::default()
             };
 
             let project = Project {
@@ -187,6 +190,7 @@ mod sync_project {
             platform.config = RustConfig {
                 sync_toolchain_config: true,
                 version: Some("1.70.0".into()),
+                ..RustConfig::default()
             };
 
             let project = Project {

--- a/crates/rust/tool/src/rust_tool.rs
+++ b/crates/rust/tool/src/rust_tool.rs
@@ -6,7 +6,10 @@ use moon_tool::{Tool, ToolError};
 use moon_utils::process::Command;
 use proto::{async_trait, rust::RustLanguage, Installable, Proto, Tool as ProtoTool};
 use rustc_hash::FxHashMap;
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 
 #[derive(Debug)]
 pub struct RustTool {
@@ -39,7 +42,11 @@ impl RustTool {
         Ok(rust)
     }
 
-    pub async fn exec_cargo(&self, args: &[&str], working_dir: &Path) -> Result<(), ToolError> {
+    pub async fn exec_cargo<I, S>(&self, args: I, working_dir: &Path) -> Result<(), ToolError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
         Command::new("cargo")
             .args(args)
             .cwd(working_dir)

--- a/packages/types/src/toolchain-config.ts
+++ b/packages/types/src/toolchain-config.ts
@@ -38,6 +38,7 @@ export interface NodeConfig {
 }
 
 export interface RustConfig {
+	cargoBins: string[] | null;
 	syncToolchainConfig: boolean;
 	version: string | null;
 }

--- a/website/docs/config/toolchain.mdx
+++ b/website/docs/config/toolchain.mdx
@@ -502,6 +502,30 @@ rust:
 
 > Version can also be defined with [`.prototools`](../proto/config).
 
+### `cargoBins`
+
+<HeadingApiLink to="/api/types/interface/RustConfig#cargoBins" />
+
+A list of crates/binaries (with optional versions) to install into Cargo (`~/.cargo/bin`), and make
+them available to the `cargo` command. Binaries will be installed with
+[`cargo-binstall`](https://crates.io/crates/cargo-binstall) in an effort to reduce build and
+compilation times.
+
+```yaml title=".moon/toolchain.yml" {2}
+rust:
+  cargoBins:
+    - 'make@0.35.0'
+    - 'nextest'
+```
+
+Binaries that have been installed into Cargo can be referenced from task commands:
+
+```yaml title="moon.yml"
+tasks:
+  test:
+    command: 'nextest run --workspace'
+```
+
 ### `syncToolchainConfig`
 
 <HeadingApiLink to="/api/types/interface/RustConfig#syncToolchainConfig" />


### PR DESCRIPTION
This will install Cargo binaries with `cargo-binstall` so that they're available for tasks.