### PR TITLE
fix: Include args when generating Git hooks.

### DIFF
--- a/crates/core/moon/src/lib.rs
+++ b/crates/core/moon/src/lib.rs
@@ -44,7 +44,7 @@ pub async fn load_workspace() -> miette::Result<Workspace> {
     if !is_test_env() {
         if workspace.vcs.is_enabled() {
             if let Ok(slug) = workspace.vcs.get_repository_slug().await {
-                env::set_var("MOON_REPO_SLUG", slug);
+                env::set_var("MOONBASE_REPO_SLUG", slug);
             }
         }
 

--- a/nextgen/api/src/launchpad.rs
+++ b/nextgen/api/src/launchpad.rs
@@ -48,7 +48,6 @@ fn create_anonymous_rid(workspace_root: &Path) -> String {
         "{:x}",
         md5::compute(
             env::var("MOONBASE_REPO_SLUG")
-                .or_else(|_| env::var("MOON_REPO_SLUG"))
                 .unwrap_or_else(|_| fs::file_name(workspace_root)),
         )
     )

--- a/nextgen/api/src/launchpad.rs
+++ b/nextgen/api/src/launchpad.rs
@@ -47,8 +47,7 @@ fn create_anonymous_rid(workspace_root: &Path) -> String {
     format!(
         "{:x}",
         md5::compute(
-            env::var("MOONBASE_REPO_SLUG")
-                .unwrap_or_else(|_| fs::file_name(workspace_root)),
+            env::var("MOONBASE_REPO_SLUG").unwrap_or_else(|_| fs::file_name(workspace_root)),
         )
     )
 }

--- a/nextgen/vcs-hooks/src/hooks_generator.rs
+++ b/nextgen/vcs-hooks/src/hooks_generator.rs
@@ -141,7 +141,7 @@ impl<'app> HooksGenerator<'app> {
                 self.create_file(
                     &external_path,
                     format!(
-                        "#!/bin/sh\n{} -NoProfile -ExecutionPolicy Bypass -File '{}'",
+                        "#!/bin/sh\n{} -NoProfile -ExecutionPolicy Bypass -File \"{} $1 $2 $3\"",
                         powershell_exe, external_command
                     ),
                 )?;
@@ -151,7 +151,11 @@ impl<'app> HooksGenerator<'app> {
             #[cfg(not(windows))]
             {
                 // pre-commit
-                self.create_hook_file(&external_path, &[external_command], false)?;
+                self.create_hook_file(
+                    &external_path,
+                    &[format!("{} $1 $2 $3", external_command)],
+                    false,
+                )?;
             }
         }
 

--- a/nextgen/vcs-hooks/tests/snapshots/hooks_generator_test__unix__links_git_hooks-2.snap
+++ b/nextgen/vcs-hooks/tests/snapshots/hooks_generator_test__unix__links_git_hooks-2.snap
@@ -5,4 +5,4 @@ expression: "fs::read_to_string(post_push).unwrap()"
 #!/usr/bin/env bash
 set -eo pipefail
 
-./.moon/hooks/post-push.sh
+./.moon/hooks/post-push.sh $1 $2 $3

--- a/nextgen/vcs-hooks/tests/snapshots/hooks_generator_test__unix__links_git_hooks.snap
+++ b/nextgen/vcs-hooks/tests/snapshots/hooks_generator_test__unix__links_git_hooks.snap
@@ -5,4 +5,4 @@ expression: "fs::read_to_string(pre_commit).unwrap()"
 #!/usr/bin/env bash
 set -eo pipefail
 
-./.moon/hooks/pre-commit.sh
+./.moon/hooks/pre-commit.sh $1 $2 $3

--- a/nextgen/vcs-hooks/tests/snapshots/hooks_generator_test__windows__links_git_hooks-2.snap
+++ b/nextgen/vcs-hooks/tests/snapshots/hooks_generator_test__windows__links_git_hooks-2.snap
@@ -3,4 +3,4 @@ source: nextgen/vcs-hooks/tests/hooks_generator_test.rs
 expression: "out2.replace(\"powershell.exe\", \"pwsh.exe\")"
 ---
 #!/bin/sh
-pwsh.exe -NoProfile -ExecutionPolicy Bypass -File '.\.moon\hooks\post-push.ps1'
+pwsh.exe -NoProfile -ExecutionPolicy Bypass -File ".\.moon\hooks\post-push.ps1 $1 $2 $3"

--- a/nextgen/vcs-hooks/tests/snapshots/hooks_generator_test__windows__links_git_hooks.snap
+++ b/nextgen/vcs-hooks/tests/snapshots/hooks_generator_test__windows__links_git_hooks.snap
@@ -3,4 +3,4 @@ source: nextgen/vcs-hooks/tests/hooks_generator_test.rs
 expression: "out1.replace(\"powershell.exe\", \"pwsh.exe\")"
 ---
 #!/bin/sh
-pwsh.exe -NoProfile -ExecutionPolicy Bypass -File '.\.moon\hooks\pre-commit.ps1'
+pwsh.exe -NoProfile -ExecutionPolicy Bypass -File ".\.moon\hooks\pre-commit.ps1 $1 $2 $3"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -15,6 +15,8 @@
 #### 🐞 Fixes
 
 - Fixed an issue where non-YAML files in `.moon/tasks` would be parsed as YAML configs.
+- Fixed an issue where arguments were not passed to generated Git hooks.
+- Fixed an issue where moonbase would fail to sign in in CI.
 
 ## 1.14.1
 


### PR DESCRIPTION
Fixes https://github.com/moonrepo/moon/issues/1078

According to https://git-scm.com/docs/githooks the most args a hook can receive is 3, so passing all 3 to every hook. I tested this locally and its fine, they just are undefined.