### PR TITLE
fix: Update platform detection to infer based on toolchain settings.

### DIFF
--- a/crates/core/platform-detector/src/task_platform.rs
+++ b/crates/core/platform-detector/src/task_platform.rs
@@ -1,4 +1,4 @@
-use moon_config::{PlatformType, ProjectLanguage};
+use moon_config::{PlatformType, ProjectLanguage, ToolchainConfig};
 use moon_utils::regex::{self, UNIX_SYSTEM_COMMAND, WINDOWS_SYSTEM_COMMAND};
 use once_cell::sync::Lazy;
 
@@ -11,16 +11,20 @@ static NODE_COMMANDS: Lazy<regex::Regex> = Lazy::new(|| {
     regex::create_regex("^(node|nodejs|npm|npx|yarn|yarnpkg|pnpm|pnpx|corepack)$").unwrap()
 });
 
-pub fn detect_task_platform(command: &str, language: &ProjectLanguage) -> PlatformType {
-    if DENO_COMMANDS.is_match(command) {
+pub fn detect_task_platform(
+    command: &str,
+    language: &ProjectLanguage,
+    toolchain_config: &ToolchainConfig,
+) -> PlatformType {
+    if toolchain_config.deno.is_some() && DENO_COMMANDS.is_match(command) {
         return PlatformType::Deno;
     }
 
-    if NODE_COMMANDS.is_match(command) {
+    if toolchain_config.node.is_some() && NODE_COMMANDS.is_match(command) {
         return PlatformType::Node;
     }
 
-    if RUST_COMMANDS.is_match(command) {
+    if toolchain_config.rust.is_some() && RUST_COMMANDS.is_match(command) {
         return PlatformType::Rust;
     }
 

--- a/crates/core/project-graph/src/project_builder.rs
+++ b/crates/core/project-graph/src/project_builder.rs
@@ -192,7 +192,11 @@ impl<'ws> ProjectGraphBuilder<'ws> {
             // Detect the platform if its unknown
             if task.platform.is_unknown() {
                 task.platform = if project_platform.is_unknown() {
-                    detect_task_platform(&task.command, &project.language)
+                    detect_task_platform(
+                        &task.command,
+                        &project.language,
+                        &self.workspace.toolchain_config,
+                    )
                 } else {
                     project_platform
                 };

--- a/crates/core/project-graph/tests/project_graph_test.rs
+++ b/crates/core/project-graph/tests/project_graph_test.rs
@@ -1,5 +1,5 @@
 use moon::{generate_project_graph, load_workspace_from};
-use moon_config::{WorkspaceConfig, WorkspaceProjects};
+use moon_config::{NodeConfig, RustConfig, ToolchainConfig, WorkspaceConfig, WorkspaceProjects};
 use moon_project::{Project, ProjectDependency, ProjectDependencySource};
 use moon_project_graph::ProjectGraph;
 use moon_test_utils::{
@@ -156,8 +156,18 @@ async fn get_queries_graph() -> (ProjectGraph, Sandbox) {
         ..WorkspaceConfig::default()
     };
 
-    let sandbox =
-        create_sandbox_with_config("project-graph/query", Some(workspace_config), None, None);
+    let toolchain_config = ToolchainConfig {
+        node: Some(NodeConfig::default()),
+        rust: Some(RustConfig::default()),
+        ..ToolchainConfig::default()
+    };
+
+    let sandbox = create_sandbox_with_config(
+        "project-graph/query",
+        Some(workspace_config),
+        Some(toolchain_config),
+        None,
+    );
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
     let graph = generate_project_graph(&mut workspace).await.unwrap();

--- a/crates/core/project-graph/tests/projects_test.rs
+++ b/crates/core/project-graph/tests/projects_test.rs
@@ -3,8 +3,8 @@
 
 use moon::{generate_project_graph, load_workspace_from};
 use moon_config::{
-    InheritedTasksConfig, PlatformType, TaskCommandArgs, TaskConfig, TaskOptionsConfig,
-    WorkspaceConfig, WorkspaceProjects,
+    InheritedTasksConfig, NodeConfig, PlatformType, RustConfig, TaskCommandArgs, TaskConfig,
+    TaskOptionsConfig, ToolchainConfig, WorkspaceConfig, WorkspaceProjects,
 };
 use moon_project::Project;
 use moon_project_graph::ProjectGraph;
@@ -336,6 +336,11 @@ tasks:
                 ..WorkspaceConfig::default()
             };
 
+            let toolchain_config = ToolchainConfig {
+                node: Some(NodeConfig::default()),
+                ..ToolchainConfig::default()
+            };
+
             let tasks_config = InheritedTasksConfig {
                 tasks: BTreeMap::from_iter([
                     (
@@ -372,7 +377,7 @@ tasks:
             let sandbox = create_sandbox_with_config(
                 "task-inheritance",
                 Some(workspace_config),
-                None,
+                Some(toolchain_config),
                 Some(tasks_config),
             );
 
@@ -1419,6 +1424,12 @@ mod detection {
             ..WorkspaceConfig::default()
         };
 
+        let toolchain_config = ToolchainConfig {
+            node: Some(NodeConfig::default()),
+            rust: Some(RustConfig::default()),
+            ..ToolchainConfig::default()
+        };
+
         let tasks_config = InheritedTasksConfig {
             tasks: BTreeMap::from_iter([(
                 "command".to_owned(),
@@ -1433,7 +1444,7 @@ mod detection {
         let sandbox = create_sandbox_with_config(
             "project-graph/langs",
             Some(workspace_config),
-            None,
+            Some(toolchain_config),
             Some(tasks_config),
         );
 

--- a/crates/core/runner/src/runner.rs
+++ b/crates/core/runner/src/runner.rs
@@ -83,7 +83,13 @@ impl<'a> Runner<'a> {
                 if !self.workspace.root.join(output).exists() {
                     return Err(RunnerError::Task(TaskError::MissingOutput(
                         self.task.target.id.clone(),
-                        path::to_string(output.strip_prefix(&self.project.source).unwrap())?,
+                        path::to_string(
+                            if let Ok(stripped) = output.strip_prefix(&self.project.source) {
+                                stripped
+                            } else {
+                                output
+                            },
+                        )?,
                     )));
                 }
             }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,10 +5,15 @@
 #### 🚀 Updates
 
 - Added support for persistent tasks.
-  - Added `persistent` task option to `moon.yml` (is set via `local`).
+  - Added `persistent` task option to `moon.yml` (is also set via `local`).
   - Persistent tasks _run last_ in the dependency graph.
 - Updated long running processes to log a checkpoint indicating it's still running.
+- Updated task `platform` detection to only use the platform if the toolchain language is enabled.
 - Started migrating to a newer logging implementation.
+
+#### 🐞 Fixes
+
+- Fixed an issue where a task would panic for missing outputs.
 
 #### ⚙️ Internal
 


### PR DESCRIPTION
When creating tasks, we attempt to detect the platform it should run in. For example, `cargo` commands should use the `rust` platform. This works perfectly, however... If the Rust platform has not been enabled in `.moon/toolchain.yml`, it triggers an error, an error that is confusing to consumers.

This updates detection to also check against the config.