### PR TITLE
fix: Fix tasks running in CI when they shouldn't.

### DIFF
--- a/.yarn/versions/5135b648.yml
+++ b/.yarn/versions/5135b648.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/cli/src/commands/task.rs
+++ b/crates/cli/src/commands/task.rs
@@ -68,7 +68,7 @@ pub async fn task(id: String, json: bool) -> Result<(), AnyError> {
             "Serially"
         },
     )?;
-    term.render_entry_bool("Runs in CI", task.options.run_in_ci)?;
+    term.render_entry_bool("Runs in CI", task.should_run_in_ci())?;
 
     if !task.deps.is_empty() {
         term.write_line("")?;

--- a/crates/core/task/src/task.rs
+++ b/crates/core/task/src/task.rs
@@ -338,7 +338,11 @@ impl Task {
     }
 
     pub fn should_run_in_ci(&self) -> bool {
-        self.is_build_type() || self.is_test_type() || self.options.run_in_ci
+        if !self.options.run_in_ci {
+            return false;
+        }
+
+        self.is_build_type() || self.is_test_type()
     }
 
     fn merge_env_vars(

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where tasks would run in CI even though `runInCI` was false.
+
 ## 1.5.0
 
 #### 🚀 Updates


### PR DESCRIPTION
Broke this when reworking the task type detection.