### PR TITLE
docs: correct escape sequence in proto plugin example

### DIFF
--- a/website/docs/proto/plugins.mdx
+++ b/website/docs/proto/plugins.mdx
@@ -156,7 +156,7 @@ To resolve a list of available versions using Git tags, the following settings a
 
 [resolve]
 git-url = "https://github.com/moonrepo/protostar"
-git-tag-pattern = "^@protostar/cli@((\d+)\.(\d+)\.(\d+))"
+git-tag-pattern = "^@protostar/cli@((\\d+)\.(\\d+)\.(\\d+))"
 ```
 
 ###### JSON manifest


### PR DESCRIPTION
The proto plugin docs have an example that reads:

```toml
[resolve]
git-url = "https://github.com/moonrepo/protostar"
git-tag-pattern = "^@protostar/cli@((\d+)\.(\d+)\.(\d+))"
```

But lint and proto cli complains:

```shell
  × Failed to parse TOML file ~/Projects/skipa/www.skipa.io/./proto-dprint.toml
  ╰─▶ TOML parse error at line 26, column 37
         |
      26 | git-tag-pattern = "^@dprint/cli@((\d+)\.(\d+)\.(\d+)"
         |                                     ^
      invalid escape sequence
      expected `b`, `f`, `n`, `r`, `t`, `u`, `U`, `\`, `"`      
```

This minor change escapes the digits with `\\d`
