### PR TITLE
deps: Upgrade to Rust v1.70.

### DIFF
--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -1,7 +1,7 @@
 $schema: '../website/static/schemas/toolchain.json'
 
 rust:
-  version: '1.69.0'
+  version: '1.70.0'
   bins:
     - 'cargo-make'
     - 'cargo-nextest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,7 +2619,6 @@ dependencies = [
  "diff",
  "httpmock",
  "indicatif",
- "is-terminal",
  "itertools",
  "miette",
  "mimalloc",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -54,7 +54,6 @@ dialoguer = { version = "0.10.4", default-features = false }
 diff = "0.1.13"
 indicatif = "0.17.3"
 itertools = "0.10.5"
-is-terminal = "0.4.5"
 miette = { workspace = true }
 mimalloc = { version = "0.1.37", default-features = false }
 open = "4.1.0"

--- a/crates/cli/src/commands/init/rust.rs
+++ b/crates/cli/src/commands/init/rust.rs
@@ -19,7 +19,7 @@ fn detect_rust_version(dest_dir: &Path) -> AppResult<String> {
         }
     }
 
-    Ok("1.69.0".into())
+    Ok("1.70.0".into())
 }
 
 pub async fn init_rust(

--- a/crates/cli/src/commands/query.rs
+++ b/crates/cli/src/commands/query.rs
@@ -7,14 +7,13 @@ pub use crate::queries::touched_files::{
     query_touched_files, QueryTouchedFilesOptions, QueryTouchedFilesResult,
 };
 use console::Term;
-use is_terminal::IsTerminal;
 use miette::IntoDiagnostic;
 use moon::load_workspace;
 use moon_terminal::ExtendedTerm;
 use rustc_hash::FxHashMap;
 use starbase::AppResult;
 use starbase_styles::color;
-use std::io;
+use std::io::{self, IsTerminal};
 
 pub async fn hash(hash: &str, json: bool) -> AppResult {
     let workspace = load_workspace().await?;

--- a/crates/cli/src/queries/projects.rs
+++ b/crates/cli/src/queries/projects.rs
@@ -1,7 +1,6 @@
 use crate::queries::touched_files::{
     query_touched_files, QueryTouchedFilesOptions, QueryTouchedFilesResult,
 };
-use is_terminal::IsTerminal;
 use moon::generate_project_graph;
 use moon_common::Id;
 use moon_error::MoonError;
@@ -15,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use starbase::AppResult;
 use std::{
     collections::BTreeMap,
-    io::{stdin, Read},
+    io::{stdin, IsTerminal, Read},
     path::PathBuf,
 };
 

--- a/crates/core/action-pipeline/src/pipeline.rs
+++ b/crates/core/action-pipeline/src/pipeline.rs
@@ -208,7 +208,7 @@ impl Pipeline {
 
         let duration = start.elapsed();
         let estimate = Estimator::calculate(&results, duration);
-        let context = Arc::try_unwrap(context).unwrap().into_inner();
+        let context = Arc::into_inner(context).unwrap().into_inner();
 
         debug!(
             target: LOG_TARGET,

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### ⚙️ Internal
+
+- Updated Rust to v1.70.
+
 ## 1.7.1
 
 #### 🐞 Fixes

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-channel = "1.69.0"
+channel = "1.70.0"


### PR DESCRIPTION
https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html

Not much for us to change.