### PR TITLE
Force arch when running in a bun postinstall process

### DIFF
--- a/.yarn/versions/baeeda33.yml
+++ b/.yarn/versions/baeeda33.yml
@@ -1,0 +1,2 @@
+releases:
+  "@moonrepo/cli": patch

--- a/.yarn/versions/baeeda33.yml
+++ b/.yarn/versions/baeeda33.yml
@@ -1,2 +1,9 @@
 releases:
   "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/packages/cli/postinstall.js
+++ b/packages/cli/postinstall.js
@@ -13,7 +13,8 @@ const isMacos = process.platform === 'darwin';
 const isWindows = process.platform === 'win32';
 
 const platform = isWindows ? 'windows' : isMacos ? 'macos' : process.platform;
-const parts = [platform, process.arch];
+const arch = process.env['npm_config_user_agent'].match(/^bun.*arm64$/) ? 'arm64' : process.arch; // https://github.com/moonrepo/moon/issues/1103
+const parts = [platform, arch];
 
 if (isLinux) {
 	const { familySync } = require('detect-libc');

--- a/packages/cli/postinstall.js
+++ b/packages/cli/postinstall.js
@@ -13,7 +13,7 @@ const isMacos = process.platform === 'darwin';
 const isWindows = process.platform === 'win32';
 
 const platform = isWindows ? 'windows' : isMacos ? 'macos' : process.platform;
-const arch = process.env['npm_config_user_agent'].match(/^bun.*arm64$/) ? 'arm64' : process.arch; // https://github.com/moonrepo/moon/issues/1103
+const arch = process.env['npm_config_user_agent'] && process.env['npm_config_user_agent'].match(/^bun.*arm64$/) ? 'arm64' : process.arch; // https://github.com/moonrepo/moon/issues/1103
 const parts = [platform, arch];
 
 if (isLinux) {


### PR DESCRIPTION
Fixes problem when installing via Bun package manager.

Bun runs its package manager process with the correct process.arch var. This env var influences Moon's arch-specific core dependency.

Bun runs postinstall processes however via node. Node does not have, or does not have set, the same process.arch which results in the postinstall process resolving the wrong core dependency

Bun thankfully sets a useful value at process.npm_config_user_agent which allows a safe edge case solution here