### PR TITLE
fix: Allow non-yaml files in `.moon/tasks`.

### DIFF
--- a/.yarn/versions/8dfb2dc3.yml
+++ b/.yarn/versions/8dfb2dc3.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/nextgen/config/src/inherited_tasks_config.rs
+++ b/nextgen/config/src/inherited_tasks_config.rs
@@ -289,11 +289,18 @@ fn load_dir(
             })?;
 
         if file_type.is_file() {
-            manager.add_config(
-                workspace_root,
-                &path,
-                InheritedTasksConfig::load_partial(workspace_root, &path)?,
-            );
+            // Non-yaml files may be located in these folders,
+            // so avoid failing when trying to parse it as a config
+            if path
+                .extension()
+                .is_some_and(|ext| ext == "yml" || ext == "yaml")
+            {
+                manager.add_config(
+                    workspace_root,
+                    &path,
+                    InheritedTasksConfig::load_partial(workspace_root, &path)?,
+                );
+            }
         } else if file_type.is_dir() {
             load_dir(manager, workspace_root, &path)?;
         }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,12 @@
   - More accurately monitors signals (ctrl+c) and shutdowns.
   - Tasks can now be configured with a timeout.
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where non-YAML files in `.moon/tasks` would be parsed as YAML configs.
+
 ## 1.14.1
 
 #### 🐞 Fixes


### PR DESCRIPTION
Fixes https://github.com/moonrepo/moon/issues/1077