### PR TITLE
new: Add `owners` setting to `moon.yml`.

### DIFF
--- a/.yarn/versions/b8f025bc.yml
+++ b/.yarn/versions/b8f025bc.yml
@@ -1,9 +1,15 @@
 releases:
-  "@moonrepo/cli": minor
-  "@moonrepo/core-linux-arm64-gnu": minor
-  "@moonrepo/core-linux-arm64-musl": minor
-  "@moonrepo/core-linux-x64-gnu": minor
-  "@moonrepo/core-linux-x64-musl": minor
-  "@moonrepo/core-macos-arm64": minor
-  "@moonrepo/core-macos-x64": minor
-  "@moonrepo/core-windows-x64-msvc": minor
+  '@moonrepo/cli': minor
+  '@moonrepo/core-linux-arm64-gnu': minor
+  '@moonrepo/core-linux-arm64-musl': minor
+  '@moonrepo/core-linux-x64-gnu': minor
+  '@moonrepo/core-linux-x64-musl': minor
+  '@moonrepo/core-macos-arm64': minor
+  '@moonrepo/core-macos-x64': minor
+  '@moonrepo/core-windows-x64-msvc': minor
+  '@moonrepo/report': patch
+  '@moonrepo/types': minor
+
+declined:
+  - '@moonrepo/runtime'
+  - website

--- a/nextgen/config/src/project/mod.rs
+++ b/nextgen/config/src/project/mod.rs
@@ -1,9 +1,11 @@
 mod dep_config;
 mod overrides_config;
+mod owners_config;
 mod task_config;
 mod task_options_config;
 
 pub use dep_config::*;
 pub use overrides_config::*;
+pub use owners_config::*;
 pub use task_config::*;
 pub use task_options_config::*;

--- a/nextgen/config/src/project/owners_config.rs
+++ b/nextgen/config/src/project/owners_config.rs
@@ -1,6 +1,6 @@
 use moon_common::cacheable;
 use rustc_hash::FxHashMap;
-use schematic::{derive_enum, Config, ValidateError};
+use schematic::{derive_enum, Config, Segment, ValidateError};
 
 derive_enum!(
     #[serde(
@@ -19,9 +19,37 @@ impl Default for OwnersPaths {
     }
 }
 
