### PR TITLE
fix: support new panic message format in rust 1.73

### DIFF
--- a/crates/cli/tests/run_rust_test.rs
+++ b/crates/cli/tests/run_rust_test.rs
@@ -73,7 +73,11 @@ fn handles_panic() {
 
     let output = assert.output();
 
-    assert!(predicate::str::contains("thread 'main' panicked at 'Oops'").eval(&output));
+    assert!(
+        predicate::str::is_match("thread 'main' panicked at(?s:.)*Oops")
+            .unwrap()
+            .eval(&output)
+    );
 }
 
 #[test]


### PR DESCRIPTION
Adds support for the new default panic handler message format landing in rust 1.73. rust-lang/rust#112849
