### PR TITLE
fix: Fix git hashing from sub-directories.

### DIFF
--- a/.yarn/versions/ae826143.yml
+++ b/.yarn/versions/ae826143.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/cli/tests/misc_test.rs
+++ b/crates/cli/tests/misc_test.rs
@@ -16,5 +16,5 @@ fn fails_on_version_constraint() {
 
     assert
         .failure()
-        .stderr(predicate::str::contains("expected >=1000.0.0"));
+        .stderr(predicate::str::contains(">=1000.0.0"));
 }

--- a/crates/core/project-graph/src/helpers.rs
+++ b/crates/core/project-graph/src/helpers.rs
@@ -55,7 +55,7 @@ pub fn detect_projects_with_globs(
             }
 
             if let Some(vcs) = vcs {
-                if vcs.is_ignored(&project_source) {
+                if vcs.is_ignored(&project_root) {
                     debug!(
                         target: "moon:project",
                         "Found a project with source {}, but this path has been ignored by your VCS. Skipping ignored source.",

--- a/nextgen/vcs/src/git.rs
+++ b/nextgen/vcs/src/git.rs
@@ -228,7 +228,9 @@ impl Vcs for Git {
             let abs_file = self.process.root.join(file);
 
             // File must exist or git fails
-            if abs_file.exists() && abs_file.is_file() && (allow_ignored || !self.is_ignored(file))
+            if abs_file.exists()
+                && abs_file.is_file()
+                && (allow_ignored || !self.is_ignored(&abs_file))
             {
                 objects.push(file.to_owned());
             }
@@ -555,7 +557,7 @@ impl Vcs for Git {
         self.repository_root.join(".git").exists()
     }
 
-    fn is_ignored(&self, file: &str) -> bool {
+    fn is_ignored(&self, file: &Path) -> bool {
         if let Some(ignore) = &self.ignore {
             ignore.matched(file, false).is_ignore()
         } else {

--- a/nextgen/vcs/src/git.rs
+++ b/nextgen/vcs/src/git.rs
@@ -3,8 +3,8 @@ use crate::touched_files::TouchedFiles;
 use crate::vcs::Vcs;
 use async_trait::async_trait;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use miette::Diagnostic;
-use moon_common::path::WorkspaceRelativePathBuf;
+use miette::{Diagnostic, IntoDiagnostic};
+use moon_common::path::{RelativePathBuf, WorkspaceRelativePathBuf};
 use moon_common::{Style, Stylize};
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -71,7 +71,7 @@ pub struct Git {
     pub default_branch: String,
 
     /// Path between the git and workspace root.
-    // file_prefix: RelativePathBuf,
+    root_prefix: RelativePathBuf,
 
     /// Ignore rules derived from a root `.gitignore` file.
     ignore: Option<Gitignore>,
@@ -152,10 +152,16 @@ impl Git {
 
         Ok(Git {
             default_branch: default_branch.as_ref().to_owned(),
-            repository_root: git_root.to_owned(),
             ignore,
-            process: ProcessCache::new("git", workspace_root),
             remote_candidates: remote_candidates.to_owned(),
+            root_prefix: if git_root == workspace_root {
+                RelativePathBuf::default()
+            } else {
+                RelativePathBuf::from_path(workspace_root.strip_prefix(git_root).unwrap())
+                    .into_diagnostic()?
+            },
+            process: ProcessCache::new("git", workspace_root),
+            repository_root: git_root.to_owned(),
         })
     }
 
@@ -217,12 +223,13 @@ impl Vcs for Git {
 
     async fn get_file_hashes(
         &self,
-        files: &[String],
+        files: &[String], // Workspace relative
         allow_ignored: bool,
         batch_size: u16,
     ) -> miette::Result<BTreeMap<WorkspaceRelativePathBuf, String>> {
         let mut objects = vec![];
         let mut map = BTreeMap::new();
+        let is_not_root = self.process.root != self.repository_root;
 
         for file in files {
             let abs_file = self.process.root.join(file);
@@ -232,7 +239,14 @@ impl Vcs for Git {
                 && abs_file.is_file()
                 && (allow_ignored || !self.is_ignored(&abs_file))
             {
-                objects.push(file.to_owned());
+                // When moon is setup in a sub-folder and not the git root,
+                // we need to prefix the paths because `--stdin-paths` assumes
+                // the paths are from the git root and don't work correctly...
+                if is_not_root {
+                    objects.push(self.root_prefix.join(file).as_str().to_owned());
+                } else {
+                    objects.push(file.to_owned());
+                }
             }
         }
 
@@ -260,7 +274,14 @@ impl Vcs for Git {
 
             for (i, hash) in output.split('\n').enumerate() {
                 if !hash.is_empty() {
-                    map.insert(WorkspaceRelativePathBuf::from(&slice[i]), hash.to_owned());
+                    let mut file = WorkspaceRelativePathBuf::from(&slice[i]);
+
+                    // Convert the prefixed path back to a workspace relative one...
+                    if is_not_root {
+                        file = file.strip_prefix(&self.root_prefix).unwrap().to_owned();
+                    }
+
+                    map.insert(file, hash.to_owned());
                 }
             }
 

--- a/nextgen/vcs/src/vcs.rs
+++ b/nextgen/vcs/src/vcs.rs
@@ -4,7 +4,7 @@ use moon_common::path::WorkspaceRelativePathBuf;
 use semver::{Version, VersionReq};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[async_trait]
 pub trait Vcs: Debug {
@@ -68,7 +68,7 @@ pub trait Vcs: Debug {
     fn is_enabled(&self) -> bool;
 
     /// Return true if the provided file path has been ignored.
-    fn is_ignored(&self, file: &str) -> bool;
+    fn is_ignored(&self, file: &Path) -> bool;
 
     /// Return true if the current binary version matches the provided requirement.
     async fn is_version_supported(&self, req: &str) -> miette::Result<bool> {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where `.gitignore` patterns weren't always applied correctly.
+
 ## 1.10.0
 
 #### 💥 Breaking

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### 🐞 Fixes
 
 - Fixed an issue where `.gitignore` patterns weren't always applied correctly.
+- Fixed an issue where `git hash-object` commands would fail if moon was setup in a sub-directory.
 
 ## 1.10.0
 


### PR DESCRIPTION
Fixes https://github.com/moonrepo/moon/issues/966

Looks like `--stdin-paths` requires paths from the git root, and not relative from the working directory.