### PR TITLE
new: Implement stricter dep/project graph rules.

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,4 +1,4 @@
-# Trigger CI: 18
+# Trigger CI: 19
 
 $schema: '../website/static/schemas/workspace.json'
 

--- a/crates/cli/tests/run_test.rs
+++ b/crates/cli/tests/run_test.rs
@@ -600,11 +600,11 @@ mod hashing {
         // Hashes change because `.moon/workspace.yml` is different from `walk_strategy`
         assert_eq!(
             hash_vcs,
-            "9ffd42e4882528bb44ae0cb5e7f705fa5aa40b81792c6f2b1010a3d977c2a43d"
+            "cfed7d902ce197ea76a924f31d513f741b7ac5e82d162c8a2a121756ec3c1b41"
         );
         assert_eq!(
             hash_glob,
-            "c6cb49b5ba54547f1735be77ebca2fdd7489dc6e727085ccd6027563e2cfe126"
+            "2722726fbc183ffdd19d648eedd76019f652f3206d6ebe1cb0ecaf8d15d0b5c9"
         );
     }
 }
@@ -809,10 +809,10 @@ mod outputs {
 
         moon_archive::untar(tarball, &dir, None).unwrap();
 
-        assert!(dir.join("outputs/build/one.js").exists());
-        assert!(dir.join("outputs/build/two.js").exists());
-        assert!(!dir.join("outputs/build/styles.css").exists());
-        assert!(!dir.join("outputs/build/image.png").exists());
+        assert!(dir.join("outputs/multiple-types/one.js").exists());
+        assert!(dir.join("outputs/multiple-types/two.js").exists());
+        assert!(!dir.join("outputs/multiple-types/styles.css").exists());
+        assert!(!dir.join("outputs/multiple-types/image.png").exists());
     }
 
     #[test]
@@ -835,8 +835,8 @@ mod outputs {
 
         assert!(dir.join("stdout.log").exists());
         assert!(dir.join("stderr.log").exists());
-        assert!(dir.join("outputs/lib/one.js").exists());
-        assert!(dir.join("outputs/esm/two.js").exists());
+        assert!(dir.join("outputs/both/a/one.js").exists());
+        assert!(dir.join("outputs/both/b/two.js").exists());
     }
 
     #[test]
@@ -859,8 +859,8 @@ mod outputs {
 
         assert!(dir.join("stdout.log").exists());
         assert!(dir.join("stderr.log").exists());
-        assert!(dir.join("lib/one.js").exists());
-        assert!(dir.join("esm/two.js").exists());
+        assert!(dir.join("both/a/one.js").exists());
+        assert!(dir.join("both/b/two.js").exists());
     }
 
     #[test]
@@ -960,19 +960,19 @@ mod outputs {
             });
 
             // Remove outputs
-            fs::remove_dir_all(sandbox.path().join("outputs/esm")).unwrap();
-            fs::remove_dir_all(sandbox.path().join("outputs/lib")).unwrap();
+            fs::remove_dir_all(sandbox.path().join("outputs/both/a")).unwrap();
+            fs::remove_dir_all(sandbox.path().join("outputs/both/b")).unwrap();
 
-            assert!(!sandbox.path().join("outputs/esm").exists());
-            assert!(!sandbox.path().join("outputs/lib").exists());
+            assert!(!sandbox.path().join("outputs/both/a").exists());
+            assert!(!sandbox.path().join("outputs/both/b").exists());
 
             sandbox.run_moon(|cmd| {
                 cmd.arg("run").arg("outputs:generateFileAndFolder");
             });
 
             // Outputs should come back
-            assert!(sandbox.path().join("outputs/esm").exists());
-            assert!(sandbox.path().join("outputs/lib").exists());
+            assert!(sandbox.path().join("outputs/both/a").exists());
+            assert!(sandbox.path().join("outputs/both/b").exists());
         }
 
         #[test]
@@ -985,7 +985,8 @@ mod outputs {
             });
 
             let hash1 = extract_hash_from_run(sandbox.path(), "outputs:generateFileAndFolder");
-            let contents1 = fs::read_to_string(sandbox.path().join("outputs/lib/one.js")).unwrap();
+            let contents1 =
+                fs::read_to_string(sandbox.path().join("outputs/both/a/one.js")).unwrap();
 
             // Create a file to trigger an inputs change
             sandbox.create_file("outputs/trigger.js", "");
