### PR TITLE
docs: fix indentation in eslint example

### DIFF
--- a/website/docs/guides/examples/eslint.mdx
+++ b/website/docs/guides/examples/eslint.mdx
@@ -24,7 +24,7 @@ Since linting is a universal workflow, add a `lint` task to
 tasks:
   lint:
     command:
-       - 'eslint'
+      - 'eslint'
       # Support other extensions
       - '--ext'
       - '.js,.jsx,.ts,.tsx'


### PR DESCRIPTION
The additional space causes an error in the task execution:
```
  × Failed to parse .moon/tasks/node.yml.
  ╰─▶   × tasks.lint.?: did not find expected key at line 6 column 7, while parsing a block mapping at line 3 column 5
         ╭─[5:1]
       5 │       # Support other extensions
       6 │       - '--ext'
         ·       ▲
         ·       ╰── Fix this
       7 │       - '.js,.jsx,.ts,.tsx'
         ╰────
```