### PR TITLE
internal: Clean up `moon init` templates.

### DIFF
--- a/crates/cli/src/commands/init/mod.rs
+++ b/crates/cli/src/commands/init/mod.rs
@@ -6,12 +6,8 @@ use crate::helpers::AnyError;
 use clap::ValueEnum;
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::Confirm;
-use moon_config::{
-    load_tasks_config_template, load_toolchain_config_template, load_workspace_config_template,
-};
-use moon_constants::{
-    CONFIG_DIRNAME, CONFIG_TASKS_FILENAME, CONFIG_TOOLCHAIN_FILENAME, CONFIG_WORKSPACE_FILENAME,
-};
+use moon_config::{load_toolchain_config_template, load_workspace_config_template};
+use moon_constants::{CONFIG_DIRNAME, CONFIG_TOOLCHAIN_FILENAME, CONFIG_WORKSPACE_FILENAME};
 use moon_node_lang::NPM;
 use moon_rust_lang::CARGO;
 use moon_terminal::{create_theme, safe_exit};
@@ -211,13 +207,6 @@ pub async fn init(
         moon_dir.join(CONFIG_WORKSPACE_FILENAME),
         render_workspace_template(&context)?,
     )?;
-
-    if !options.minimal {
-        fs::write_file(
-            moon_dir.join(CONFIG_TASKS_FILENAME),
-            Tera::one_off(load_tasks_config_template(), &context, false)?,
-        )?;
-    }
 
     // Append to ignore file
     let mut file = OpenOptions::new()

--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__rust__tests__renders_default.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__rust__tests__renders_default.snap
@@ -4,8 +4,11 @@ expression: render_template(context).unwrap()
 ---
 # Configures Rust within the toolchain.
 rust:
-  # The toolchain to use. Must be a semantic version that includes major, minor, and patch.
+  # The Rust toolchain to use. Must be a semantic version that includes major, minor, and patch.
   version: '1.70.0'
+
+  # List of Cargo binaries to install globally and make available to tasks.
+  bins: []
 
   # Sync the configured version above as a channel to the root `rust-toolchain.toml` config.
   syncToolchainConfig: false

--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_default.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_default.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/cli/src/commands/init/mod.rs
-assertion_line: 238
 expression: render_workspace_template(&context).unwrap()
 ---
 # https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Require a specific version of moon while running commands, otherwise fail.
-# versionConstraint: '>=0.0.0'
+# versionConstraint: '>=1.0.0'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: './shared/workspace.yml'

--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_git_vcs.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_git_vcs.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/cli/src/commands/init/mod.rs
-assertion_line: 263
 expression: render_workspace_template(&context).unwrap()
 ---
 # https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Require a specific version of moon while running commands, otherwise fail.
-# versionConstraint: '>=0.0.0'
+# versionConstraint: '>=1.0.0'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: './shared/workspace.yml'

--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_glob_list.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_glob_list.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/cli/src/commands/init/mod.rs
-assertion_line: 246
 expression: render_workspace_template(&context).unwrap()
 ---
 # https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Require a specific version of moon while running commands, otherwise fail.
-# versionConstraint: '>=0.0.0'
+# versionConstraint: '>=1.0.0'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: './shared/workspace.yml'

--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_projects_map.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_projects_map.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/cli/src/commands/init/mod.rs
-assertion_line: 254
 expression: render_workspace_template(&context).unwrap()
 ---
 # https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Require a specific version of moon while running commands, otherwise fail.
-# versionConstraint: '>=0.0.0'
+# versionConstraint: '>=1.0.0'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: './shared/workspace.yml'

--- a/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_svn_vcs.snap
+++ b/crates/cli/src/commands/init/snapshots/moon_cli__commands__init__tests__renders_svn_vcs.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/cli/src/commands/init/mod.rs
-assertion_line: 272
 expression: render_workspace_template(&context).unwrap()
 ---
 # https://moonrepo.dev/docs/config/workspace
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Require a specific version of moon while running commands, otherwise fail.
-# versionConstraint: '>=0.0.0'
+# versionConstraint: '>=1.0.0'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: './shared/workspace.yml'

