### PR TITLE
internal: Use `relative-path` for inputs/outputs/touched/etc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4885,13 +4885,14 @@ dependencies = [
 
 [[package]]
 name = "starbase_styles"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992a899124f44d47b1ee874f23585f9e51168f5ebacbd83190d13387caea20c6"
+checksum = "e66e1f18071d2faae1009fc03ef94c932e1a0e4e126195609dada0779a67b04a"
 dependencies = [
  "dirs",
  "miette",
  "owo-colors",
+ "relative-path",
  "supports-color",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,6 +2505,7 @@ name = "moon_action_context"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "moon_common",
  "moon_target",
  "rustc-hash",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 serde_yaml = "0.9.21"
 starbase_sandbox = "0.1.3"
-starbase_styles = "0.1.8"
+starbase_styles = { version = "0.1.9", features = ["relative-path"] }
 starbase_utils = { version = "0.2.10", default-features = false, features = ["editor-config", "glob", "json", "toml", "yaml"] }
 thiserror = "1.0.40"
 tokio = { version = "1.28.2", default-features = false, features = ["tracing"] }

--- a/crates/cli/src/commands/query.rs
+++ b/crates/cli/src/commands/query.rs
@@ -130,7 +130,7 @@ pub async fn touched_files(options: &mut QueryTouchedFilesOptions) -> AppResult 
         term.line(
             files
                 .iter()
-                .map(|f| f.to_string_lossy())
+                .map(|f| f.to_string())
                 .collect::<Vec<_>>()
                 .join("\n"),
         )?;

--- a/crates/cli/src/commands/task.rs
+++ b/crates/cli/src/commands/task.rs
@@ -78,8 +78,18 @@ pub async fn task(target: Target, json: bool) -> AppResult {
     if !task.input_paths.is_empty() || !task.input_globs.is_empty() {
         term.line("")?;
         term.render_label(Label::Default, "Inputs")?;
-        term.render_list(task.input_globs.iter().map(color::file).collect::<Vec<_>>())?;
-        term.render_list(task.input_paths.iter().map(color::path).collect::<Vec<_>>())?;
+        term.render_list(
+            task.input_globs
+                .iter()
+                .map(color::rel_path)
+                .collect::<Vec<_>>(),
+        )?;
+        term.render_list(
+            task.input_paths
+                .iter()
+                .map(color::rel_path)
+                .collect::<Vec<_>>(),
+        )?;
     }
 
     if !task.output_paths.is_empty() || !task.output_globs.is_empty() {
@@ -88,13 +98,13 @@ pub async fn task(target: Target, json: bool) -> AppResult {
         term.render_list(
             task.output_globs
                 .iter()
-                .map(color::file)
+                .map(color::rel_path)
                 .collect::<Vec<_>>(),
         )?;
         term.render_list(
             task.output_paths
                 .iter()
-                .map(color::path)
+                .map(color::rel_path)
                 .collect::<Vec<_>>(),
         )?;
     }

--- a/crates/cli/src/queries/projects.rs
+++ b/crates/cli/src/queries/projects.rs
@@ -2,7 +2,7 @@ use crate::queries::touched_files::{
     query_touched_files, QueryTouchedFilesOptions, QueryTouchedFilesResult,
 };
 use moon::generate_project_graph;
-use moon_common::Id;
+use moon_common::{path::WorkspaceRelativePathBuf, Id};
 use moon_error::MoonError;
 use moon_logger::{debug, trace};
 use moon_project::Project;
@@ -15,7 +15,6 @@ use starbase::AppResult;
 use std::{
     collections::BTreeMap,
     io::{stdin, IsTerminal, Read},
-    path::PathBuf,
 };
 
 const LOG_TARGET: &str = "moon:query:projects";
@@ -83,7 +82,8 @@ async fn load_touched_files(workspace: &Workspace) -> AppResult<TouchedFilePaths
 
             // As lines
         } else {
-            let files = FxHashSet::from_iter(buffer.split('\n').map(PathBuf::from));
+            let files =
+                FxHashSet::from_iter(buffer.split('\n').map(WorkspaceRelativePathBuf::from));
 
             return Ok(files);
         }

--- a/crates/cli/src/queries/touched_files.rs
+++ b/crates/cli/src/queries/touched_files.rs
@@ -1,13 +1,12 @@
 use crate::enums::TouchedStatus;
+use moon_common::path::{standardize_separators, WorkspaceRelativePathBuf};
 use moon_logger::{debug, map_list, trace};
 use moon_task::TouchedFilePaths;
-use moon_utils::path;
 use moon_workspace::Workspace;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use starbase::AppResult;
 use starbase_styles::color;
-use std::path::PathBuf;
 
 const LOG_TARGET: &str = "moon:query:touched-files";
 
@@ -110,14 +109,14 @@ pub async fn query_touched_files(
         }
     }
 
-    let touched_files: FxHashSet<PathBuf> = touched_files
+    let touched_files: FxHashSet<WorkspaceRelativePathBuf> = touched_files
         .iter()
         .map(|f| {
             if options.log {
                 touched_files_to_log.push(format!("  {}", color::file(f)));
             }
 
-            PathBuf::from(path::normalize_separators(f))
+            WorkspaceRelativePathBuf::from(standardize_separators(f))
         })
         .collect();
 

--- a/crates/core/action-context/Cargo.toml
+++ b/crates/core/action-context/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+moon_common = { path = "../../../nextgen/common" }
 moon_target = { path = "../../../nextgen/target" }
 clap = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/core/action-context/src/lib.rs
+++ b/crates/core/action-context/src/lib.rs
@@ -1,4 +1,5 @@
 use clap::ValueEnum;
+use moon_common::path::WorkspaceRelativePathBuf;
 use moon_target::Target;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
@@ -27,7 +28,7 @@ pub struct ActionContext {
 
     pub target_hashes: FxHashMap<Target, String>,
 
-    pub touched_files: FxHashSet<PathBuf>,
+    pub touched_files: FxHashSet<WorkspaceRelativePathBuf>,
 
     pub workspace_root: PathBuf,
 }

--- a/crates/core/action-pipeline/src/actions/install_deps.rs
+++ b/crates/core/action-pipeline/src/actions/install_deps.rs
@@ -118,9 +118,13 @@ pub async fn install_deps(
     // When running in the workspace root, account for nested manifests
     if project.is_none() {
         for touched_file in &context.touched_files {
-            if touched_file.ends_with(&manifest) && touched_file != &manifest_path {
+            if touched_file.ends_with(&manifest) {
                 platform
-                    .hash_manifest_deps(touched_file, &mut hashset, &workspace.config.hasher)
+                    .hash_manifest_deps(
+                        &touched_file.to_path(""),
+                        &mut hashset,
+                        &workspace.config.hasher,
+                    )
                     .await?;
             }
         }

--- a/crates/core/action-pipeline/src/subscribers/moonbase.rs
+++ b/crates/core/action-pipeline/src/subscribers/moonbase.rs
@@ -166,7 +166,7 @@ impl Subscriber for MoonbaseSubscriber {
                     let touched_files = context
                         .touched_files
                         .iter()
-                        .map(|f| f.to_string_lossy().to_string())
+                        .map(|f| f.to_string())
                         .collect::<Vec<_>>();
 
                     let response = match graphql::post_mutation::<create_run::ResponseData>(

--- a/crates/core/dep-graph/tests/dep_graph_test.rs
+++ b/crates/core/dep-graph/tests/dep_graph_test.rs
@@ -1,4 +1,5 @@
 use moon::{build_dep_graph, generate_project_graph, load_workspace_from};
+use moon_common::path::WorkspaceRelativePathBuf;
 use moon_config::{
     PartialInheritedTasksConfig, PartialNodeConfig, PartialToolchainConfig, PartialWorkspaceConfig,
     WorkspaceProjects,
@@ -10,7 +11,6 @@ use moon_test_utils::{assert_snapshot, create_input_paths, create_sandbox_with_c
 use moon_workspace::Workspace;
 use petgraph::graph::NodeIndex;
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::path::PathBuf;
 
 async fn create_project_graph() -> (Workspace, ProjectGraph, Sandbox) {
     let workspace_config = PartialWorkspaceConfig {
@@ -436,8 +436,8 @@ mod run_target_if_touched {
         let (workspace, projects, _sandbox) = create_tasks_project_graph().await;
 
         let mut touched_files = FxHashSet::default();
-        touched_files.insert(PathBuf::from("input-a/a.ts"));
-        touched_files.insert(PathBuf::from("input-c/c.ts"));
+        touched_files.insert(WorkspaceRelativePathBuf::from("input-a/a.ts"));
+        touched_files.insert(WorkspaceRelativePathBuf::from("input-c/c.ts"));
 
         let mut graph = build_dep_graph(&workspace, &projects);
         graph
@@ -456,9 +456,9 @@ mod run_target_if_touched {
         let (workspace, projects, _sandbox) = create_tasks_project_graph().await;
 
         let mut touched_files = FxHashSet::default();
-        touched_files.insert(PathBuf::from("input-a/a2.ts"));
-        touched_files.insert(PathBuf::from("input-b/b2.ts"));
-        touched_files.insert(PathBuf::from("input-c/any.ts"));
+        touched_files.insert(WorkspaceRelativePathBuf::from("input-a/a2.ts"));
+        touched_files.insert(WorkspaceRelativePathBuf::from("input-b/b2.ts"));
+        touched_files.insert(WorkspaceRelativePathBuf::from("input-c/any.ts"));
 
         let mut graph = build_dep_graph(&workspace, &projects);
         graph

--- a/crates/core/project-graph/src/token_resolver.rs
+++ b/crates/core/project-graph/src/token_resolver.rs
@@ -186,7 +186,7 @@ impl<'task> TokenResolver<'task> {
 
             // This is a special case for inputs that converts "foo" to "foo/**/*",
             // when the input is a directory. This is necessary for VCS hashing.
-            if self.workspace_root.join(resolved.as_str()).is_dir() {
+            if resolved.to_path(self.workspace_root).is_dir() {
                 is_glob = true;
                 resolved = resolved.join("**/*");
             }

--- a/crates/core/runner/src/inputs_collector.rs
+++ b/crates/core/runner/src/inputs_collector.rs
@@ -1,6 +1,8 @@
 use crate::RunnerError;
-use moon_common::consts::CONFIG_PROJECT_FILENAME;
-use moon_common::path::WorkspaceRelativePathBuf;
+use moon_common::{
+    consts::CONFIG_PROJECT_FILENAME,
+    path::{standardize_separators, WorkspaceRelativePathBuf},
+};
 use moon_config::{HasherConfig, HasherWalkStrategy};
 use moon_logger::{warn, Logable};
 use moon_task::Task;
@@ -54,7 +56,7 @@ fn convert_paths_to_strings(
             continue;
         }
 
-        files.push(path::to_string(rel_path)?);
+        files.push(standardize_separators(path::to_string(rel_path)?));
     }
 
     Ok(files)

--- a/crates/core/runner/src/inputs_collector.rs
+++ b/crates/core/runner/src/inputs_collector.rs
@@ -1,5 +1,6 @@
 use crate::RunnerError;
 use moon_common::consts::CONFIG_PROJECT_FILENAME;
+use moon_common::path::WorkspaceRelativePathBuf;
 use moon_config::{HasherConfig, HasherWalkStrategy};
 use moon_logger::{warn, Logable};
 use moon_task::Task;
@@ -75,7 +76,7 @@ fn is_valid_input_source(
         return false;
     }
 
-    let workspace_relative_path = PathBuf::from(workspace_relative_input);
+    let workspace_relative_path = WorkspaceRelativePathBuf::from(workspace_relative_input);
 
     for output in &task.output_paths {
         if &workspace_relative_path == output || workspace_relative_path.starts_with(output) {
@@ -106,7 +107,7 @@ pub async fn collect_and_hash_inputs(
 
     if !task.input_paths.is_empty() {
         for input in &task.input_paths {
-            files_to_hash.insert(workspace_root.join(input));
+            files_to_hash.insert(input.to_path(workspace_root));
         }
     }
 

--- a/crates/core/runner/src/runner.rs
+++ b/crates/core/runner/src/runner.rs
@@ -80,7 +80,7 @@ impl<'a> Runner<'a> {
         // We don't check globs here as it would required walking the file system
         if !self.task.outputs.is_empty() {
             for output in &self.task.output_paths {
-                if !self.workspace.root.join(output).exists() {
+                if !output.to_path(self.workspace.root).exists() {
                     return Err(RunnerError::Task(TaskError::MissingOutput(
                         self.task.target.id.clone(),
                         path::to_string(
@@ -448,7 +448,7 @@ impl<'a> Runner<'a> {
             .task
             .output_paths
             .iter()
-            .all(|p| self.workspace.root.join(p).exists());
+            .all(|p| p.to_path(&self.workspace.root).exists());
 
         if self.cache.hash == hash && has_outputs {
             debug!(

--- a/crates/core/runner/src/runner.rs
+++ b/crates/core/runner/src/runner.rs
@@ -80,15 +80,16 @@ impl<'a> Runner<'a> {
         // We don't check globs here as it would required walking the file system
         if !self.task.outputs.is_empty() {
             for output in &self.task.output_paths {
-                if !output.to_path(self.workspace.root).exists() {
+                if !output.to_path(&self.workspace.root).exists() {
                     return Err(RunnerError::Task(TaskError::MissingOutput(
                         self.task.target.id.clone(),
                         path::to_string(
-                            if let Ok(stripped) = output.strip_prefix(&self.project.source) {
+                            (if let Ok(stripped) = output.strip_prefix(&self.project.source) {
                                 stripped
                             } else {
                                 output
-                            },
+                            })
+                            .to_path(""),
                         )?,
                     )));
                 }

--- a/crates/core/task/src/task.rs
+++ b/crates/core/task/src/task.rs
@@ -2,7 +2,7 @@ use crate::errors::TaskError;
 use crate::task_options::TaskOptions;
 use crate::types::TouchedFilePaths;
 use moon_args::{split_args, ArgsSplitError};
-use moon_common::{cacheable, cacheable_enum, Id};
+use moon_common::{cacheable, cacheable_enum, path::WorkspaceRelativePathBuf, Id};
 use moon_config::{
     InputPath, OutputPath, PlatformType, TaskCommandArgs, TaskConfig, TaskMergeStrategy, TaskType,
 };
@@ -43,11 +43,9 @@ cacheable!(
 
         pub inputs: Vec<InputPath>,
 
-        // Relative from workspace root
-        pub input_globs: FxHashSet<String>,
+        pub input_globs: FxHashSet<WorkspaceRelativePathBuf>,
 
-        // Relative from workspace root
-        pub input_paths: FxHashSet<PathBuf>,
+        pub input_paths: FxHashSet<WorkspaceRelativePathBuf>,
 
         pub input_vars: FxHashSet<String>,
 
@@ -58,11 +56,9 @@ cacheable!(
 
         pub outputs: Vec<OutputPath>,
 
-        // Relative from workspace root
-        pub output_globs: FxHashSet<String>,
+        pub output_globs: FxHashSet<WorkspaceRelativePathBuf>,
 
-        // Relative from workspace root
-        pub output_paths: FxHashSet<PathBuf>,
+        pub output_paths: FxHashSet<WorkspaceRelativePathBuf>,
 
         pub platform: PlatformType,
 
@@ -199,9 +195,9 @@ impl Task {
                 continue;
             }
 
-            if self.input_paths.contains(file) || globset.matches(file) {
+            if self.input_paths.contains(file) || globset.matches(file.as_str()) {
                 // Mimic relative from ("./")
-                files.push(PathBuf::from(".").join(file.strip_prefix(project_source).unwrap()));
+                files.push(file.strip_prefix(project_source).unwrap().to_path("."));
             }
         }
 
@@ -237,17 +233,17 @@ impl Task {
                 trace!(
                     target: self.get_log_target(),
                     "Affected by {} (via input files)",
-                    color::path(file),
+                    "", // color::path(file), TODO
                 );
 
                 return Ok(true);
             }
 
-            if globset.matches(file) {
+            if globset.matches(file.as_str()) {
                 trace!(
                     target: self.get_log_target(),
                     "Affected by {} (via input globs)",
-                    color::path(file),
+                    "", // color::path(file), TODO
                 );
 
                 return Ok(true);

--- a/crates/core/task/src/task.rs
+++ b/crates/core/task/src/task.rs
@@ -233,7 +233,7 @@ impl Task {
                 trace!(
                     target: self.get_log_target(),
                     "Affected by {} (via input files)",
-                    "", // color::path(file), TODO
+                    color::rel_path(file),
                 );
 
                 return Ok(true);
@@ -243,7 +243,7 @@ impl Task {
                 trace!(
                     target: self.get_log_target(),
                     "Affected by {} (via input globs)",
-                    "", // color::path(file), TODO
+                    color::rel_path(file),
                 );
 
                 return Ok(true);

--- a/crates/core/task/src/types.rs
+++ b/crates/core/task/src/types.rs
@@ -1,4 +1,4 @@
+use moon_common::path::WorkspaceRelativePathBuf;
 use rustc_hash::FxHashSet;
-use std::path::PathBuf;
 
-pub type TouchedFilePaths = FxHashSet<PathBuf>;
+pub type TouchedFilePaths = FxHashSet<WorkspaceRelativePathBuf>;

--- a/crates/core/task/tests/task_test.rs
+++ b/crates/core/task/tests/task_test.rs
@@ -1,3 +1,4 @@
+use moon_common::path::WorkspaceRelativePathBuf;
 use moon_config::{
     FilePath, InputPath, TaskCommandArgs, TaskConfig, TaskMergeStrategy, TaskOptionEnvFile,
     TaskOptionsConfig, TaskOutputStyle,
@@ -8,7 +9,6 @@ use moon_test_utils::create_sandbox;
 use moon_utils::string_vec;
 use rustc_hash::FxHashSet;
 use std::env;
-use std::path::PathBuf;
 use std::str::FromStr;
 
 pub fn create_task(config: TaskConfig) -> Task {
@@ -602,7 +602,7 @@ mod is_affected {
 
     #[test]
     fn returns_true_if_matches_file() {
-        let project_source = PathBuf::from("files-and-dirs");
+        let project_source = WorkspaceRelativePathBuf::from("files-and-dirs");
         let mut task = create_task(TaskConfig {
             inputs: Some(vec![InputPath::from_str("file.ts").unwrap()]),
             ..TaskConfig::default()
@@ -618,7 +618,7 @@ mod is_affected {
 
     #[test]
     fn returns_true_if_matches_glob() {
-        let project_source = PathBuf::from("files-and-dirs");
+        let project_source = WorkspaceRelativePathBuf::from("files-and-dirs");
         let mut task = create_task(TaskConfig {
             inputs: Some(vec![InputPath::from_str("file.*").unwrap()]),
             ..TaskConfig::default()
@@ -639,17 +639,18 @@ mod is_affected {
             ..TaskConfig::default()
         });
 
-        task.input_paths.insert(PathBuf::from("package.json"));
+        task.input_paths
+            .insert(WorkspaceRelativePathBuf::from("package.json"));
 
         let mut set = FxHashSet::default();
-        set.insert(PathBuf::from("package.json"));
+        set.insert(WorkspaceRelativePathBuf::from("package.json"));
 
         assert!(task.is_affected(&set).unwrap());
     }
 
     #[test]
     fn returns_false_if_outside_project() {
-        let project_source = PathBuf::from("files-and-dirs");
+        let project_source = WorkspaceRelativePathBuf::from("files-and-dirs");
         let mut task = create_task(TaskConfig {
             inputs: Some(vec![InputPath::from_str("file.ts").unwrap()]),
             ..TaskConfig::default()
@@ -658,14 +659,14 @@ mod is_affected {
         task.input_paths.insert(project_source.join("file.ts"));
 
         let mut set = FxHashSet::default();
-        set.insert(PathBuf::from("base/other/outside.ts"));
+        set.insert(WorkspaceRelativePathBuf::from("base/other/outside.ts"));
 
         assert!(!task.is_affected(&set).unwrap());
     }
 
     #[test]
     fn returns_false_if_no_match() {
-        let project_source = PathBuf::from("files-and-dirs");
+        let project_source = WorkspaceRelativePathBuf::from("files-and-dirs");
         let mut task = create_task(TaskConfig {
             inputs: Some(vec![
                 InputPath::from_str("file.ts").unwrap(),
@@ -688,7 +689,7 @@ mod is_affected {
         let sandbox = create_sandbox("base");
         sandbox.create_file("files-and-dirs/.env", "");
 
-        let project_source = PathBuf::from("files-and-dirs");
+        let project_source = WorkspaceRelativePathBuf::from("files-and-dirs");
         let mut task = create_task(TaskConfig {
             options: TaskOptionsConfig {
                 env_file: Some(TaskOptionEnvFile::Enabled(true)),


### PR DESCRIPTION
This crate (https://crates.io/crates/relative-path) solves a bunch of our portability problems.