### PR TITLE
new: Support an object for `bins`. Add Deno support.

### DIFF
--- a/crates/deno/platform/src/bins_hasher.rs
+++ b/crates/deno/platform/src/bins_hasher.rs
@@ -1,0 +1,35 @@
+use moon_config::BinEntry;
+use moon_hasher::{Digest, Hasher, Sha256};
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DenoBinsHasher {
+    pub bins: Vec<BinEntry>,
+}
+
+impl Hasher for DenoBinsHasher {
+    fn hash(&self, sha: &mut Sha256) {
+        for bin in &self.bins {
+            match bin {
+                BinEntry::Name(name) => {
+                    sha.update(name.as_bytes());
+                }
+                BinEntry::Config(cfg) => {
+                    sha.update(cfg.bin.as_bytes());
+
+                    if let Some(name) = cfg.name.as_ref() {
+                        sha.update(name.as_bytes());
+                    }
+
+                    sha.update(cfg.force.to_string());
+                    sha.update(cfg.local.to_string());
+                }
+            };
+        }
+    }
+
+    fn serialize(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+}

--- a/crates/deno/platform/src/lib.rs
+++ b/crates/deno/platform/src/lib.rs
@@ -1,4 +1,5 @@
 mod actions;
+mod bins_hasher;
 mod platform;
 mod target_hasher;
 

--- a/crates/deno/platform/src/platform.rs
+++ b/crates/deno/platform/src/platform.rs
@@ -1,15 +1,15 @@
 use crate::actions;
 use crate::target_hasher::DenoTargetHasher;
 use moon_action_context::ActionContext;
-use moon_common::Id;
+use moon_common::{color, is_ci, Id};
 use moon_config::{
-    DenoConfig, DependencyConfig, HasherConfig, HasherOptimization, PlatformType, ProjectConfig,
-    ProjectsAliasesMap, TypeScriptConfig,
+    BinEntry, DenoConfig, DependencyConfig, HasherConfig, HasherOptimization, PlatformType,
+    ProjectConfig, ProjectsAliasesMap, TypeScriptConfig,
 };
 use moon_deno_lang::{load_lockfile_dependencies, DenoJson, DENO_DEPS};
 use moon_deno_tool::DenoTool;
 use moon_hasher::{DepsHasher, HashSet};
-use moon_logger::debug;
+use moon_logger::{debug, map_list};
 use moon_platform::{Platform, Runtime, Version};
 use moon_process::Command;
 use moon_project::Project;
@@ -188,6 +188,55 @@ impl Platform for DenoPlatform {
             .create_async()
             .exec_stream_output()
             .await?;
+
+        // Then attempt to install binaries
+        if !self.config.bins.is_empty() {
+            print_checkpoint("deno install", Checkpoint::Setup);
+
+            debug!(
+                target: LOG_TARGET,
+                "Installing Deno binaries: {}",
+                map_list(&self.config.bins, |b| color::label(b.get_name()))
+            );
+
+            for bin in &self.config.bins {
+                let mut args = vec![
+                    "install",
+                    "--allow-net",
+                    "--allow-read",
+                    "--no-prompt",
+                    "--lock",
+                    DENO_DEPS.lockfile,
+                ];
+
+                match bin {
+                    BinEntry::Name(name) => args.push(name),
+                    BinEntry::Config(cfg) => {
+                        if cfg.local && is_ci() {
+                            continue;
+                        }
+
+                        if cfg.force {
+                            args.push("--force");
+                        }
+
+                        if let Some(name) = &cfg.name {
+                            args.push("--name");
+                            args.push(name);
+                        }
+
+                        args.push(&cfg.bin);
+                    }
+                };
+
+                Command::new(tool.get_bin_path()?)
+                    .args(args)
+                    .cwd(working_dir)
+                    .create_async()
+                    .exec_stream_output()
+                    .await?;
+            }
+        }
 
         Ok(())
     }

--- a/crates/deno/platform/src/platform.rs
+++ b/crates/deno/platform/src/platform.rs
@@ -1,5 +1,5 @@
-use crate::actions;
 use crate::target_hasher::DenoTargetHasher;
+use crate::{actions, bins_hasher::DenoBinsHasher};
 use moon_action_context::ActionContext;
 use moon_common::{color, is_ci, Id};
 use moon_config::{
@@ -265,6 +265,12 @@ impl Platform for DenoPlatform {
         hashset: &mut HashSet,
         _hasher_config: &HasherConfig,
     ) -> miette::Result<()> {
+        if !self.config.bins.is_empty() {
+            hashset.hash(DenoBinsHasher {
+                bins: self.config.bins.clone(),
+            });
+        }
+
         let mut hasher = DepsHasher::new("deno".into());
         let project_root = manifest_path.parent().unwrap();
 

--- a/crates/rust/platform/src/bins_hasher.rs
+++ b/crates/rust/platform/src/bins_hasher.rs
@@ -1,15 +1,32 @@
-use moon_hasher::{hash_vec, Hasher, Sha256};
-use serde::{Deserialize, Serialize};
+use moon_config::BinEntry;
+use moon_hasher::{Digest, Hasher, Sha256};
+use serde::Serialize;
 
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RustBinsHasher {
-    pub bins: Vec<String>,
+    pub bins: Vec<BinEntry>,
 }
 
 impl Hasher for RustBinsHasher {
     fn hash(&self, sha: &mut Sha256) {
-        hash_vec(&self.bins, sha);
+        for bin in &self.bins {
+            match bin {
+                BinEntry::Name(name) => {
+                    sha.update(name.as_bytes());
+                }
+                BinEntry::Config(cfg) => {
+                    sha.update(cfg.bin.as_bytes());
+
+                    if let Some(version) = cfg.version.as_ref() {
+                        sha.update(version.as_bytes());
+                    }
+
+                    sha.update(cfg.force.to_string());
+                    sha.update(cfg.local.to_string());
+                }
+            };
+        }
     }
 
     fn serialize(&self) -> serde_json::Value {

--- a/crates/rust/platform/src/bins_hasher.rs
+++ b/crates/rust/platform/src/bins_hasher.rs
@@ -18,8 +18,8 @@ impl Hasher for RustBinsHasher {
                 BinEntry::Config(cfg) => {
                     sha.update(cfg.bin.as_bytes());
 
-                    if let Some(version) = cfg.version.as_ref() {
-                        sha.update(version.as_bytes());
+                    if let Some(name) = cfg.name.as_ref() {
+                        sha.update(name.as_bytes());
                     }
 
                     sha.update(cfg.force.to_string());

--- a/crates/rust/platform/src/rust_platform.rs
+++ b/crates/rust/platform/src/rust_platform.rs
@@ -236,19 +236,19 @@ impl Platform for RustPlatform {
             }
 
             // Then attempt to install binaries
-            debug!(
-                target: LOG_TARGET,
-                "Installing Cargo binaries: {}",
-                map_list(&self.config.bins, |b| color::label(b))
-            );
+            // debug!(
+            //     target: LOG_TARGET,
+            //     "Installing Cargo binaries: {}",
+            //     map_list(&self.config.bins, |b| color::label(b))
+            // );
 
-            let mut args = string_vec!["binstall", "--no-confirm", "--log-level", "info"];
+            // let mut args = string_vec!["binstall", "--no-confirm", "--log-level", "info"];
 
-            for bin in &self.config.bins {
-                args.push(bin.to_owned());
-            }
+            // for bin in &self.config.bins {
+            //     args.push(bin.to_owned());
+            // }
 
-            tool.exec_cargo(args, working_dir).await?;
+            // tool.exec_cargo(args, working_dir).await?;
         }
 
         Ok(())
@@ -343,11 +343,11 @@ impl Platform for RustPlatform {
         hashset: &mut HashSet,
         _hasher_config: &HasherConfig,
     ) -> miette::Result<()> {
-        if !self.config.bins.is_empty() {
-            hashset.hash(RustBinsHasher {
-                bins: self.config.bins.clone(),
-            });
-        }
+        // if !self.config.bins.is_empty() {
+        //     hashset.hash(RustBinsHasher {
+        //         bins: self.config.bins.clone(),
+        //     });
+        // }
 
         // NOTE: Since Cargo has no way to install dependencies, we don't actually need this!
         // However, will leave it around incase a new cargo command is added in the future.

--- a/crates/rust/platform/src/rust_platform.rs
+++ b/crates/rust/platform/src/rust_platform.rs
@@ -356,11 +356,11 @@ impl Platform for RustPlatform {
         hashset: &mut HashSet,
         _hasher_config: &HasherConfig,
     ) -> miette::Result<()> {
-        // if !self.config.bins.is_empty() {
-        //     hashset.hash(RustBinsHasher {
-        //         bins: self.config.bins.clone(),
-        //     });
-        // }
+        if !self.config.bins.is_empty() {
+            hashset.hash(RustBinsHasher {
+                bins: self.config.bins.clone(),
+            });
+        }
 
         // NOTE: Since Cargo has no way to install dependencies, we don't actually need this!
         // However, will leave it around incase a new cargo command is added in the future.

--- a/nextgen/config/src/main.rs
+++ b/nextgen/config/src/main.rs
@@ -6,6 +6,7 @@ use schematic::schema::typescript::{TypeScriptOptions, TypeScriptRenderer};
 use schematic::schema::SchemaGenerator;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::process::Command;
 
 fn generate_project() {
     let mut generator = SchemaGenerator::default();
@@ -158,4 +159,9 @@ fn main() {
     generate_template();
     generate_toolchain();
     generate_workspace();
+
+    // Run prettier
+    let mut cmd = Command::new("node_modules/.bin/prettier");
+    cmd.args(["--write", "packages/types"]);
+    cmd.output().unwrap();
 }

--- a/nextgen/config/src/toolchain/bin_config.rs
+++ b/nextgen/config/src/toolchain/bin_config.rs
@@ -1,0 +1,17 @@
+use schematic::Config;
+
+#[derive(Config, Debug)]
+pub struct BinConfig {
+    pub bin: String,
+    pub force: bool,
+    pub local: bool,
+    pub version: Option<String>,
+}
+
+#[derive(Config, Debug)]
+#[config(serde(untagged, expecting = "expecting a bin name, or bin config object"))]
+pub enum BinEntry {
+    Name(String),
+    #[setting(nested)]
+    Config(BinConfig),
+}

--- a/nextgen/config/src/toolchain/bin_config.rs
+++ b/nextgen/config/src/toolchain/bin_config.rs
@@ -13,7 +13,7 @@ pub struct BinConfig {
 }
 
 #[derive(Clone, Config, Debug, Eq, PartialEq, Serialize)]
-#[config(serde(untagged, expecting = "expecting a bin name, or bin config object"))]
+#[serde(untagged, expecting = "expecting a bin name, or bin config object")]
 pub enum BinEntry {
     Name(String),
     #[setting(nested)]

--- a/nextgen/config/src/toolchain/bin_config.rs
+++ b/nextgen/config/src/toolchain/bin_config.rs
@@ -1,14 +1,17 @@
 use schematic::Config;
 
-#[derive(Config, Debug)]
+#[derive(Clone, Config, Debug)]
 pub struct BinConfig {
     pub bin: String,
+
     pub force: bool,
+
     pub local: bool,
+
     pub version: Option<String>,
 }
 
-#[derive(Config, Debug)]
+#[derive(Clone, Config, Debug)]
 #[config(serde(untagged, expecting = "expecting a bin name, or bin config object"))]
 pub enum BinEntry {
     Name(String),

--- a/nextgen/config/src/toolchain/bin_config.rs
+++ b/nextgen/config/src/toolchain/bin_config.rs
@@ -9,7 +9,7 @@ pub struct BinConfig {
 
     pub local: bool,
 
-    pub version: Option<String>,
+    pub name: Option<String>,
 }
 
 #[derive(Clone, Config, Debug, Eq, PartialEq, Serialize)]
@@ -21,16 +21,10 @@ pub enum BinEntry {
 }
 
 impl BinEntry {
-    pub fn get_package_identifier(&self) -> String {
+    pub fn get_name(&self) -> &str {
         match self {
-            BinEntry::Name(name) => name.to_owned(),
-            BinEntry::Config(cfg) => {
-                if let Some(version) = cfg.version.as_ref() {
-                    format!("{}@{version}", cfg.bin)
-                } else {
-                    cfg.bin.to_owned()
-                }
-            }
+            BinEntry::Name(name) => name,
+            BinEntry::Config(cfg) => &cfg.bin,
         }
     }
 }

--- a/nextgen/config/src/toolchain/bin_config.rs
+++ b/nextgen/config/src/toolchain/bin_config.rs
@@ -18,3 +18,18 @@ pub enum BinEntry {
     #[setting(nested)]
     Config(BinConfig),
 }
+
+impl BinEntry {
+    pub fn get_package_identifier(&self) -> String {
+        match self {
+            BinEntry::Name(name) => name.to_owned(),
+            BinEntry::Config(cfg) => {
+                if let Some(version) = cfg.version.as_ref() {
+                    format!("{}@{version}", cfg.bin)
+                } else {
+                    cfg.bin.to_owned()
+                }
+            }
+        }
+    }
+}

--- a/nextgen/config/src/toolchain/bin_config.rs
+++ b/nextgen/config/src/toolchain/bin_config.rs
@@ -1,6 +1,7 @@
 use schematic::Config;
+use serde::Serialize;
 
-#[derive(Clone, Config, Debug)]
+#[derive(Clone, Config, Debug, Eq, PartialEq, Serialize)]
 pub struct BinConfig {
     pub bin: String,
 
@@ -11,7 +12,7 @@ pub struct BinConfig {
     pub version: Option<String>,
 }
 
-#[derive(Clone, Config, Debug)]
+#[derive(Clone, Config, Debug, Eq, PartialEq, Serialize)]
 #[config(serde(untagged, expecting = "expecting a bin name, or bin config object"))]
 pub enum BinEntry {
     Name(String),

--- a/nextgen/config/src/toolchain/deno_config.rs
+++ b/nextgen/config/src/toolchain/deno_config.rs
@@ -1,8 +1,12 @@
+use super::bin_config::BinEntry;
 use schematic::Config;
 
 /// Docs: https://moonrepo.dev/docs/config/toolchain#deno
 #[derive(Clone, Config, Debug)]
 pub struct DenoConfig {
+    #[setting(nested)]
+    pub bins: Vec<BinEntry>,
+
     #[setting(default = "deps.ts")]
     pub deps_file: String,
 

--- a/nextgen/config/src/toolchain/deno_config.rs
+++ b/nextgen/config/src/toolchain/deno_config.rs
@@ -1,8 +1,7 @@
 use schematic::Config;
-use serde::Serialize;
 
 /// Docs: https://moonrepo.dev/docs/config/toolchain#deno
-#[derive(Clone, Config, Debug, Serialize)]
+#[derive(Clone, Config, Debug)]
 pub struct DenoConfig {
     #[setting(default = "deps.ts")]
     pub deps_file: String,

--- a/nextgen/config/src/toolchain/mod.rs
+++ b/nextgen/config/src/toolchain/mod.rs
@@ -1,8 +1,10 @@
+mod bin_config;
 mod deno_config;
 mod node_config;
 mod rust_config;
 mod typescript_config;
 
+pub use bin_config::*;
 pub use deno_config::*;
 pub use node_config::*;
 pub use rust_config::*;

--- a/nextgen/config/src/toolchain/node_config.rs
+++ b/nextgen/config/src/toolchain/node_config.rs
@@ -2,7 +2,6 @@ use crate::validate::validate_semver;
 use crate::{inherit_tool, inherit_tool_required};
 use proto::ToolsConfig;
 use schematic::{derive_enum, Config, ConfigEnum};
-use serde::Serialize;
 
 derive_enum!(
     #[derive(ConfigEnum, Copy, Default)]
@@ -64,19 +63,19 @@ derive_enum!(
     }
 );
 
-#[derive(Clone, Config, Debug, Serialize)]
+#[derive(Clone, Config, Debug)]
 pub struct NpmConfig {
     #[setting(env = "MOON_NPM_VERSION", validate = validate_semver)]
     pub version: Option<String>,
 }
 
-#[derive(Clone, Config, Debug, Serialize)]
+#[derive(Clone, Config, Debug)]
 pub struct PnpmConfig {
     #[setting(env = "MOON_PNPM_VERSION", validate = validate_semver)]
     pub version: Option<String>,
 }
 
-#[derive(Clone, Config, Debug, Serialize)]
+#[derive(Clone, Config, Debug)]
 pub struct YarnConfig {
     pub plugins: Vec<String>,
 
@@ -85,7 +84,7 @@ pub struct YarnConfig {
 }
 
 /// Docs: https://moonrepo.dev/docs/config/toolchain#node
-#[derive(Clone, Config, Debug, Serialize)]
+#[derive(Clone, Config, Debug)]
 pub struct NodeConfig {
     #[setting(default = true)]
     pub add_engines_constraint: bool,

--- a/nextgen/config/src/toolchain/rust_config.rs
+++ b/nextgen/config/src/toolchain/rust_config.rs
@@ -1,10 +1,9 @@
 use super::bin_config::BinEntry;
 use crate::validate::validate_semver;
 use schematic::Config;
-use serde::Serialize;
 
 /// Docs: https://moonrepo.dev/docs/config/toolchain#rust
-#[derive(Clone, Config, Debug, Serialize)]
+#[derive(Clone, Config, Debug)]
 pub struct RustConfig {
     #[setting(nested)]
     pub bins: Vec<BinEntry>,

--- a/nextgen/config/src/toolchain/rust_config.rs
+++ b/nextgen/config/src/toolchain/rust_config.rs
@@ -1,3 +1,4 @@
+use super::bin_config::BinEntry;
 use crate::validate::validate_semver;
 use schematic::Config;
 use serde::Serialize;
@@ -5,7 +6,8 @@ use serde::Serialize;
 /// Docs: https://moonrepo.dev/docs/config/toolchain#rust
 #[derive(Clone, Config, Debug, Serialize)]
 pub struct RustConfig {
-    pub bins: Vec<String>,
+    #[setting(nested)]
+    pub bins: Vec<BinEntry>,
 
     pub sync_toolchain_config: bool,
 

--- a/nextgen/config/src/toolchain/typescript_config.rs
+++ b/nextgen/config/src/toolchain/typescript_config.rs
@@ -1,8 +1,7 @@
 use schematic::Config;
-use serde::Serialize;
 
 /// Docs: https://moonrepo.dev/docs/config/toolchain#typescript
-#[derive(Clone, Config, Debug, Serialize)]
+#[derive(Clone, Config, Debug)]
 pub struct TypeScriptConfig {
     #[setting(default = true)]
     pub create_missing_config: bool,

--- a/nextgen/config/tests/toolchain_config_test.rs
+++ b/nextgen/config/tests/toolchain_config_test.rs
@@ -1,6 +1,6 @@
 mod utils;
 
-use moon_config::{NodePackageManager, ToolchainConfig};
+use moon_config::{BinEntry, NodePackageManager, ToolchainConfig};
 use proto::ToolsConfig;
 use starbase_sandbox::create_sandbox;
 use std::env;
@@ -411,7 +411,7 @@ node:
 
             let cfg = config.rust.unwrap();
 
-            assert_eq!(cfg.bins, Vec::<String>::new());
+            assert!(cfg.bins.is_empty());
             assert!(!cfg.sync_toolchain_config);
         }
 
@@ -429,7 +429,7 @@ rust:
 
             let cfg = config.rust.unwrap();
 
-            assert_eq!(cfg.bins, vec!["cargo-make"]);
+            assert_eq!(cfg.bins, vec![BinEntry::Name("cargo-make".into())]);
             assert!(cfg.sync_toolchain_config);
         }
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added support for `MOON_BASE` and `MOON_HEAD` environment variables.
   - Will be used when diffing across branches or commits.
   - Works for both `moon ci` and `moon run`.
+- Added `deno.bins` support in `.moon/toolchain.yml`.
 - Updated `moon ci` to include a summary of all failed actions.
 - Updated `moon run` to compare against the previous commit when running on the default branch and
   using `--remote`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Updated `moon ci` to include a summary of all failed actions.
 - Updated `moon run` to compare against the previous commit when running on the default branch and
   using `--remote`.
+- Updated `rust.bins` in `.moon/toolchain.yml` to support an object for each bin entry.
+  - Can denote bins as CI or local only.
+  - Can force install bins.
 - Updated the run report to include stderr/stdout for all attempts.
 
 #### 🐞 Fixes

--- a/packages/types/src/toolchain-config.ts
+++ b/packages/types/src/toolchain-config.ts
@@ -57,8 +57,17 @@ export interface PartialNodeConfig {
 	yarn?: PartialYarnConfig | null;
 }
 
+export interface PartialBinConfig {
+	bin?: string | null;
+	force?: boolean | null;
+	local?: boolean | null;
+	version?: string | null;
+}
+
+export type PartialBinEntry = string | PartialBinConfig;
+
 export interface PartialRustConfig {
-	bins?: string[] | null;
+	bins?: PartialBinEntry[] | null;
 	syncToolchainConfig?: boolean | null;
 	version?: string | null;
 }
@@ -126,8 +135,17 @@ export interface NodeConfig {
 	yarn: YarnConfig | null;
 }
 
+export interface BinConfig {
+	bin: string;
+	force: boolean;
+	local: boolean;
+	version: string | null;
+}
+
+export type BinEntry = string | BinConfig;
+
 export interface RustConfig {
-	bins: string[];
+	bins: BinEntry[];
 	syncToolchainConfig: boolean;
 	version: string | null;
 }

--- a/packages/types/src/toolchain-config.ts
+++ b/packages/types/src/toolchain-config.ts
@@ -2,7 +2,17 @@
 
 /* eslint-disable */
 
+export interface PartialBinConfig {
+	bin?: string | null;
+	force?: boolean | null;
+	local?: boolean | null;
+	name?: string | null;
+}
+
+export type PartialBinEntry = string | PartialBinConfig;
+
 export interface PartialDenoConfig {
+	bins?: PartialBinEntry[] | null;
 	/** @default 'deps.ts' */
 	depsFile?: string | null;
 	lockfile?: boolean | null;
@@ -57,15 +67,6 @@ export interface PartialNodeConfig {
 	yarn?: PartialYarnConfig | null;
 }
 
-export interface PartialBinConfig {
-	bin?: string | null;
-	force?: boolean | null;
-	local?: boolean | null;
-	version?: string | null;
-}
-
-export type PartialBinEntry = string | PartialBinConfig;
-
 export interface PartialRustConfig {
 	bins?: PartialBinEntry[] | null;
 	syncToolchainConfig?: boolean | null;
@@ -97,7 +98,17 @@ export interface PartialToolchainConfig {
 	typescript?: PartialTypeScriptConfig | null;
 }
 
+export interface BinConfig {
+	bin: string;
+	force: boolean;
+	local: boolean;
+	name: string | null;
+}
+
+export type BinEntry = string | BinConfig;
+
 export interface DenoConfig {
+	bins: BinEntry[];
 	/** @default 'deps.ts' */
 	depsFile: string;
 	lockfile: boolean;
@@ -134,15 +145,6 @@ export interface NodeConfig {
 	version: string | null;
 	yarn: YarnConfig | null;
 }
-
-export interface BinConfig {
-	bin: string;
-	force: boolean;
-	local: boolean;
-	version: string | null;
-}
-
-export type BinEntry = string | BinConfig;
 
 export interface RustConfig {
 	bins: BinEntry[];

--- a/website/docs/config/toolchain.mdx
+++ b/website/docs/config/toolchain.mdx
@@ -46,6 +46,26 @@ taking precedence over those defined in the extended configuration.
 
 Enables and configures [Deno](../guides/javascript/deno-handbook).
 
+### `bins`<VersionLabel version="1.10.0" />
+
+<HeadingApiLink to="/api/types/interface/DenoConfig#bins" />
+
+A list of binaries to install globally into Deno (`~/.deno/bin`). This setting requires a list of
+URLs or binary configuration objects with the following fields:
+
+- `bin` (required) - URL of the binary.
+- `name` - Provide a custom name for the binary.
+- `local` - Only install the binary locally, and not in CI.
+- `force` - Force install the binary. This _should_ be toggled for one-offs.
+
+```yaml title=".moon/toolchain.yml" {2-5}
+deno:
+  bins:
+    - 'https://deno.land/std@0.192.0/http/file_server.ts'
+    - bin: 'https://deno.land/std@0.192.0/http/file_server.ts'
+      name: 'fs'
+```
+
 ### `depsFile`
 
 <HeadingApiLink to="/api/types/interface/DenoConfig#depsFile" />
@@ -508,20 +528,28 @@ rust:
 
 > Version can also be defined with [`.prototools`](../proto/config).
 
-### `bins`
+### `bins`<VersionLabel version="1.10.0" updated />
 
 <HeadingApiLink to="/api/types/interface/RustConfig#bins" />
 
-A list of crates/binaries (with optional versions) to install into Cargo (`~/.cargo/bin`), and make
-them available to the `cargo` command. Binaries will be installed with
+A list of binaries (with optional versions) to install into Cargo (`~/.cargo/bin`), and make them
+available to the `cargo` command. Binaries will be installed with
 [`cargo-binstall`](https://crates.io/crates/cargo-binstall) in an effort to reduce build and
 compilation times.
 
-```yaml title=".moon/toolchain.yml" {2-4}
+This setting requires a list of package names or binary configuration objects with the following
+fields:
+
+- `bin` (required) - Name of the binary.
+- `local` - Only install the binary locally, and not in CI.
+- `force` - Force install the binary. This _should_ be toggled for one-offs.
+
+```yaml title=".moon/toolchain.yml" {2-5}
 rust:
   bins:
-    - 'cargo-make@0.35.0'
-    - 'cargo-nextest'
+    - 'cargo-nextest@0.9.52'
+    - bin: 'cargo-nextest'
+      local: true
 ```
 
 Binaries that have been installed into Cargo can be referenced from task commands:

--- a/website/static/schemas/toolchain.json
+++ b/website/static/schemas/toolchain.json
@@ -104,6 +104,64 @@
         "nvm"
       ]
     },
+    "PartialBinConfig": {
+      "title": "PartialBinConfig",
+      "type": "object",
+      "properties": {
+        "bin": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "force": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "local": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "PartialBinEntry": {
+      "title": "PartialBinEntry",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/PartialBinConfig"
+        }
+      ]
+    },
     "PartialDenoConfig": {
       "title": "PartialDenoConfig",
       "description": "Docs: https://moonrepo.dev/docs/config/toolchain#deno",
@@ -322,7 +380,7 @@
             {
               "type": "array",
               "items": {
-                "type": "string"
+                "$ref": "#/definitions/PartialBinEntry"
               }
             },
             {

--- a/website/static/schemas/toolchain.json
+++ b/website/static/schemas/toolchain.json
@@ -138,7 +138,7 @@
             }
           ]
         },
-        "version": {
+        "name": {
           "anyOf": [
             {
               "type": "string"
@@ -167,6 +167,19 @@
       "description": "Docs: https://moonrepo.dev/docs/config/toolchain#deno",
       "type": "object",
       "properties": {
+        "bins": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PartialBinEntry"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "depsFile": {
           "default": "deps.ts",
           "anyOf": [


### PR DESCRIPTION
This adds an object form for `rust.bins` and also adds `deno.bins` support.