### PR TITLE
fix: Ensure action node is always present.

### DIFF
--- a/crates/core/action-pipeline/src/actions/run_task.rs
+++ b/crates/core/action-pipeline/src/actions/run_task.rs
@@ -37,7 +37,7 @@ pub async fn run_task(
         color::label(&task.target)
     );
 
-    runner.node = action.node.clone();
+    runner.node = Arc::clone(&action.node);
     action.allow_failure = task.options.allow_failure;
 
     // If a dependency failed, we should skip this target

--- a/crates/core/action-pipeline/src/estimator.rs
+++ b/crates/core/action-pipeline/src/estimator.rs
@@ -47,10 +47,6 @@ impl Estimator {
         // Bucket every ran target based on task name,
         // and aggregate all tasks of the same name.
         for result in results {
-            let Some(node) = &result.node else {
-                continue;
-            };
-
             let Some(duration) = &result.duration else {
                 continue;
             };
@@ -66,7 +62,7 @@ impl Estimator {
                 task_duration *= 10;
             }
 
-            match node {
+            match &*result.node {
                 ActionNode::SetupTool { .. }
                 | ActionNode::InstallDeps { .. }
                 | ActionNode::InstallProjectDeps { .. } => {

--- a/crates/core/action-pipeline/src/pipeline.rs
+++ b/crates/core/action-pipeline/src/pipeline.rs
@@ -367,8 +367,8 @@ impl Pipeline {
             }
 
             term.line(label_checkpoint(
-                match &result.node {
-                    Some(ActionNode::RunTask { target, .. }) => target.as_str(),
+                match &*result.node {
+                    ActionNode::RunTask { target, .. } => target.as_str(),
                     _ => &result.label,
                 },
                 Checkpoint::RunFailed,
@@ -470,7 +470,7 @@ impl Pipeline {
         let mut skipped_count = 0;
 
         for result in results {
-            if compact && !matches!(result.node.as_ref().unwrap(), ActionNode::RunTask { .. }) {
+            if compact && !matches!(*result.node, ActionNode::RunTask { .. }) {
                 continue;
             }
 

--- a/crates/core/action-pipeline/tests/estimator_test.rs
+++ b/crates/core/action-pipeline/tests/estimator_test.rs
@@ -2,18 +2,19 @@ use moon_action::{Action, ActionNode, ActionStatus};
 use moon_action_pipeline::estimator::{Estimator, TaskEstimate};
 use moon_platform::Runtime;
 use rustc_hash::FxHashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 const NANOS_PER_MILLI: u32 = 1_000_000;
 const HALF_SECOND: u32 = NANOS_PER_MILLI * 500;
 
-fn create_run_task_action(runtime: Runtime, target: &str) -> ActionNode {
-    ActionNode::RunTask {
+fn create_run_task_action(runtime: Runtime, target: &str) -> Arc<ActionNode> {
+    Arc::new(ActionNode::RunTask {
         interactive: false,
         persistent: false,
         runtime,
         target: target.into(),
-    }
+    })
 }
 
 mod estimator {
@@ -40,7 +41,7 @@ mod estimator {
         let est = Estimator::calculate(
             &[Action {
                 duration: Some(Duration::new(10, 0)),
-                node: Some(create_run_task_action(Runtime::system(), "proj:task")),
+                node: create_run_task_action(Runtime::system(), "proj:task"),
                 ..Action::default()
             }],
             Duration::new(5, 0),
@@ -67,27 +68,27 @@ mod estimator {
             &[
                 Action {
                     duration: Some(Duration::new(10, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "a:build")),
+                    node: create_run_task_action(Runtime::system(), "a:build"),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(5, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "a:lint")),
+                    node: create_run_task_action(Runtime::system(), "a:lint"),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(15, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "b:build")),
+                    node: create_run_task_action(Runtime::system(), "b:build"),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(8, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "c:test")),
+                    node: create_run_task_action(Runtime::system(), "c:test"),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(12, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "d:lint")),
+                    node: create_run_task_action(Runtime::system(), "d:lint"),
                     ..Action::default()
                 },
             ],
@@ -122,21 +123,21 @@ mod estimator {
             &[
                 Action {
                     duration: Some(Duration::new(10, 0)),
-                    node: Some(ActionNode::SetupTool {
+                    node: Arc::new(ActionNode::SetupTool {
                         runtime: Runtime::system(),
                     }),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(25, 0)),
-                    node: Some(ActionNode::InstallDeps {
+                    node: Arc::new(ActionNode::InstallDeps {
                         runtime: Runtime::system(),
                     }),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(10, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "proj:task")),
+                    node: create_run_task_action(Runtime::system(), "proj:task"),
                     ..Action::default()
                 },
             ],
@@ -166,7 +167,7 @@ mod estimator {
         let est = Estimator::calculate(
             &[Action {
                 duration: Some(Duration::new(3, 0)),
-                node: Some(create_run_task_action(Runtime::system(), "proj:task")),
+                node: create_run_task_action(Runtime::system(), "proj:task"),
                 status: ActionStatus::Cached,
                 ..Action::default()
             }],
@@ -194,41 +195,41 @@ mod estimator {
             &[
                 Action {
                     duration: Some(Duration::new(10, 0)),
-                    node: Some(ActionNode::SetupTool {
+                    node: Arc::new(ActionNode::SetupTool {
                         runtime: Runtime::system(),
                     }),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(25, 0)),
-                    node: Some(ActionNode::InstallDeps {
+                    node: Arc::new(ActionNode::InstallDeps {
                         runtime: Runtime::system(),
                     }),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(10, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "a:build")),
+                    node: create_run_task_action(Runtime::system(), "a:build"),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(5, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "a:lint")),
+                    node: create_run_task_action(Runtime::system(), "a:lint"),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(15, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "b:build")),
+                    node: create_run_task_action(Runtime::system(), "b:build"),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(8, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "c:test")),
+                    node: create_run_task_action(Runtime::system(), "c:test"),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(12, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "d:lint")),
+                    node: create_run_task_action(Runtime::system(), "d:lint"),
                     ..Action::default()
                 },
             ],
@@ -267,41 +268,41 @@ mod estimator {
             &[
                 Action {
                     duration: Some(Duration::new(10, 0)),
-                    node: Some(ActionNode::SetupTool {
+                    node: Arc::new(ActionNode::SetupTool {
                         runtime: Runtime::system(),
                     }),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(25, 0)),
-                    node: Some(ActionNode::InstallDeps {
+                    node: Arc::new(ActionNode::InstallDeps {
                         runtime: Runtime::system(),
                     }),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(10, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "a:build")),
+                    node: create_run_task_action(Runtime::system(), "a:build"),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(5, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "a:lint")),
+                    node: create_run_task_action(Runtime::system(), "a:lint"),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(15, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "b:build")),
+                    node: create_run_task_action(Runtime::system(), "b:build"),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(8, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "c:test")),
+                    node: create_run_task_action(Runtime::system(), "c:test"),
                     ..Action::default()
                 },
                 Action {
                     duration: Some(Duration::new(12, 0)),
-                    node: Some(create_run_task_action(Runtime::system(), "d:lint")),
+                    node: create_run_task_action(Runtime::system(), "d:lint"),
                     ..Action::default()
                 },
             ],

--- a/crates/core/action/src/action.rs
+++ b/crates/core/action/src/action.rs
@@ -2,6 +2,7 @@ use moon_action_graph::ActionNode;
 use moon_common::color;
 use moon_utils::time::{chrono::prelude::*, now_timestamp};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 fn has_failed(status: &ActionStatus) -> bool {
@@ -100,7 +101,7 @@ pub struct Action {
     pub log_target: String,
 
     #[serde(skip)]
-    pub node: Option<ActionNode>,
+    pub node: Arc<ActionNode>,
 
     #[serde(skip)]
     pub node_index: usize,
@@ -126,7 +127,7 @@ impl Action {
             flaky: false,
             label: node.label(),
             log_target: String::new(),
-            node: Some(node),
+            node: Arc::new(node),
             node_index: 0,
             started_at: None,
             start_time: None,

--- a/nextgen/action-graph/src/action_node.rs
+++ b/nextgen/action-graph/src/action_node.rs
@@ -4,9 +4,12 @@ use moon_task::Target;
 use serde::Serialize;
 use std::hash::{Hash, Hasher};
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
 #[serde(tag = "action", content = "params")]
 pub enum ActionNode {
+    #[default]
+    None,
+
     /// Install tool dependencies in the workspace root.
     InstallDeps { runtime: Runtime },
 
@@ -40,7 +43,7 @@ impl ActionNode {
             Self::RunTask { runtime, .. } => runtime,
             Self::SetupTool { runtime } => runtime,
             Self::SyncProject { runtime, .. } => runtime,
-            Self::SyncWorkspace => unreachable!(),
+            _ => unreachable!(),
         }
     }
 
@@ -97,6 +100,7 @@ impl ActionNode {
                 format!("Sync{runtime}Project({project})")
             }
             Self::SyncWorkspace => "SyncWorkspace".into(),
+            Self::None => "None".into(),
         }
     }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## Unreleased
 
+#### 🐞 Fixes
+
+- Fixed an issue where interactive/persistent flags weren't always bubbled up the the task runner.
+
 #### ⚙️ Internal
 
 - Updated to proto v0.20.


### PR DESCRIPTION
When we would `take()` it, there's a small window where the node information is unavailable, causing some weirdness. This uses an `Arc` so it's always present.