### PR TITLE
fix: Don't auto-link dependency when a root-level project.

### DIFF
--- a/.yarn/versions/5f1de95c.yml
+++ b/.yarn/versions/5f1de95c.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/node/platform/src/actions/sync_project.rs
+++ b/crates/node/platform/src/actions/sync_project.rs
@@ -66,9 +66,8 @@ pub async fn sync_project(
                     };
 
                     match dep_cfg.scope {
-                        DependencyScope::Build => {
+                        DependencyScope::Build | DependencyScope::Root => {
                             // Not supported by Node.js
-                            unimplemented!();
                         }
                         DependencyScope::Production => {
                             package_prod_deps.insert(dep_package_name.to_owned(), dep_version);

--- a/crates/node/platform/src/actions/sync_project.rs
+++ b/crates/node/platform/src/actions/sync_project.rs
@@ -35,6 +35,10 @@ pub async fn sync_project(
             continue;
         };
 
+        if dep_project.is_root_level() || matches!(dep_cfg.scope, DependencyScope::Root) {
+            continue;
+        }
+
         let dep_relative_path =
             path::relative_from(&dep_project.root, &project.root).unwrap_or_default();
         let is_dep_typescript_enabled = dep_project.config.toolchain.is_typescript_enabled();

--- a/nextgen/config/src/project/dep_config.rs
+++ b/nextgen/config/src/project/dep_config.rs
@@ -10,7 +10,7 @@ derive_enum!(
         #[default]
         Production,
 
-        // Special case when dependening on the root-level project
+        // Special case when depending on the root-level project
         Root,
     }
 );

--- a/nextgen/config/src/project/dep_config.rs
+++ b/nextgen/config/src/project/dep_config.rs
@@ -9,6 +9,9 @@ derive_enum!(
         Peer,
         #[default]
         Production,
+
+        // Special case when dependening on the root-level project
+        Root,
     }
 );
 

--- a/nextgen/project-builder/src/project_builder.rs
+++ b/nextgen/project-builder/src/project_builder.rs
@@ -27,7 +27,7 @@ impl Event for DetectLanguageEvent {
 pub struct ProjectBuilderContext<'app> {
     pub detect_language: &'app Emitter<DetectLanguageEvent>,
     pub detect_platform: &'app Emitter<DetectPlatformEvent>,
-    pub root_id: Option<&'app Id>,
+    pub root_project_id: Option<&'app Id>,
     pub toolchain_config: &'app ToolchainConfig,
     pub workspace_root: &'app Path,
 }
@@ -269,7 +269,7 @@ impl<'app> ProjectBuilder<'app> {
                         dep_id.to_owned(),
                         DependencyConfig {
                             id: dep_id.to_owned(),
-                            scope: if self.context.root_id.is_some_and(|r| r == dep_id) {
+                            scope: if self.context.root_project_id.is_some_and(|id| id == dep_id) {
                                 DependencyScope::Root
                             } else {
                                 DependencyScope::Peer

--- a/nextgen/project-builder/src/project_builder.rs
+++ b/nextgen/project-builder/src/project_builder.rs
@@ -27,6 +27,7 @@ impl Event for DetectLanguageEvent {
 pub struct ProjectBuilderContext<'app> {
     pub detect_language: &'app Emitter<DetectLanguageEvent>,
     pub detect_platform: &'app Emitter<DetectPlatformEvent>,
+    pub root_id: Option<&'app Id>,
     pub toolchain_config: &'app ToolchainConfig,
     pub workspace_root: &'app Path,
 }
@@ -268,7 +269,11 @@ impl<'app> ProjectBuilder<'app> {
                         dep_id.to_owned(),
                         DependencyConfig {
                             id: dep_id.to_owned(),
-                            scope: DependencyScope::Peer,
+                            scope: if self.context.root_id.is_some_and(|r| r == dep_id) {
+                                DependencyScope::Root
+                            } else {
+                                DependencyScope::Peer
+                            },
                             source: DependencySource::Implicit,
                             via: Some(task_config.target.to_string()),
                         },

--- a/nextgen/project-builder/tests/project_builder_test.rs
+++ b/nextgen/project-builder/tests/project_builder_test.rs
@@ -56,7 +56,7 @@ impl Stub {
             ProjectBuilderContext {
                 detect_language: &self.detect_language,
                 detect_platform: &self.detect_platform,
-                root_id: None,
+                root_project_id: None,
                 toolchain_config: &self.toolchain_config,
                 workspace_root: &self.workspace_root,
             },

--- a/nextgen/project-builder/tests/project_builder_test.rs
+++ b/nextgen/project-builder/tests/project_builder_test.rs
@@ -56,6 +56,7 @@ impl Stub {
             ProjectBuilderContext {
                 detect_language: &self.detect_language,
                 detect_platform: &self.detect_platform,
+                root_id: None,
                 toolchain_config: &self.toolchain_config,
                 workspace_root: &self.workspace_root,
             },

--- a/nextgen/project-graph/src/project_graph_builder.rs
+++ b/nextgen/project-graph/src/project_graph_builder.rs
@@ -60,7 +60,8 @@ pub struct ProjectGraphBuilder<'app> {
     nodes: FxHashMap<Id, NodeIndex>,
 
     /// The root project ID.
-    root_id: Option<Id>,
+    #[serde(skip)]
+    root_project_id: Option<Id>,
 
     /// Mapping of project IDs to file system sources,
     /// derived from the `workspace.projects` setting.
@@ -80,7 +81,7 @@ impl<'app> ProjectGraphBuilder<'app> {
             aliases: FxHashMap::default(),
             graph: DiGraph::new(),
             nodes: FxHashMap::default(),
-            root_id: None,
+            root_project_id: None,
             sources: FxHashMap::default(),
         };
 
@@ -297,7 +298,7 @@ impl<'app> ProjectGraphBuilder<'app> {
             ProjectBuilderContext {
                 detect_language: &context.detect_language,
                 detect_platform: &context.detect_platform,
-                root_id: self.root_id.as_ref(),
+                root_project_id: self.root_project_id.as_ref(),
                 toolchain_config: context.toolchain_config,
                 workspace_root: context.workspace_root,
             },
@@ -465,7 +466,7 @@ impl<'app> ProjectGraphBuilder<'app> {
             .await?;
 
         // Find the root project
-        self.root_id = sources.iter().find_map(|(id, source)| {
+        self.root_project_id = sources.iter().find_map(|(id, source)| {
             if source.as_str().is_empty() || source.as_str() == "." {
                 Some(id.to_owned())
             } else {

--- a/nextgen/project-graph/tests/__fixtures__/dependency-types/from-root-task-deps/moon.yml
+++ b/nextgen/project-graph/tests/__fixtures__/dependency-types/from-root-task-deps/moon.yml
@@ -1,0 +1,4 @@
+tasks:
+  build:
+    command: 'build'
+    deps: ['root:noop']

--- a/nextgen/project-graph/tests/__fixtures__/dependency-types/moon.yml
+++ b/nextgen/project-graph/tests/__fixtures__/dependency-types/moon.yml
@@ -1,0 +1,3 @@
+tasks:
+  noop:
+    command: 'noop'

--- a/nextgen/project-graph/tests/project_graph_test.rs
+++ b/nextgen/project-graph/tests/project_graph_test.rs
@@ -719,6 +719,27 @@ mod project_graph {
                     .await;
 
                 assert_eq!(map_ids(graph.ids()), ["b", "c", "from-task-deps"]);
+
+                let deps = &graph.get("from-root-task-deps").unwrap().dependencies;
+
+                assert_eq!(deps.get("b").unwrap().scope, DependencyScope::Peer);
+                assert_eq!(deps.get("c").unwrap().scope, DependencyScope::Peer);
+            }
+
+            #[tokio::test]
+            async fn from_root_task_deps() {
+                let sandbox = create_sandbox("dependency-types");
+                let container = ProjectGraphContainer::new(sandbox.path());
+                let context = container.create_context();
+                let graph = container
+                    .build_graph_for(context, &["from-root-task-deps"])
+                    .await;
+
+                assert_eq!(map_ids(graph.ids()), ["root", "from-root-task-deps"]);
+
+                let deps = &graph.get("from-root-task-deps").unwrap().dependencies;
+
+                assert_eq!(deps.get("root").unwrap().scope, DependencyScope::Root);
             }
 
             #[tokio::test]

--- a/nextgen/project-graph/tests/project_graph_test.rs
+++ b/nextgen/project-graph/tests/project_graph_test.rs
@@ -720,7 +720,7 @@ mod project_graph {
 
                 assert_eq!(map_ids(graph.ids()), ["b", "c", "from-task-deps"]);
 
-                let deps = &graph.get("from-root-task-deps").unwrap().dependencies;
+                let deps = &graph.get("from-task-deps").unwrap().dependencies;
 
                 assert_eq!(deps.get("b").unwrap().scope, DependencyScope::Peer);
                 assert_eq!(deps.get("c").unwrap().scope, DependencyScope::Peer);

--- a/nextgen/project/src/project.rs
+++ b/nextgen/project/src/project.rs
@@ -106,6 +106,11 @@ impl Project {
             .any(|file| file.starts_with(&self.source))
     }
 
+    /// Return true if the root-level project.
+    pub fn is_root_level(&self) -> bool {
+        self.source.as_str().is_empty() || self.source.as_str() == "."
+    }
+
     /// Return true if the provided locator string (an ID or alias) matches the
     /// current project.
     pub fn matches_locator(&self, locator: &str) -> bool {

--- a/nextgen/test-utils/src/project_graph.rs
+++ b/nextgen/test-utils/src/project_graph.rs
@@ -1,6 +1,7 @@
 use moon_config::{
     InheritedTasksEntry, InheritedTasksManager, NodeConfig, PartialInheritedTasksConfig,
     PartialTaskConfig, ToolchainConfig, ToolsConfig, WorkspaceConfig, WorkspaceProjects,
+    WorkspaceProjectsConfig,
 };
 use moon_project_graph::{
     DetectLanguageEvent, DetectPlatformEvent, ExtendProjectEvent, ExtendProjectGraphEvent,
@@ -52,7 +53,15 @@ impl ProjectGraphContainer {
         }
 
         // Use folders as project names
-        graph.workspace_config.projects = WorkspaceProjects::Globs(vec!["*".into()]);
+        let mut projects = WorkspaceProjectsConfig::default();
+
+        projects.globs = vec!["*".into()];
+
+        if root.join("moon.yml").exists() {
+            projects.sources.insert("root".into(), ".".into());
+        }
+
+        graph.workspace_config.projects = WorkspaceProjects::Both(projects);
 
         graph
     }

--- a/nextgen/test-utils/src/project_graph.rs
+++ b/nextgen/test-utils/src/project_graph.rs
@@ -53,9 +53,10 @@ impl ProjectGraphContainer {
         }
 
         // Use folders as project names
-        let mut projects = WorkspaceProjectsConfig::default();
-
-        projects.globs = vec!["*".into()];
+        let mut projects = WorkspaceProjectsConfig {
+            globs: vec!["*".into()],
+            ..WorkspaceProjectsConfig::default()
+        };
 
         if root.join("moon.yml").exists() {
             projects.sources.insert("root".into(), ".".into());

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,18 @@
   - More accurately monitors signals (ctrl+c) and shutdowns.
   - Tasks can now be configured with a timeout.
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Based on feedback, we've updated the automatic dependency linking to _not apply_ when the target
+  is the root-level project. This should alleviate all unwanted cycles.
+
+#### 🐞 Fixes
+
+- Fixed an issue where Node.js dependency syncing would fail on `build` dependencies, and be over
+  zealous with root-level projects.
+
 ## 1.15.0
 
 #### 💥 Breaking


### PR DESCRIPTION
This is causing more problems than it solves, so adding an exception for the root project.