### PR TITLE
fix: Fix upper/lower case for codegen.

### DIFF
--- a/nextgen/codegen/src/filters.rs
+++ b/nextgen/codegen/src/filters.rs
@@ -41,11 +41,15 @@ pub fn upper_snake_case(value: &Value, _: &HashMap<String, Value>) -> Result<Val
 }
 
 pub fn lower_case(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    to_case("lower_case", Case::Lower, value)
+    let s = try_get_value!("lower_case", "value", String, value);
+
+    Ok(to_value(s.to_lowercase()).unwrap())
 }
 
 pub fn upper_case(value: &Value, _: &HashMap<String, Value>) -> Result<Value> {
-    to_case("upper_case", Case::Upper, value)
+    let s = try_get_value!("upper_case", "value", String, value);
+
+    Ok(to_value(s.to_uppercase()).unwrap())
 }
 
 // PATHS

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### 🐞 Fixes
 
 - Fixed some `PATH` inconsistencies when executing npm/pnpm/yarn binaries.
+- Fixed codegen `lower_case` and `upper_case` stripping characters.
 
 ## 1.14.3
 


### PR DESCRIPTION
The casing functions would remove chars like `-` since it tries to convert it. This is unexpected.