### PR TITLE
fix: Fix Cargo running in the wrong directory.

### DIFF
--- a/.yarn/versions/fdaa96bc.yml
+++ b/.yarn/versions/fdaa96bc.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/rust/platform/src/rust_platform.rs
+++ b/crates/rust/platform/src/rust_platform.rs
@@ -89,8 +89,8 @@ impl Platform for RustPlatform {
     // PROJECT GRAPH
 
     fn is_project_in_dependency_workspace(&self, _project: &Project) -> Result<bool, MoonError> {
-        // Always assume Cargo is running from the root
-        Ok(true)
+        // moon requires a Rust project to be the root of the Cargo workspace
+        Ok(false)
     }
 
     fn load_project_graph_aliases(

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Rust
+  - Fixed an issue where `cargo generate-lockfile` would run in the wrong directory.
+
 ## 1.7.1
 
 #### 🐞 Fixes


### PR DESCRIPTION
moon requires a Rust project to be the root of a Cargo workspace, but this platform method was causing it to be anywhere, resulting in the wrong working directory.