--- a/crates/cli/tests/init_test.rs
+++ b/crates/cli/tests/init_test.rs
@@ -7,11 +7,9 @@ fn creates_files_in_dest() {
     let sandbox = create_sandbox("init-sandbox");
     let root = sandbox.path().to_path_buf();
     let workspace_config = root.join(".moon").join(CONFIG_WORKSPACE_FILENAME);
-    let project_config = root.join(".moon").join(CONFIG_TASKS_FILENAME);
     let gitignore = root.join(".gitignore");
 
     assert!(!workspace_config.exists());
-    assert!(!project_config.exists());
     assert!(!gitignore.exists());
 
     let assert = sandbox.run_moon(|cmd| {
@@ -23,7 +21,6 @@ fn creates_files_in_dest() {
     ));
 
     assert!(workspace_config.exists());
-    assert!(project_config.exists());
     assert!(gitignore.exists());
 }
 
@@ -58,23 +55,23 @@ fn creates_workspace_config_from_template() {
     );
 }
 
-#[test]
-fn creates_project_config_from_template() {
-    let sandbox = create_sandbox("init-sandbox");
-    let root = sandbox.path().to_path_buf();
-    let project_config = root
-        .join(".moon")
-        .join(moon_constants::CONFIG_TASKS_FILENAME);
+// #[test]
+// fn creates_project_config_from_template() {
+//     let sandbox = create_sandbox("init-sandbox");
+//     let root = sandbox.path().to_path_buf();
+//     let project_config = root
+//         .join(".moon")
+//         .join(moon_constants::CONFIG_TASKS_FILENAME);
 
-    sandbox.run_moon(|cmd| {
-        cmd.arg("init").arg("--yes").arg(root);
-    });
+//     sandbox.run_moon(|cmd| {
+//         cmd.arg("init").arg("--yes").arg(root);
+//     });
 
-    assert!(
-        predicate::str::contains("https://moonrepo.dev/schemas/tasks.json")
-            .eval(&fs::read_to_string(project_config).unwrap())
-    );
-}
+//     assert!(
+//         predicate::str::contains("https://moonrepo.dev/schemas/tasks.json")
+//             .eval(&fs::read_to_string(project_config).unwrap())
+//     );
+// }
 
 #[test]
 fn creates_gitignore_file() {

--- a/crates/core/config/templates/project.yml
+++ b/crates/core/config/templates/project.yml
@@ -7,8 +7,7 @@ type: 'library'
 # Primary programming language the project is written in.
 language: 'typescript'
 
-# This setting defines metadata about the project itself. Although this
-# setting is optional, when defined, all fields within it must be defined as well.
+# This setting defines metadata about the project itself.
 project:
   # A human readable name of the project.
   name: 'Example'

--- a/crates/core/config/templates/tasks.yml
+++ b/crates/core/config/templates/tasks.yml
@@ -13,22 +13,14 @@ $schema: 'https://moonrepo.dev/schemas/tasks.json'
 # globs. Globs are relative to a project, even though they are defined globally. This enables
 # enforcement of organizational patterns across all projects in the workspace.
 fileGroups:
-  # List of configuration files located within the project root.
   configs:
     - '*.{js,json}'
-
-  # List of non-test source files.
   sources:
     - 'src/**/*'
     - 'types/**/*'
-
-  # List of non-source test files.
   tests:
     - 'tests/**/*.test.*'
     - '**/__tests__/**/*'
-
-  # All static assets within the project.
-  # This may include styles, images, videos, etc.
   assets:
     - 'assets/**/*'
     - 'images/**/*'
@@ -36,38 +28,13 @@ fileGroups:
     - '**/*.{scss,css}'
     - '**/*.mdx'
 
-# A task is an action that is ran within the context of a project, and wraps
-# around an npm or system command. Tasks that are defined here and inherited by all projects
-# within the workspace, but can be overridden per project.
+# A task is a command that is ran within the context of a project. Tasks that are
+# defined here and inherited by all projects within the workspace, but can be
+# overridden per project.
 #
 # This setting requires a map, where the key is a unique name for the task,
-# and the value is an object of task parameters.
-tasks:
-  # Name of the task.
-  noop:
-    # The name of the binary/command on your system.
-    command: 'noop'
-
-    # List of arguments to pass on the command line when executing the task.
-    args: []
-
-    # List of targets that will be executed *before* this task.
-    deps: []
-
-    # Map of environment variables to pass when executing the command.
-    env: {}
-
-    # List of file paths/globs to calculate whether to execute the task based on files
-    # that have been modified since the last time the task has been ran. By default inputs are
-    # relative from the *project root*, and can reference file groups (above). To reference files
-    # from the workspace root (for example, config files), prefix the path with a "/".
-    inputs: []
-
-    # List of files and folders that are created as a result of executing this task,
-    # excluding cache related items. By default outputs are relative from the *project root*.
-    # To output files to the workspace root, prefix the path with a "/".
-    outputs: []
-
-    # The platform to run the command on, and where to locate it.
-    # Accepts "node" or "system". Defaults based on project `language`.
-    platform: 'node'
+# and the value is an object of task parameters. Learn more about tasks and inheritance.
+#
+# - https://moonrepo.dev/docs/concepts/task
+# - https://moonrepo.dev/docs/config/tasks
+tasks: {}

--- a/crates/core/config/templates/toolchain_rust.yml
+++ b/crates/core/config/templates/toolchain_rust.yml
@@ -7,8 +7,11 @@ rust:
 
 # Configures Rust within the toolchain.
 rust:
-  # The toolchain to use. Must be a semantic version that includes major, minor, and patch.
+  # The Rust toolchain to use. Must be a semantic version that includes major, minor, and patch.
   version: '{{ rust_version }}'
+
+  # List of Cargo binaries to install globally and make available to tasks.
+  bins: []
 
   # Sync the configured version above as a channel to the root `rust-toolchain.toml` config.
   syncToolchainConfig: false

--- a/crates/core/config/templates/workspace.yml
+++ b/crates/core/config/templates/workspace.yml
@@ -2,7 +2,7 @@
 $schema: 'https://moonrepo.dev/schemas/workspace.json'
 
 # Require a specific version of moon while running commands, otherwise fail.
-# versionConstraint: '>=0.0.0'
+# versionConstraint: '>=1.0.0'
 
 # Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
 # extends: './shared/workspace.yml'

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -20,7 +20,7 @@
 #### ⚙️ Internal
 
 - Reworked `moon init --yes` to not enable all tools, and instead enable based on file detection.
-- Cleaned up `moon init` templates.
+- Cleaned up `moon init` templates. Will no longer scaffold `.moon/tasks.yml`.
 
 ## 1.4.0
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 #### ⚙️ Internal
 
 - Reworked `moon init --yes` to not enable all tools, and instead enable based on file detection.
+- Cleaned up `moon init` templates.
 
 ## 1.4.0
 

--- a/website/static/schemas/toolchain.json
+++ b/website/static/schemas/toolchain.json
@@ -210,6 +210,12 @@
     "RustConfig": {
       "type": "object",
       "properties": {
+        "cargoBins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "syncToolchainConfig": {
           "type": "boolean"
         },

--- a/website/static/schemas/toolchain.json
+++ b/website/static/schemas/toolchain.json
@@ -210,7 +210,7 @@
     "RustConfig": {
       "type": "object",
       "properties": {
-        "cargoBins": {
+        "bins": {
           "type": "array",
           "items": {
             "type": "string"


### PR DESCRIPTION
Some of these were too noisy, or had outdated info.