### PR TITLE
internal: Move Node.js syncing logic.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ on:
       - Makefile.toml
       - rust-toolchain.toml
 env:
-  RUST_BACKTRACE: 1
+  # RUST_BACKTRACE: 1
   WITH_COVERAGE: ${{ contains(github.head_ref, 'develop-') || endsWith(github.ref, 'master') }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/crates/cli/tests/run_node_test.rs
+++ b/crates/cli/tests/run_node_test.rs
@@ -471,6 +471,8 @@ mod engines {
             cmd.arg("run").arg("node:standard");
         });
 
+        sandbox.debug_files();
+
         assert_snapshot!(read_to_string(sandbox.path().join("package.json")).unwrap());
     }
 
@@ -530,6 +532,8 @@ mod version_manager {
         sandbox.run_moon(|cmd| {
             cmd.arg("run").arg("node:standard");
         });
+
+        sandbox.debug_files();
 
         assert!(sandbox.path().join(".node-version").exists());
 

--- a/crates/cli/tests/run_node_test.rs
+++ b/crates/cli/tests/run_node_test.rs
@@ -471,8 +471,6 @@ mod engines {
             cmd.arg("run").arg("node:standard");
         });
 
-        sandbox.debug_files();
-
         assert_snapshot!(read_to_string(sandbox.path().join("package.json")).unwrap());
     }
 
