### PR TITLE
fix: Use `.editorconfig` when writing `CODEOWNERS`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4634,9 +4634,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
 dependencies = [
  "indexmap",
  "itoa",
@@ -4895,9 +4895,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_sandbox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdea800d59826627268386762973162e35e38b8db6dd8b738bf505f0ec71e30"
+checksum = "e830673d56b507194471b834a0d5823db747e72f6ae4b099607be5891aff0fbc"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -4911,9 +4911,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_styles"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66e1f18071d2faae1009fc03ef94c932e1a0e4e126195609dada0779a67b04a"
+checksum = "7e90aad208a2a27137042da4039efb62c7ecd5c2ee78b9c82885e16ce828e984"
 dependencies = [
  "dirs",
  "miette",
@@ -4924,9 +4924,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_utils"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f9e355df7318394c0d8a17e7934b69bbf8fea964802148afb017dd8a6d3bdc"
+checksum = "8b89a6b84dee72cc983a70b8ceb425ef9d4045f421c8d098859005ad967f2546"
 dependencies = [
  "dirs",
  "ec4rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ schematic = { version = "0.9.4", default-features = false, features = ["schema"]
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 serde_yaml = "0.9.21"
-starbase_sandbox = "0.1.3"
-starbase_styles = { version = "0.1.9", features = ["relative-path"] }
-starbase_utils = { version = "0.2.11", default-features = false, features = ["editor-config", "glob", "json", "toml", "yaml"] }
+starbase_sandbox = "0.1.4"
+starbase_styles = { version = "0.1.10", features = ["relative-path"] }
+starbase_utils = { version = "0.2.12", default-features = false, features = ["editor-config", "glob", "json", "toml", "yaml"] }
 thiserror = "1.0.40"
 tokio = { version = "1.28.2", default-features = false, features = ["tracing"] }
 tracing = "0.1.37"

--- a/nextgen/codeowners/src/codeowners_generator.rs
+++ b/nextgen/codeowners/src/codeowners_generator.rs
@@ -145,9 +145,13 @@ impl CodeownersGenerator {
     }
 
     pub fn generate(mut self) -> Result<(), FsError> {
-        self.write("")?;
-
         debug!(file = %self.file_path.display(), "Generating and writing CODEOWNERS file");
+
+        let editor_config = fs::get_editor_config_props(&self.file_path);
+
+        if editor_config.eof == "\n" {
+            self.write("")?;
+        }
 
         self.file.flush().map_err(|error| FsError::Create {
             path: self.file_path.to_path_buf(),

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Updated `CODEOWNERS` to take `.editorconfig` into account when generating.
+- Fixed an issue where `git` branch commands would fail on <= v2.22.
+
 ## 1.8.1
 
 #### 🐞 Fixes


### PR DESCRIPTION
Title.