### PR TITLE
docs: Add zig-plugin for proto.

### DIFF
--- a/website/src/data/proto-tools.tsx
+++ b/website/src/data/proto-tools.tsx
@@ -247,4 +247,13 @@ export const THIRD_PARTY_TOOLS: Record<string, ProtoTool> = {
 		pluginType: 'toml',
 		repoUrl: 'https://github.com/stk0vrfl0w/proto-toml-plugins/blob/main/plugins/zig.toml',
 	},
+	'zig-plugin': {
+		bins: ['zig'],
+		description: 'Zig is a general-purpose programming language and toolchain.',
+		homepageUrl: 'https://ziglang.org',
+		name: 'zig',
+		pluginLocator: 'github:konomae/zig-plugin',
+		pluginType: 'wasm',
+		repoUrl: 'https://github.com/konomae/zig-plugin',
+	},
 };


### PR DESCRIPTION
Hi.
I created a wasm plugin for Zig!
It supports installing zig [master builds](https://ziglang.org/download/) as well as release builds.