@@ -532,8 +530,6 @@ mod version_manager {
         sandbox.run_moon(|cmd| {
             cmd.arg("run").arg("node:standard");
         });
-
-        sandbox.debug_files();
 
         assert!(sandbox.path().join(".node-version").exists());
 

--- a/crates/core/action-pipeline/src/actions/run_target.rs
+++ b/crates/core/action-pipeline/src/actions/run_target.rs
@@ -70,7 +70,7 @@ pub async fn run_target(
     } else {
         // Concurrent long-running tasks will cause a deadlock, as some threads will
         // attempt to write to context while others are reading from it, and long-running
-        // tasks may never release the lock. Unfortuantely we have to clone  here to work
+        // tasks may never release the lock. Unfortuantely we have to clone here to work
         // around it, so revisit in the future.
         let context = (context.read().await).clone();
 

--- a/crates/node/platform/src/actions/install_deps.rs
+++ b/crates/node/platform/src/actions/install_deps.rs
@@ -1,73 +1,16 @@
-use moon_config::{NodeConfig, NodePackageManager, NodeVersionManager};
-use moon_error::MoonError;
+use moon_config::NodePackageManager;
 use moon_lang::has_vendor_installed_dependencies;
 use moon_logger::{debug, warn};
-use moon_node_lang::{PackageJson, NODE, NODENV, NPM, NVM};
+use moon_node_lang::NODE;
 use moon_node_tool::NodeTool;
 use moon_terminal::{print_checkpoint, Checkpoint};
 use moon_tool::ToolError;
 use moon_utils::{is_ci, is_test_env};
-use starbase_styles::color;
-use starbase_utils::fs;
 use std::path::Path;
 
 const LOG_TARGET: &str = "moon:node-platform:install-deps";
 
-/// Add `packageManager` to `package.json`.
-fn add_package_manager(node_config: &NodeConfig, package_json: &mut PackageJson) -> bool {
-    let manager_version = match node_config.package_manager {
-        NodePackageManager::Npm => node_config.npm.version.as_ref().map(|v| format!("npm@{v}")),
-        NodePackageManager::Pnpm => node_config.pnpm.as_ref().map(|cfg| {
-            cfg.version
-                .as_ref()
-                .map(|v| format!("pnpm@{v}"))
-                .unwrap_or_default()
-        }),
-        NodePackageManager::Yarn => node_config.yarn.as_ref().map(|cfg| {
-            cfg.version
-                .as_ref()
-                .map(|v| format!("yarn@{v}"))
-                .unwrap_or_default()
-        }),
-    };
-
-    if let Some(version) = manager_version {
-        if package_json.set_package_manager(&version) {
-            debug!(
-                target: LOG_TARGET,
-                "Adding package manager version to {}",
-                color::file(NPM.manifest)
-            );
-
-            return true;
-        }
-    }
-
-    false
-}
-
-/// Add `engines` constraint to `package.json`.
-fn add_engines_constraint(node_config: &NodeConfig, package_json: &mut PackageJson) -> bool {
-    if let Some(node_version) = &node_config.version {
-        if node_config.add_engines_constraint && package_json.add_engine("node", node_version) {
-            debug!(
-                target: LOG_TARGET,
-                "Adding engines version constraint to {}",
-                color::file(NPM.manifest)
-            );
-
-            return true;
-        }
-    }
-
-    false
-}
-
-pub async fn install_deps(
-    node: &NodeTool,
-    working_dir: &Path,
-    workspace_root: &Path,
-) -> Result<(), ToolError> {
+pub async fn install_deps(node: &NodeTool, working_dir: &Path) -> Result<(), ToolError> {
     // When in CI, we can avoid installing dependencies because
     // we can assume they've already been installed before moon runs!
     if is_ci() && has_vendor_installed_dependencies(working_dir, &NODE) {
@@ -77,35 +20,6 @@ pub async fn install_deps(
         );
 
         return Ok(());
-    }
-
-    // Sync values to `package.json`
-    if working_dir == workspace_root {
-        PackageJson::sync(working_dir, |package_json| {
-            let added_manager = add_package_manager(&node.config, package_json);
-            let added_constraint = add_engines_constraint(&node.config, package_json);
-
-            Ok(added_manager || added_constraint)
-        })?;
-    }
-
-    // Create nvm/nodenv version file
-    if let Some(version_manager) = &node.config.sync_version_manager_config {
-        if let Some(node_version) = &node.config.version {
-            let rc_name = match version_manager {
-                NodeVersionManager::Nodenv => NODENV.version_file.to_string(),
-                NodeVersionManager::Nvm => NVM.version_file.to_string(),
-            };
-            let rc_path = working_dir.join(rc_name);
-
-            fs::write_file(&rc_path, node_version).map_err(MoonError::StarFs)?;
-
-            debug!(
-                target: LOG_TARGET,
-                "Syncing Node.js version to {}",
-                color::path(&rc_path)
-            );
-        }
     }
 
     let package_manager = node.get_package_manager();

--- a/crates/node/platform/src/actions/mod.rs
+++ b/crates/node/platform/src/actions/mod.rs
@@ -1,7 +1,9 @@
 mod install_deps;
 mod run_target;
+mod setup_tool;
 mod sync_project;
 
 pub use install_deps::*;
 pub use run_target::*;
+pub use setup_tool::*;
 pub use sync_project::*;

--- a/crates/node/platform/src/actions/setup_tool.rs
+++ b/crates/node/platform/src/actions/setup_tool.rs
@@ -1,0 +1,110 @@
+use moon_config::{NodeConfig, NodePackageManager, NodeVersionManager};
+use moon_error::MoonError;
+use moon_logger::debug;
+use moon_node_lang::{PackageJson, NODENV, NPM, NVM, PNPM, YARN};
+use moon_node_tool::NodeTool;
+use moon_tool::ToolError;
+use moon_utils::is_ci;
+use starbase_styles::color;
+use starbase_utils::fs;
+use std::path::Path;
+
+const LOG_TARGET: &str = "moon:node-platform:setup-tool";
+
+/// Add `packageManager` to `package.json`.
+fn add_package_manager(node_config: &NodeConfig, package_json: &mut PackageJson) -> bool {
+    let manager_version = match node_config.package_manager {
+        NodePackageManager::Npm => node_config.npm.version.as_ref().map(|v| format!("npm@{v}")),
+        NodePackageManager::Pnpm => node_config.pnpm.as_ref().map(|cfg| {
+            cfg.version
+                .as_ref()
+                .map(|v| format!("pnpm@{v}"))
+                .unwrap_or_default()
+        }),
+        NodePackageManager::Yarn => node_config.yarn.as_ref().map(|cfg| {
+            cfg.version
+                .as_ref()
+                .map(|v| format!("yarn@{v}"))
+                .unwrap_or_default()
+        }),
+    };
+
+    if let Some(version) = manager_version {
+        if package_json.set_package_manager(&version) {
+            debug!(
+                target: LOG_TARGET,
+                "Adding package manager version to {}",
+                color::file(NPM.manifest)
+            );
+
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Add `engines` constraint to `package.json`.
+fn add_engines_constraint(node_config: &NodeConfig, package_json: &mut PackageJson) -> bool {
+    if let Some(node_version) = &node_config.version {
+        if node_config.add_engines_constraint && package_json.add_engine("node", node_version) {
+            debug!(
+                target: LOG_TARGET,
+                "Adding engines version constraint to {}",
+                color::file(NPM.manifest)
+            );
+
+            return true;
+        }
+    }
+
+    false
+}
+
+pub async fn setup_tool(node: &NodeTool, workspace_root: &Path) -> Result<(), ToolError> {
+    if is_ci() {
+        return Ok(());
+    }
+
+    // Find the `package.json` workspaces root
+    let lockfile = match node.config.package_manager {
+        NodePackageManager::Npm => NPM.lockfile,
+        NodePackageManager::Pnpm => PNPM.lockfile,
+        NodePackageManager::Yarn => YARN.lockfile,
+    };
+
+    let lockfile_path = fs::find_upwards(lockfile, workspace_root);
+    let packages_root = lockfile_path
+        .as_ref()
+        .map(|p| p.parent().unwrap())
+        .unwrap_or(workspace_root);
+
+    // Sync values to root `package.json`
+    PackageJson::sync(packages_root, |package_json| {
+        let added_manager = add_package_manager(&node.config, package_json);
+        let added_constraint = add_engines_constraint(&node.config, package_json);
+
+        Ok(added_manager || added_constraint)
+    })?;
+
+    // Create nvm/nodenv version file
+    if let Some(version_manager) = &node.config.sync_version_manager_config {
+        if let Some(node_version) = &node.config.version {
+            let rc_name = match version_manager {
+                NodeVersionManager::Nodenv => NODENV.version_file.to_string(),
+                NodeVersionManager::Nvm => NVM.version_file.to_string(),
+            };
+            let rc_path = packages_root.join(rc_name);
+
+            fs::write_file(&rc_path, node_version).map_err(MoonError::StarFs)?;
+
+            debug!(
+                target: LOG_TARGET,
+                "Syncing Node.js version to {}",
+                color::path(&rc_path)
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/node/platform/src/actions/setup_tool.rs
+++ b/crates/node/platform/src/actions/setup_tool.rs
@@ -4,7 +4,6 @@ use moon_logger::debug;
 use moon_node_lang::{PackageJson, NODENV, NPM, NVM, PNPM, YARN};
 use moon_node_tool::NodeTool;
 use moon_tool::ToolError;
-use moon_utils::is_ci;
 use starbase_styles::color;
 use starbase_utils::fs;
 use std::path::Path;
@@ -62,10 +61,6 @@ fn add_engines_constraint(node_config: &NodeConfig, package_json: &mut PackageJs
 }
 
 pub async fn setup_tool(node: &NodeTool, workspace_root: &Path) -> Result<(), ToolError> {
-    if is_ci() {
-        return Ok(());
-    }
-
     // Find the `package.json` workspaces root
     let lockfile = match node.config.package_manager {
         NodePackageManager::Npm => NPM.lockfile,

--- a/crates/node/platform/src/platform.rs
+++ b/crates/node/platform/src/platform.rs
@@ -304,7 +304,15 @@ impl Platform for NodePlatform {
             );
         }
 
-        Ok(self.toolchain.setup(&version, last_versions).await?)
+        let installed = self.toolchain.setup(&version, last_versions).await?;
+
+        actions::setup_tool(
+            self.toolchain.get_for_version(runtime.version())?,
+            &self.workspace_root,
+        )
+        .await?;
+
+        Ok(installed)
     }
 
     async fn install_deps(
@@ -316,7 +324,6 @@ impl Platform for NodePlatform {
         actions::install_deps(
             self.toolchain.get_for_version(runtime.version())?,
             working_dir,
-            &self.workspace_root,
         )
         .await?;
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Added VCS hooks management support.
   - Added `vcs.hooks` and `vcs.syncHooksOnRun` settings to `.moon/workspace.yml`.
   - Added `moon sync hooks` command.
+- Node.js
+  - Moved syncing logic from `InstallNodeDeps` action to `SetupNodeTool` action. This includes
+    syncing `packageManager`, `engines`, and version files. This should feel more natural.
 
 #### 🐞 Fixes
 


### PR DESCRIPTION
This sync logic shouldn't require installing node modules, so makes more sense as part of setup tool.