### PR TITLE
fix: Remove concurrency limit from persistent tasks.

### DIFF
--- a/crates/core/action-pipeline/src/pipeline.rs
+++ b/crates/core/action-pipeline/src/pipeline.rs
@@ -229,10 +229,6 @@ impl Pipeline {
             let mut action = Action::new(node.to_owned());
             action.node_index = node_index.index();
 
-            let Ok(permit) = semaphore.clone().acquire_owned().await else {
-                continue; // Should error?
-            };
-
             action_handles.push(tokio::spawn(async move {
                 let result = tokio::select! {
                     biased;
@@ -252,8 +248,6 @@ impl Pipeline {
                 if let Ok(action) = &result {
                     let _ = sender.send(action.node_index);
                 }
-
-                drop(permit);
 
                 result
             }));

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## Unreleased
 
+#### 🚀 Updates
+
+- Removed the maximum concurrency limit from persistent tasks.
+
 #### 🐞 Fixes
 
 - Fixed `moon docker scaffold` not copying the project specific `moon.yml` file, resulting in a


### PR DESCRIPTION
Otherwise, if you had more tasks than CPU count, some of them will never start. This is intended for the task runner, but for persistent tasks which are the last tasks to run, it's a blocker.