### PR TITLE
fix: Fix docker scaffold not copying `moon.yml`.

### DIFF
--- a/.yarn/versions/0957d65a.yml
+++ b/.yarn/versions/0957d65a.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/cli/src/commands/docker/scaffold.rs
+++ b/crates/cli/src/commands/docker/scaffold.rs
@@ -1,7 +1,7 @@
 use super::MANIFEST_NAME;
 use clap::Args;
 use moon::generate_project_graph;
-use moon_common::consts::CONFIG_DIRNAME;
+use moon_common::consts::{CONFIG_DIRNAME, CONFIG_PROJECT_FILENAME, CONFIG_TEMPLATE_FILENAME};
 use moon_common::Id;
 use moon_config::{ConfigEnum, LanguageType};
 use moon_platform_detector::detect_language_files;
@@ -60,7 +60,11 @@ fn scaffold_workspace(
     // Copy manifest and config files for every type of language,
     // not just the one the project is configured as!
     let copy_from_dir = |source: &Path, dest: &Path| -> AppResult {
-        let mut files: Vec<String> = vec![".prototools".to_owned()];
+        let mut files: Vec<String> = vec![
+            ".prototools".to_owned(),
+            CONFIG_PROJECT_FILENAME.to_owned(),
+            CONFIG_TEMPLATE_FILENAME.to_owned(),
+        ];
 
         for lang in LanguageType::variants() {
             files.extend(detect_language_files(&lang));

--- a/crates/cli/tests/docker_test.rs
+++ b/crates/cli/tests/docker_test.rs
@@ -71,6 +71,9 @@ mod scaffold_workspace {
         assert!(docker.join(".moon/tasks/node.yml").exists());
         assert!(docker.join(".moon/toolchain.yml").exists());
         assert!(docker.join(".moon/workspace.yml").exists());
+        assert!(docker.join("base/moon.yml").exists());
+        assert!(docker.join("swc/moon.yml").exists());
+        assert!(docker.join("version-override/moon.yml").exists());
     }
 
     #[test]

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,13 @@
   - More accurately monitors signals (ctrl+c) and shutdowns.
   - Tasks can now be configured with a timeout.
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed `moon docker scaffold` not copying the project specific `moon.yml` file, resulting in a
+  skewed project graph.
+
 ## 1.20.0
 
 #### 🚀 Updates


### PR DESCRIPTION
Oversight? Previously this worked fine, since this config is just for tasks, which aren't important for the scaffolding process.

However, now that we support `id`, this causes a failure for unknown projects.