@@ -995,18 +996,19 @@ mod outputs {
             });
 
             let hash2 = extract_hash_from_run(sandbox.path(), "outputs:generateFileAndFolder");
-            let contents2 = fs::read_to_string(sandbox.path().join("outputs/lib/one.js")).unwrap();
+            let contents2 =
+                fs::read_to_string(sandbox.path().join("outputs/both/a/one.js")).unwrap();
 
             // Hashes and contents should be different!
             assert_ne!(hash1, hash2);
             assert_ne!(contents1, contents2);
 
             // Remove outputs
-            fs::remove_dir_all(sandbox.path().join("outputs/esm")).unwrap();
-            fs::remove_dir_all(sandbox.path().join("outputs/lib")).unwrap();
+            fs::remove_dir_all(sandbox.path().join("outputs/both/a")).unwrap();
+            fs::remove_dir_all(sandbox.path().join("outputs/both/b")).unwrap();
 
-            assert!(!sandbox.path().join("outputs/esm").exists());
-            assert!(!sandbox.path().join("outputs/lib").exists());
+            assert!(!sandbox.path().join("outputs/both/a").exists());
+            assert!(!sandbox.path().join("outputs/both/b").exists());
 
             // Remove the trigger file
             fs::remove_file(sandbox.path().join("outputs/trigger.js")).unwrap();
@@ -1016,7 +1018,8 @@ mod outputs {
             });
 
             let hash3 = extract_hash_from_run(sandbox.path(), "outputs:generateFileAndFolder");
-            let contents3 = fs::read_to_string(sandbox.path().join("outputs/lib/one.js")).unwrap();
+            let contents3 =
+                fs::read_to_string(sandbox.path().join("outputs/both/a/one.js")).unwrap();
 
             // Hashes and contents should match the original!
             assert_eq!(hash1, hash3);
@@ -1024,8 +1027,8 @@ mod outputs {
             assert_ne!(contents2, contents3);
 
             // Outputs should come back
-            assert!(sandbox.path().join("outputs/esm").exists());
-            assert!(sandbox.path().join("outputs/lib").exists());
+            assert!(sandbox.path().join("outputs/both/a").exists());
+            assert!(sandbox.path().join("outputs/both/b").exists());
         }
     }
 

--- a/crates/cli/tests/snapshots/run_test__dependencies__changes_primary_hash_if_deps_hash_changes.snap
+++ b/crates/cli/tests/snapshots/run_test__dependencies__changes_primary_hash_if_deps_hash_changes.snap
@@ -3,8 +3,8 @@ source: crates/cli/tests/run_test.rs
 expression: "[h1, h2, extract_hash_from_run(sandbox.path(), \"outputs:asDep\"),\n        extract_hash_from_run(sandbox.path(), \"outputs:withDeps\")]"
 ---
 [
-    "7078862e6abb5e7546a71012976b2968c79736c3eafe7fba0407f1c8ebf4800d",
-    "23b532cbca388015cabc6de4785d3fb6fe336a4fdc683bf1fca963c9a96aed2c",
-    "0ad56f1d25a0db32119b3e18c7559ea0b8bbf0ee1b9ab3da147fdc39f1ad7b2d",
-    "ff35e266085f49966f9153970b0a6958123087751c371e1f782d6bffa9ba84c0",
+    "d60679e94de064abd8378dd564e83ffda2b223cb87d3cec82c75be0113c5cec6",
+    "9700588a327322748182268b87be585248c101c5dc1aa156a935681f008a3011",
+    "8c319282b2c9296f769c847bbb5adffdda522ec35df7e78450793f1166a49c35",
+    "abdd4d4ed7b2b0252f4bebc77340fa797c2f579e969d06e0143381e255727083",
 ]

--- a/crates/cli/tests/snapshots/run_test__dependencies__generates_unique_hashes_for_each_target.snap
+++ b/crates/cli/tests/snapshots/run_test__dependencies__generates_unique_hashes_for_each_target.snap
@@ -3,6 +3,6 @@ source: crates/cli/tests/run_test.rs
 expression: "[extract_hash_from_run(sandbox.path(), \"outputs:asDep\"),\n        extract_hash_from_run(sandbox.path(), \"outputs:withDeps\")]"
 ---
 [
-    "7078862e6abb5e7546a71012976b2968c79736c3eafe7fba0407f1c8ebf4800d",
-    "23b532cbca388015cabc6de4785d3fb6fe336a4fdc683bf1fca963c9a96aed2c",
+    "d60679e94de064abd8378dd564e83ffda2b223cb87d3cec82c75be0113c5cec6",
+    "9700588a327322748182268b87be585248c101c5dc1aa156a935681f008a3011",
 ]

