### PR TITLE
fix: Fix pnpm deduping.

### DIFF
--- a/.yarn/versions/4c6095cd.yml
+++ b/.yarn/versions/4c6095cd.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,13 @@
   - More accurately monitors signals (ctrl+c) and shutdowns.
   - Tasks can now be configured with a timeout.
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where pnpm would fail to dedupe when its toolchain version is not using a
+  fully-qualified version.
+
 ## 1.15.3
 
 #### 🐞 Fixes


### PR DESCRIPTION
It runs the npx version when using a non-fq version, which isn't correct.