### PR TITLE
Fix broken get_local_branch when using older git versions

### DIFF
--- a/.yarn/versions/0c454339.yml
+++ b/.yarn/versions/0c454339.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/core/vcs/src/git.rs
+++ b/crates/core/vcs/src/git.rs
@@ -190,7 +190,7 @@ impl Vcs for Git {
         }
 
         self.run_command(
-            self.create_command(vec!["rev-parse --abbrev-ref HEAD"]),
+            self.create_command(vec!["rev-parse", "--abbrev-ref", "HEAD"]),
             true,
         )
         .await


### PR DESCRIPTION
When running git <2.22.0 (I had 2.14.1), I get

```
moon run build
Error:   × Process git failed with a 1 exit code.
  │ 
  │ git: 'rev-parse --abbrev-ref HEAD' is not a git command. See 'git --help'.
```