--- a/crates/core/action-context/src/lib.rs
+++ b/crates/core/action-context/src/lib.rs
@@ -11,6 +11,21 @@ pub enum ProfileType {
     Heap,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "state", content = "hash", rename_all = "lowercase")]
+pub enum TargetState {
+    Completed(String),
+    Failed,
+    Skipped,
+    Passthrough,
+}
+
+impl TargetState {
+    pub fn is_complete(&self) -> bool {
+        matches!(self, TargetState::Completed(_) | TargetState::Passthrough)
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActionContext {
@@ -26,7 +41,7 @@ pub struct ActionContext {
 
     pub profile: Option<ProfileType>,
 
-    pub target_hashes: FxHashMap<Target, String>,
+    pub target_states: FxHashMap<Target, TargetState>,
 
     pub touched_files: FxHashSet<WorkspaceRelativePathBuf>,
 

--- a/crates/core/action-pipeline/src/pipeline.rs
+++ b/crates/core/action-pipeline/src/pipeline.rs
@@ -321,15 +321,14 @@ impl Pipeline {
 
         for result in results {
             let status = match result.status {
-                ActionStatus::Passed
-                | ActionStatus::Cached
-                | ActionStatus::CachedFromRemote
-                | ActionStatus::Skipped => color::success("pass"),
+                ActionStatus::Passed | ActionStatus::Cached | ActionStatus::CachedFromRemote => {
+                    color::success("pass")
+                }
                 ActionStatus::Failed | ActionStatus::FailedAndAbort => {
                     failed = true;
                     color::failure("fail")
                 }
-                ActionStatus::Invalid => color::invalid("warn"),
+                ActionStatus::Invalid | ActionStatus::Skipped => color::invalid("warn"),
                 _ => color::muted_light("oops"),
             };
 
@@ -366,6 +365,7 @@ impl Pipeline {
         let mut pass_count = 0;
         let mut fail_count = 0;
         let mut invalid_count = 0;
+        let mut skipped_count = 0;
 
         for result in results {
             if compact
@@ -382,7 +382,7 @@ impl Pipeline {
                     cached_count += 1;
                     pass_count += 1;
                 }
-                ActionStatus::Passed | ActionStatus::Skipped => {
+                ActionStatus::Passed => {
                     pass_count += 1;
                 }
                 ActionStatus::Failed | ActionStatus::FailedAndAbort => {
@@ -390,6 +390,9 @@ impl Pipeline {
                 }
                 ActionStatus::Invalid => {
                     invalid_count += 1;
+                }
+                ActionStatus::Skipped => {
+                    skipped_count += 1;
                 }
                 _ => {}
             }
@@ -413,6 +416,10 @@ impl Pipeline {
 
         if invalid_count > 0 {
             counts_message.push(color::invalid(format!("{invalid_count} invalid")));
+        }
+
+        if skipped_count > 0 {
+            counts_message.push(color::invalid(format!("{skipped_count} skipped")));
         }
 
         let term = Term::buffered_stdout();

--- a/crates/core/project-graph/src/errors.rs
+++ b/crates/core/project-graph/src/errors.rs
@@ -1,9 +1,21 @@
 use miette::Diagnostic;
+use moon_target::Target;
 use starbase_styles::{Style, Stylize};
 use thiserror::Error;
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum ProjectGraphError {
+    #[diagnostic(code(project_graph::task::overlapping_outputs))]
+    #[error(
+        "Tasks {} have configured the same output {}. Overlapping outputs is not supported as it can cause non-deterministic results.",
+        .targets.iter().map(|t| t.id.style(Style::Label)).collect::<Vec<_>>().join(", "),
+        .output.style(Style::File),
+    )]
+    OverlappingTaskOutputs {
+        output: String,
+        targets: Vec<Target>,
+    },
+
     #[diagnostic(code(project_graph::task_dep::persistent_requirement))]
     #[error(
         "Non-persistent task {} cannot depend on persistent task {}.\nA task is marked persistent with the {} or {} settings.\n\nIf you're looking to avoid the cache, disable {} instead.",

--- a/crates/core/project-graph/tests/projects_test.rs
+++ b/crates/core/project-graph/tests/projects_test.rs
@@ -1436,13 +1436,13 @@ mod task_expansion {
 
             assert!(task
                 .output_paths
-                .contains(&WorkspaceRelativePathBuf::from(&project.source).join("dir")));
+                .contains(&WorkspaceRelativePathBuf::from(&project.source).join("path")));
 
             let task = project.get_task("outputsGlobs").unwrap();
 
             assert!(task
                 .output_globs
-                .contains(&WorkspaceRelativePathBuf::from(&project.source).join("dir/**/*.js")));
+                .contains(&WorkspaceRelativePathBuf::from(&project.source).join("glob/**/*.js")));
         }
 
         #[tokio::test]

--- a/crates/core/runner/src/target_hasher.rs
+++ b/crates/core/runner/src/target_hasher.rs
@@ -110,7 +110,17 @@ impl TargetHasher {
             self.deps.insert(
                 dep.id.to_owned(),
                 match hashes.get(dep) {
-                    Some(hash) => hash.to_owned(),
+                    Some(hash) => {
+                        if hash == "failed" || hash == "skipped" {
+                            return Err(RunnerError::MissingDependencyHash(
+                                dep.id.to_owned(),
+                                task.target.id.to_owned(),
+                            )
+                            .into());
+                        }
+
+                        hash.to_owned()
+                    }
                     None => {
                         return Err(RunnerError::MissingDependencyHash(
                             dep.id.to_owned(),

--- a/crates/core/runner/tests/inputs_collector_test.rs
+++ b/crates/core/runner/tests/inputs_collector_test.rs
@@ -3,8 +3,8 @@ use moon_config::{HasherWalkStrategy, WorkspaceConfig};
 use moon_runner::inputs_collector::collect_and_hash_inputs;
 use moon_test_utils::{create_sandbox_with_config, get_cases_fixture_configs, Sandbox};
 use moon_vcs::{BoxedVcs, Git};
-use std::fs;
 use std::path::Path;
+use std::{env, fs};
 
 fn cases_sandbox() -> Sandbox {
     let (workspace_config, toolchain_config, tasks_config) = get_cases_fixture_configs();
@@ -40,6 +40,8 @@ fn load_vcs(workspace_root: &Path, workspace_config: &WorkspaceConfig) -> BoxedV
 
 #[tokio::test]
 async fn filters_using_input_globs() {
+    env::set_var("MOON_DISABLE_OVERLAPPING_OUTPUTS", "true");
+
     let sandbox = cases_sandbox();
     sandbox.enable_git();
 
@@ -48,6 +50,8 @@ async fn filters_using_input_globs() {
     let vcs = load_vcs(&workspace.root, &workspace.config);
 
     let project = project_graph.get("outputsFiltering").unwrap();
+
+    env::remove_var("MOON_DISABLE_OVERLAPPING_OUTPUTS");
 
     create_out_files(&project.root);
 
@@ -105,6 +109,8 @@ async fn filters_using_input_globs() {
 
 #[tokio::test]
 async fn filters_using_input_globs_in_glob_mode() {
+    env::set_var("MOON_DISABLE_OVERLAPPING_OUTPUTS", "true");
+
     let sandbox = cases_sandbox();
     sandbox.enable_git();
 
@@ -113,6 +119,8 @@ async fn filters_using_input_globs_in_glob_mode() {
     let vcs = load_vcs(&workspace.root, &workspace.config);
 
     workspace.config.hasher.walk_strategy = HasherWalkStrategy::Glob;
+
+    env::remove_var("MOON_DISABLE_OVERLAPPING_OUTPUTS");
 
     let project = project_graph.get("outputsFiltering").unwrap();
 
@@ -172,12 +180,16 @@ async fn filters_using_input_globs_in_glob_mode() {
 
 #[tokio::test]
 async fn filters_using_input_files() {
+    env::set_var("MOON_DISABLE_OVERLAPPING_OUTPUTS", "true");
+
     let sandbox = cases_sandbox();
     sandbox.enable_git();
 
     let mut workspace = load_workspace_from(sandbox.path()).await.unwrap();
     let project_graph = generate_project_graph(&mut workspace).await.unwrap();
     let vcs = load_vcs(&workspace.root, &workspace.config);
+
+    env::remove_var("MOON_DISABLE_OVERLAPPING_OUTPUTS");
 
     let project = project_graph.get("outputsFiltering").unwrap();
 
@@ -236,6 +248,8 @@ async fn filters_using_input_files() {
 
 #[tokio::test]
 async fn filters_using_input_files_in_glob_mode() {
+    env::set_var("MOON_DISABLE_OVERLAPPING_OUTPUTS", "true");
+
     let sandbox = cases_sandbox();
     sandbox.enable_git();
 
@@ -244,6 +258,8 @@ async fn filters_using_input_files_in_glob_mode() {
     let vcs = load_vcs(&workspace.root, &workspace.config);
 
     workspace.config.hasher.walk_strategy = HasherWalkStrategy::Glob;
+
+    env::remove_var("MOON_DISABLE_OVERLAPPING_OUTPUTS");
 
     let project = project_graph.get("outputsFiltering").unwrap();
 

--- a/crates/core/test-utils/src/cli.rs
+++ b/crates/core/test-utils/src/cli.rs
@@ -18,6 +18,8 @@ pub fn create_moon_command<T: AsRef<Path>>(path: T) -> assert_cmd::Command {
     // Enable logging for code coverage
     cmd.env("MOON_LOG", "trace");
     cmd.env("PROTO_LOG", "trace");
+    // Feature flags
+    // cmd.env("MOON_DISABLE_OVERLAPPING_OUTPUTS", "true");
     cmd
 }
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - Tasks that configure the same outputs will now error. This change was made as multiple tasks
   writing to the same output location will cause caching and hydration issues.
+- If a dependency of a task failed to run or was skipped, then the parent task will now be skipped.
+  This primarily applies to `moon ci`.
 
 #### 🚀 Updates
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+#### 💥 Breaking
+
+> These changes are fixing edge cases that should not have been allowed, but may break existing
+> repos. If these changes become troublesome, we'll revert.
+
+- Tasks that configure the same outputs will now error. This change was made as multiple tasks
+  writing to the same output location will cause caching and hydration issues.
+
 #### 🚀 Updates
 
 - Added support for `MOON_BASE` and `MOON_HEAD` environment variables.

--- a/packages/report/tests/report.test.ts
+++ b/packages/report/tests/report.test.ts
@@ -72,7 +72,7 @@ function mockReport(): RunReport {
 			passthroughArgs: [],
 			primaryTargets: [],
 			profile: null,
-			targetHashes: {},
+			targetStates: {},
 			touchedFiles: [],
 			workspaceRoot: '',
 		},

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -8,6 +8,6 @@ export interface Duration {
 }
 
 export interface Runtime {
-	platform: Capitalize<PlatformType>;
+	plaform: Capitalize<PlatformType>;
 	version?: string;
 }

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -8,6 +8,6 @@ export interface Duration {
 }
 
 export interface Runtime {
-	plaform: Capitalize<PlatformType>;
+	platform: Capitalize<PlatfomType>;
 	version?: string;
 }

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -8,6 +8,6 @@ export interface Duration {
 }
 
 export interface Runtime {
-	platform: Capitalize<PlatfomType>;
+	platform: Capitalize<PlatformType>;
 	version?: string;
 }

--- a/packages/types/src/pipeline.ts
+++ b/packages/types/src/pipeline.ts
@@ -31,6 +31,11 @@ export interface Action {
 	status: ActionStatus;
 }
 
+export interface TargetState {
+	state: 'completed' | 'failed' | 'passthrough' | 'skipped';
+	hash?: string;
+}
+
 export interface ActionContext {
 	affectedOnly: boolean;
 	initialTargets: string[];
@@ -38,7 +43,7 @@ export interface ActionContext {
 	passthroughArgs: string[];
 	primaryTargets: string[];
 	profile: 'cpu' | 'heap' | null;
-	targetHashes: Record<string, string>;
+	targetStates: Record<string, TargetState>;
 	touchedFiles: string[];
 	workspaceRoot: string;
 }

--- a/tests/fixtures/cases/outputs/generate.js
+++ b/tests/fixtures/cases/outputs/generate.js
@@ -5,7 +5,7 @@ const type = process.argv[2];
 const inWorkspace = process.argv.includes('--workspace');
 
 function createFile(file, content) {
-	const filePath = path.join(inWorkspace ? process.env.MOON_WORKSPACE_ROOT : __dirname, file);
+	const filePath = path.join(inWorkspace ? process.env.MOON_WORKSPACE_ROOT : __dirname, type, file);
 
 	fs.mkdirSync(path.dirname(filePath), { recursive: true });
 	fs.writeFileSync(filePath, content ?? String(Date.now()), 'utf8');
@@ -13,23 +13,23 @@ function createFile(file, content) {
 
 switch (type) {
 	case 'single-file':
-		createFile('lib/one.js');
+		createFile('one.js');
 		break;
 	case 'single-folder':
 	case 'multiple-files':
-		createFile('lib/one.js');
-		createFile('lib/two.js');
+		createFile('one.js');
+		createFile('two.js');
 		break;
 	case 'multiple-folders':
 	case 'both':
-		createFile('lib/one.js');
-		createFile('esm/two.js');
+		createFile('a/one.js');
+		createFile('b/two.js');
 		break;
 	case 'multiple-types':
-		createFile('build/one.js');
-		createFile('build/two.js');
-		createFile('build/styles.css');
-		createFile('build/image.png');
+		createFile('one.js');
+		createFile('two.js');
+		createFile('styles.css');
+		createFile('image.png');
 		break;
 	case 'custom':
 		createFile(process.argv[3], 'fixed content');

--- a/tests/fixtures/cases/outputs/moon.yml
+++ b/tests/fixtures/cases/outputs/moon.yml
@@ -7,60 +7,60 @@ tasks:
     inputs:
       - '*.js'
     outputs:
-      - 'lib/one.js'
+      - 'single-file/one.js'
   generateFiles:
     command: node
     args: generate.js multiple-files
     inputs:
       - '*.js'
     outputs:
-      - 'lib/one.js'
-      - 'lib/two.js'
+      - 'multiple-files/one.js'
+      - 'multiple-files/two.js'
   generateFolder:
     command: node
     args: generate.js single-folder
     inputs:
       - '*.js'
     outputs:
-      - 'lib'
+      - 'single-folder'
   generateFolders:
     command: node
     args: generate.js multiple-folders
     inputs:
       - '*.js'
     outputs:
-      - 'lib'
-      - 'esm'
+      - 'multiple-folders/a'
+      - 'multiple-folders/b'
   generateFileAndFolder:
     command: node
     args: generate.js both
     inputs:
       - '*.js'
     outputs:
-      - 'lib/one.js'
-      - 'esm'
+      - 'both/a/one.js'
+      - 'both/b'
   generateFileAndFolderWorkspace:
     command: node
     args: generate.js both --workspace
     inputs:
       - '*.js'
     outputs:
-      - '/lib/one.js'
-      - '/esm'
+      - '/both/a/one.js'
+      - '/both/b'
   generateFixed:
     command: node
-    args: generate.js custom test.mjs
+    args: generate.js custom test.cjs
     inputs:
       - '*.js'
     outputs:
-      - 'test.mjs'
+      - 'custom/test.cjs'
   generateFileTypes:
     command: node
     args: generate.js multiple-types
     inputs:
       - '*.js'
     outputs:
-      - 'build/*.js'
+      - 'multiple-types/*.js'
 
   # Dependency hashing
   asDep:
@@ -69,7 +69,7 @@ tasks:
     inputs:
       - '*.js'
     outputs:
-      - 'test.js'
+      - 'custom/test.js'
   withDeps:
     command: node
     args: generate.js custom test.mjs
@@ -78,7 +78,7 @@ tasks:
     inputs:
       - '*.mjs'
     outputs:
-      - 'test.mjs'
+      - 'custom/test.mjs'
 
   # Other cases
   noCache:
@@ -87,8 +87,7 @@ tasks:
     inputs:
       - '*.js'
     outputs:
-      - 'lib/one.js'
-      - 'esm'
+      - 'both/**/*'
     options:
       cache: false
   missingOutput:

--- a/tests/fixtures/tasks/tokens/moon.yml
+++ b/tests/fixtures/tasks/tokens/moon.yml
@@ -64,10 +64,10 @@ tasks:
       - 'file.$projectType'
   outputs:
     outputs:
-      - 'dir'
+      - 'path'
   outputsGlobs:
     outputs:
-      - 'dir/**/*.js'
+      - 'glob/**/*.js'
   outputsFileGroups:
     outputs:
       - 'file.ts'


### PR DESCRIPTION
This fixes a few edge cases:

- Tasks writing to the same output location is no longer allowed.
- Task shouldn't run if one of it's deps failed.