### PR TITLE
fix:Fix version cleaning for VFSForGit windows (#1281).

### DIFF
--- a/nextgen/vcs/src/git.rs
+++ b/nextgen/vcs/src/git.rs
@@ -24,7 +24,7 @@ pub static DIFF_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(A|D|M|T|U|X)$
 pub static DIFF_SCORE_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(C|M|R)(\d{3})$").unwrap());
 
 pub static VERSION_CLEAN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"\.(windows|win|msysgit|msys)\.\d+").unwrap());
+    Lazy::new(|| Regex::new(r"\.(windows|win|msysgit|msys|vfs)(\.\d+){1,2}").unwrap());
 
 pub fn clean_git_version(version: String) -> String {
     let version = if let Some(index) = version.find('(') {

--- a/nextgen/vcs/tests/git_test.rs
+++ b/nextgen/vcs/tests/git_test.rs
@@ -722,5 +722,9 @@ mod version_cleaning {
             clean_git_version("git for windows 1.2.3.msysgit.23  (64bit) ".into()),
             "1.2.3"
         );
+        assert_eq!(
+            clean_git_version("git version 1.2.3.vfs.0.0".into()),
+            "1.2.3"
+        );
     }
 }


### PR DESCRIPTION
VFSForGit has the version '2.43.0.vfs.0.0', which has raised issue #1281. 

The proposed fix includes a rewritten regex and an added assert.