### PR TITLE
Update package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,12 +29,12 @@
     "detect-libc": "^2.0.2"
   },
   "optionalDependencies": {
-    "@moonrepo/core-linux-arm64-gnu": "^1.18.1",
-    "@moonrepo/core-linux-arm64-musl": "^1.18.1",
-    "@moonrepo/core-linux-x64-gnu": "^1.18.1",
-    "@moonrepo/core-linux-x64-musl": "^1.18.1",
-    "@moonrepo/core-macos-arm64": "^1.18.1",
-    "@moonrepo/core-macos-x64": "^1.18.1",
-    "@moonrepo/core-windows-x64-msvc": "^1.18.1"
+    "@moonrepo/core-linux-arm64-gnu": "1.18.1",
+    "@moonrepo/core-linux-arm64-musl": "1.18.1",
+    "@moonrepo/core-linux-x64-gnu": "1.18.1",
+    "@moonrepo/core-linux-x64-musl": "1.18.1",
+    "@moonrepo/core-macos-arm64": "1.18.1",
+    "@moonrepo/core-macos-x64": "1.18.1",
+    "@moonrepo/core-windows-x64-msvc": "1.18.1"
   }
 }


### PR DESCRIPTION
Given that the version of optional dependencies is set with `^1.18.1`, any update to the MINOR number will cause the latest MAJOR version available of `@moonrepo/core-*` to be downloaded. This leads to the installation of Moon always downloading the binary of the latest version of version 1. For instance:

```
➜  cli npm list -g
/Users/david/.nvm/versions/node/v20.10.0/lib
├── @moonrepo/cli@1.17.4
├── corepack@0.22.0
└── npm@10.2.3
➜  cli pwd
/Users/david/.nvm/versions/node/v20.10.0/lib/node_modules/@moonrepo/cli
➜  cli ls moon
 moon
➜  cli rm -f moon 
➜  cli node postinstall.js
➜  cli ./moon --version
moon 1.18.1
➜  cli 
```

The expected result was that the version would be 1.17.4. "This is a bug that affects all versions ^1.x.y."