### PR TITLE
Force arch when running in a bun postinstall process

### DIFF
--- a/packages/cli/postinstall.js
+++ b/packages/cli/postinstall.js
@@ -13,7 +13,8 @@ const isMacos = process.platform === 'darwin';
 const isWindows = process.platform === 'win32';
 
 const platform = isWindows ? 'windows' : isMacos ? 'macos' : process.platform;
-const parts = [platform, process.arch];
+const arch = process.env['npm_config_user_agent'].match(/^bun.*arm64$/) ? 'arm64' : process.arch; // https://github.com/moonrepo/moon/issues/1103
+const parts = [platform, arch];
 
 if (isLinux) {
 	const { familySync } = require('detect-libc');


### PR DESCRIPTION
Fixes problem when installing via Bun package manager.

Bun runs its package manager process with the correct process.arch var. This env var influences Moon's arch-specific core dependency. 

Bun runs postinstall processes however via node. Node does not have, or does not have set, the same process.arch which results in the postinstall process resolving the wrong core dependency

Bun thankfully sets a useful value at process.npm_config_user_agent which allows a safe edge case solution here