### PR TITLE
internal: Use new relative path methods.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3325,7 +3325,6 @@ dependencies = [
  "moon_common",
  "moon_config",
  "once_cell",
- "pathdiff",
  "regex",
  "starbase_sandbox",
  "starbase_utils",
@@ -3809,7 +3808,6 @@ dependencies = [
  "moon_task_builder",
  "moon_vcs",
  "once_map",
- "pathdiff",
  "petgraph",
  "rustc-hash",
  "serde",
@@ -5075,9 +5073,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "relative-path"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
+checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ petgraph = { version = "0.6.3", default-features = false, features = [
 	"serde-1",
 ] }
 proto_cli = "0.13.1"
-relative-path = { version = "1.8.0", features = ["serde"] }
+relative-path = { version = "1.9.0", features = ["serde"] }
 regex = "1.9.3"
 # We don't use openssl but its required for musl builds
 reqwest = { version = "0.11.18", default-features = false, features = [

--- a/crates/cli/tests/snapshots/generate_test__supports_custom_filters.snap
+++ b/crates/cli/tests/snapshots/generate_test__supports_custom_filters.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/cli/tests/generate_test.rs
-expression: "fs::read_to_string(sandbox.path().join(\"./test/filters.txt\")).unwrap()"
+expression: standardize_separators(content)
 ---
 STRINGS:
 
@@ -22,7 +22,7 @@ to_up = ../../../../foo/bar
 to_down = ../../foo/bar
 to_down_norel = ../../foo/bar
 
-from_up = some/dir
+from_up = .
 from_down = ../dir
 from_down_norel = ../../some/dir
 

--- a/crates/core/runner/tests/inputs_collector_test.rs
+++ b/crates/core/runner/tests/inputs_collector_test.rs
@@ -251,8 +251,6 @@ async fn filters_using_input_files() {
 
 #[tokio::test]
 async fn filters_using_input_files_in_glob_mode() {
-    dbg!("ENV VAR");
-
     let sandbox = cases_sandbox();
     sandbox.enable_git();
 

--- a/nextgen/codegen/Cargo.toml
+++ b/nextgen/codegen/Cargo.toml
@@ -9,7 +9,6 @@ moon_config = { path = "../config" }
 convert_case = "0.6.0"
 miette = { workspace = true }
 once_cell = { workspace = true }
-pathdiff = { workspace = true }
 regex = { workspace = true }
 starbase_utils = { workspace = true }
 tera = { workspace = true }

--- a/nextgen/common/src/path.rs
+++ b/nextgen/common/src/path.rs
@@ -1,4 +1,4 @@
-pub use relative_path::{RelativePath, RelativePathBuf};
+pub use relative_path::*;
 use starbase_styles::color;
 use std::path::Path;
 

--- a/nextgen/project-graph/Cargo.toml
+++ b/nextgen/project-graph/Cargo.toml
@@ -18,7 +18,6 @@ moon_vcs = { path = "../vcs" }
 async-recursion = "1.0.4"
 miette = { workspace = true }
 once_map = { workspace = true }
-pathdiff = { workspace = true }
 petgraph = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }

--- a/nextgen/project-graph/src/project_graph.rs
+++ b/nextgen/project-graph/src/project_graph.rs
@@ -1,13 +1,12 @@
 use crate::project_graph_error::ProjectGraphError;
 use miette::IntoDiagnostic;
-use moon_common::path::WorkspaceRelativePathBuf;
+use moon_common::path::{PathExt, WorkspaceRelativePathBuf};
 use moon_common::{color, Id};
 use moon_config::DependencyScope;
 use moon_project::Project;
 use moon_project_expander::{ExpanderContext, ExpansionBoundaries, ProjectExpander};
 use moon_query::{build_query, Criteria, Queryable};
 use once_map::OnceMap;
-use pathdiff::diff_paths;
 use petgraph::dot::{Config, Dot};
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::EdgeRef;
@@ -168,7 +167,7 @@ impl ProjectGraph {
                 continue;
             }
 
-            if let Some(diff) = diff_paths(file, node.source.as_str()) {
+            if let Ok(diff) = file.relative_to(node.source.as_str()) {
                 let diff_comps = diff.components().count();
 
                 // Exact match, abort


### PR DESCRIPTION
These are available now in relative-path 1.9.