### PR TITLE
fix: Fix issues when VCS root and workspace root are not the same.

### DIFF
--- a/crates/core/runner/src/runner.rs
+++ b/crates/core/runner/src/runner.rs
@@ -78,12 +78,10 @@ impl<'a> Runner<'a> {
         }
 
         // Check that outputs actually exist
-        if !self.task.outputs.is_empty() {
-            if !self.has_outputs()? {
-                return Err(RunnerError::Task(TaskError::MissingOutput(
-                    self.task.target.id.clone(),
-                )));
-            }
+        if !self.task.outputs.is_empty() && !self.has_outputs()? {
+            return Err(RunnerError::Task(TaskError::MissingOutput(
+                self.task.target.id.clone(),
+            )));
         }
 
         // If so, then cache the archive

--- a/crates/core/vcs/src/git.rs
+++ b/crates/core/vcs/src/git.rs
@@ -44,18 +44,16 @@ impl Git {
             ignore = Some(builder.build().map_err(VcsError::Ignore)?);
         }
 
-        let prefix = workspace_root
-            .strip_prefix(&root)
-            .unwrap()
-            .to_owned()
-            .to_string_lossy()
-            .to_string();
-
         Ok(Git {
             cache: Arc::new(RwLock::new(TimedCache::with_lifespan(15))),
             config: config.to_owned(),
             ignore,
-            workspace_prefix: if prefix == "/" { String::new() } else { prefix },
+            workspace_prefix: workspace_root
+                .strip_prefix(&root)
+                .unwrap()
+                .to_owned()
+                .to_string_lossy()
+                .to_string(),
             root,
         })
     }

--- a/crates/core/vcs/src/loader.rs
+++ b/crates/core/vcs/src/loader.rs
@@ -9,14 +9,14 @@ pub struct VcsLoader {}
 
 impl VcsLoader {
     pub fn load(
-        working_dir: &Path,
+        workspace_root: &Path,
         workspace_config: &WorkspaceConfig,
     ) -> Result<BoxedVcs, VcsError> {
         let vcs_config = &workspace_config.vcs;
 
         Ok(match vcs_config.manager {
-            VcsManager::Svn => Box::new(Svn::load(vcs_config, working_dir)),
-            _ => Box::new(Git::load(vcs_config, working_dir)?),
+            VcsManager::Svn => Box::new(Svn::load(vcs_config, workspace_root)),
+            _ => Box::new(Git::load(vcs_config, workspace_root)?),
         })
     }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,8 @@
 #### 🐞 Fixes
 
 - Fixed an issue where glob task outputs were not invalidating a previous build.
+- Fixed an issue where changing inputs would not mark a task as affected, when a moon workspace is
+  nested within a repository.
 
 ## 1.7.2
 


### PR DESCRIPTION
This results in broken builds but the problem isn't very noticeable. Everything "looks" like it's working, but caching acts weird. The problem is that the VCS paths are different than the workspace ones (the prefix between the 2 is missing), resulting in path comparisons to fail.