-fn validate_required_approvals<D, C>(
+fn validate_paths<C>(
+    value: &OwnersPaths,
+    data: &PartialOwnersConfig,
+    _context: &C,
+) -> Result<(), ValidateError> {
+    match value {
+        OwnersPaths::List(list) => {
+            if !list.is_empty() && data.default_owner.is_none() {
+                return Err(ValidateError::new(
+                    "a default owner is required when defining a list of paths",
+                ));
+            }
+        }
+        OwnersPaths::Map(map) => {
+            for (key, value) in map {
+                if value.is_empty() && data.default_owner.is_none() {
+                    return Err(ValidateError::with_segment(
+                        "a default owner is required when defining an empty list of owners",
+                        Segment::Key(key.to_owned()),
+                    ));
+                }
+            }
+        }
+    };
+
+    Ok(())
+}
+
+fn validate_required_approvals<C>(
     value: &u8,
-    _data: &D,
+    _data: &PartialOwnersConfig,
     _context: &C,
 ) -> Result<(), ValidateError> {
     if *value <= 0 {
@@ -42,6 +70,7 @@ cacheable!(
         // GitLab
         pub optional: bool,
 
+        #[setting(validate = validate_paths)]
         pub paths: OwnersPaths,
 
         // GitLab

--- a/nextgen/config/src/project/owners_config.rs
+++ b/nextgen/config/src/project/owners_config.rs
@@ -52,7 +52,7 @@ fn validate_required_approvals<C>(
     _data: &PartialOwnersConfig,
     _context: &C,
 ) -> Result<(), ValidateError> {
-    if *value <= 0 {
+    if *value == 0 {
         return Err(ValidateError::new("at least 1 approver is required"));
     }
 

--- a/nextgen/config/src/project/owners_config.rs
+++ b/nextgen/config/src/project/owners_config.rs
@@ -1,0 +1,51 @@
+use moon_common::cacheable;
+use rustc_hash::FxHashMap;
+use schematic::{derive_enum, Config, ValidateError};
+
+derive_enum!(
+    #[serde(
+        untagged,
+        expecting = "expected a list of paths, or a map of paths to owners"
+    )]
+    pub enum OwnersPaths {
+        List(Vec<String>),
+        Map(FxHashMap<String, Vec<String>>),
+    }
+);
+
+impl Default for OwnersPaths {
+    fn default() -> Self {
+        OwnersPaths::List(Vec::new())
+    }
+}
+
+fn validate_required_approvals<D, C>(
+    value: &u8,
+    _data: &D,
+    _context: &C,
+) -> Result<(), ValidateError> {
+    if *value <= 0 {
+        return Err(ValidateError::new("at least 1 approver is required"));
+    }
+
+    Ok(())
+}
+
+cacheable!(
+    #[derive(Clone, Config, Debug)]
+    pub struct OwnersConfig {
+        // Bitbucket
+        pub custom_groups: FxHashMap<String, Vec<String>>,
+
+        pub default_owner: Option<String>,
+
+        // GitLab
+        pub optional: bool,
+
+        pub paths: OwnersPaths,
+
+        // GitLab
+        #[setting(default = 1, validate = validate_required_approvals)]
+        pub required_approvals: u8,
+    }
+);

--- a/nextgen/config/src/project_config.rs
+++ b/nextgen/config/src/project_config.rs
@@ -77,6 +77,9 @@ cacheable!(
 
         pub language: LanguageType,
 
+        #[setting(nested)]
+        pub owners: OwnersConfig,
+
         pub platform: Option<PlatformType>,
 
         #[setting(nested)]

--- a/nextgen/config/tests/project_config_test.rs
+++ b/nextgen/config/tests/project_config_test.rs
@@ -2,8 +2,8 @@ mod utils;
 
 use moon_common::{consts::CONFIG_PROJECT_FILENAME, Id};
 use moon_config::{
-    DependencyScope, InputPath, LanguageType, PlatformType, ProjectConfig, ProjectDependsOn,
-    ProjectType, TaskCommandArgs,
+    DependencyScope, InputPath, LanguageType, OwnersPaths, PlatformType, ProjectConfig,
+    ProjectDependsOn, ProjectType, TaskCommandArgs,
 };
 use rustc_hash::FxHashMap;
 use utils::*;
@@ -13,7 +13,7 @@ mod project_config {
 
     #[test]
     #[should_panic(
-        expected = "unknown field `unknown`, expected one of `$schema`, `dependsOn`, `env`, `fileGroups`, `language`, `platform`, `project`, `tags`, `tasks`, `toolchain`, `type`, `workspace`"
+        expected = "unknown field `unknown`, expected one of `$schema`, `dependsOn`, `env`, `fileGroups`, `language`, `owners`, `platform`, `project`, `tags`, `tasks`, `toolchain`, `type`, `workspace`"
     )]
     fn error_unknown_field() {
         test_load_config(CONFIG_PROJECT_FILENAME, "unknown: 123", |path| {
@@ -285,17 +285,147 @@ fileGroups:
         }
     }
 
+    mod owners {
+        use super::*;
+
+        #[test]
+        fn loads_defaults() {
+            let config = test_load_config(CONFIG_PROJECT_FILENAME, "owners: {}", |path| {
+                ProjectConfig::load_from(path, ".")
+            });
+
+            assert_eq!(config.owners.custom_groups, FxHashMap::default());
+            assert_eq!(config.owners.default_owner, None);
+            assert!(!config.owners.optional);
+            assert_eq!(config.owners.paths, OwnersPaths::List(vec![]));
+            assert_eq!(config.owners.required_approvals, 1);
+        }
+
+        #[test]
+        fn can_set_values() {
+            let config = test_load_config(
+                CONFIG_PROJECT_FILENAME,
+                r"
+owners:
+  customGroups:
+    foo: [a, b, c]
+    bar: [x, y, z]
+  defaultOwner: x
+  optional: true
+  requiredApprovals: 2
+",
+                |path| ProjectConfig::load_from(path, "."),
+            );
+
+            assert_eq!(
+                config.owners.custom_groups,
+                FxHashMap::from_iter([
+                    ("foo".into(), vec!["a".into(), "b".into(), "c".into()]),
+                    ("bar".into(), vec!["x".into(), "y".into(), "z".into()]),
+                ])
+            );
+            assert_eq!(config.owners.default_owner, Some("x".to_string()));
+            assert!(config.owners.optional);
+            assert_eq!(config.owners.required_approvals, 2);
+        }
+
+        #[test]
+        fn can_set_paths_as_list() {
+            let config = test_load_config(
+                CONFIG_PROJECT_FILENAME,
+                r"
+owners:
+  defaultOwner: x
+  paths:
+    - file.txt
+    - dir/**/*
+",
+                |path| ProjectConfig::load_from(path, "."),
+            );
+
+            assert_eq!(
+                config.owners.paths,
+                OwnersPaths::List(vec!["file.txt".into(), "dir/**/*".into()])
+            );
+        }
+
+        #[test]
+        fn can_set_paths_as_map() {
+            let config = test_load_config(
+                CONFIG_PROJECT_FILENAME,
+                r"
+owners:
+  paths:
+    'file.txt': [a, b]
+    'dir/**/*': [c, d]
+",
+                |path| ProjectConfig::load_from(path, "."),
+            );
+
+            assert_eq!(
+                config.owners.paths,
+                OwnersPaths::Map(FxHashMap::from_iter([
+                    ("file.txt".into(), vec!["a".into(), "b".into()]),
+                    ("dir/**/*".into(), vec!["c".into(), "d".into()]),
+                ]))
+            );
+        }
+
+        #[test]
+        #[should_panic(expected = "a default owner is required when defining a list of paths")]
+        fn errors_on_paths_list_empty_owner() {
+            test_load_config(
+                CONFIG_PROJECT_FILENAME,
+                r"
+owners:
+  paths:
+    - file.txt
+    - dir/**/*
+",
+                |path| ProjectConfig::load_from(path, "."),
+            );
+        }
+
+        #[test]
+        #[should_panic(
+            expected = "a default owner is required when defining an empty list of owners"
+        )]
+        fn errors_on_paths_map_empty_owner() {
+            test_load_config(
+                CONFIG_PROJECT_FILENAME,
+                r"
+owners:
+  paths:
+    'file.txt': []
+",
+                |path| ProjectConfig::load_from(path, "."),
+            );
+        }
+
+        #[test]
+        #[should_panic(expected = "at least 1 approver is required")]
+        fn errors_if_approvers_zero() {
+            test_load_config(
+                CONFIG_PROJECT_FILENAME,
+                r"
+owners:
+  requiredApprovals: 0
+",
+                |path| ProjectConfig::load_from(path, "."),
+            );
+        }
+    }
+
     mod project {
         use super::*;
 
-        // TODO
-        // #[test]
-        // #[should_panic(expected = "must not be empty")]
-        // fn errors_if_empty() {
-        //     test_load_config(CONFIG_PROJECT_FILENAME, "project: {}", |path| {
-        //         ProjectConfig::load_from(path, ".")
-        //     });
-        // }
+        #[test]
+        #[should_panic(expected = "must not be empty")]
+        fn errors_if_empty() {
+            test_load_config(CONFIG_PROJECT_FILENAME, "project: {}", |path| {
+                ProjectConfig::load_from(path, ".")
+            });
+        }
 
         #[test]
         fn can_set_only_description() {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+#### 🚀 Updates
+
+- Added code owners (`CODEOWNERS`) support.
+  - Added `owners` setting to `moon.yml`.
+
 #### ⚙️ Internal
 
 - Updated Rust to v1.70.

--- a/packages/types/src/project-config.ts
+++ b/packages/types/src/project-config.ts
@@ -93,11 +93,20 @@ export interface ProjectWorkspaceConfig {
 	};
 }
 
+export interface OwnersConfig {
+	customGroups: Record<string, string[]>;
+	defaultOwner: string | null;
+	optional: boolean;
+	paths: Record<string, string[]> | string[];
+	requiredApprovals: number;
+}
+
 export interface ProjectConfig {
 	dependsOn: (DependencyConfig | string)[];
 	env: Record<string, string> | null;
 	fileGroups: Record<string, string[]>;
 	language: ProjectLanguage;
+	owners: OwnersConfig;
 	platform: Platform | null;
 	project: ProjectMetadataConfig | null;
 	tags: string[];

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -76,6 +76,105 @@ language: 'kotlin'
 > For convenience, when this setting is not defined, moon will attempt to detect the language based
 > on configuration files found in the project root. This only applies to non-custom languages!
 
+## `owners`<VersionLabel version="1.8.0" />
+
+<HeadingApiLink to="/api/types/interface/ProjectConfig#owners" />
+
+Defines ownership of source code within the current project, by mapping file system paths to owners.
+An owner is either a user, team, or group.
+
+Currently supports
+[GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners),
+[GitLab](https://docs.gitlab.com/ee/user/project/codeowners/reference.html), and
+[Bitbucket](https://marketplace.atlassian.com/apps/1218598/code-owners-for-bitbucket?tab=overview&hosting=cloud)
+(via app).
+
+### `customGroups`<RequiredLabel text="Bitbucket" />
+
+<HeadingApiLink to="/api/types/interface/OwnersConfig#customGroups" />
+
+When using the
+[Code Owners for Bitbucket](https://marketplace.atlassian.com/apps/1218598/code-owners-for-bitbucket?tab=overview&hosting=cloud)
+app, this setting provides a way to define custom groups that will be injected at the top of the
+`CODEOWNERS` file. These groups _must_ be unique across all projects.
+
+```yaml title="moon.yml" {2,3}
+owners:
+  customGroups:
+    '@@@backend': ['@"user name"', '@@team']
+```
+
+### `defaultOwner`
+
+<HeadingApiLink to="/api/types/interface/OwnersConfig#defaultOwner" />
+
+The default owner for all [`paths`](#paths). This setting is optional in some cases but helps to
+avoid unnecessary repetition.
+
+```yaml title="moon.yml" {2}
+owners:
+  defaultOwner: '@frontend'
+```
+
+### `optional`<RequiredLabel text="GitLab" />
+
+<HeadingApiLink to="/api/types/interface/OwnersConfig#optional" />
+
+For GitLab, marks the project's
+[code owners section](https://docs.gitlab.com/ee/user/project/codeowners/reference.html#optional-sections)
+as optional. Defaults to `false`.
+
+```yaml title="moon.yml" {2}
+owners:
+  optional: true
+```
+
+### `paths`
+
+<HeadingApiLink to="/api/types/interface/OwnersConfig#paths" />
+
+The primary setting for defining ownership of source code within the current project. This setting
+supports 2 formats, the first being a list of file paths relative from the current project. This
+format requires [`defaultOwner`](#defaultowner) to be defined, and only supports 1 owner for every
+path (the default owner).
+
+```yaml title="moon.yml" {3-5}
+owners:
+  defaultOwner: '@frontend'
+  paths:
+    - '**/*.{js,ts,tsx}'
+    - '*.config.js'
+```
+
+The second format provides far more granularity, allowing for multiple owners per path. This format
+requires a map, where the key is a file path relative from the current project, and the value is a
+list of owners. Paths with an empty list of owners will fallback to [`defaultOwner`](#defaultowner).
+
+```yaml title="moon.yml" {3-6}
+owners:
+  defaultOwner: '@frontend'
+  paths:
+    '**/*.rs': ['@backend']
+    '**/*.{js,ts,tsx}': []
+    '*.config.js': ['@frontend', '@frontend-infra']
+```
+
+> The syntax for owners is dependent on the provider you are using for version control (GitHub,
+> GitLab, Bitbucket). moon provides no validation or guarantees that these are correct.
+
+### `requiredApprovals`<RequiredLabel text="GitLab" />
+
+<HeadingApiLink to="/api/types/interface/OwnersConfig#requiredApprovals" />
+
+For GitLab, requires a specific number of approvers for the project's
+[code owners section](https://docs.gitlab.com/ee/user/project/codeowners/reference.html#sections-requiring-multiple-approvals).
+Defaults to `1`.
+
+```yaml title="moon.yml" {2}
+owners:
+  requiredApprovals: 2
+```
+
 ## `project`
 
 <HeadingApiLink to="/api/types/interface/ProjectConfig#project" />


### PR DESCRIPTION
This is the first step in support code owners.