### PR TITLE
new: Add `stack` project setting, and expand `type` setting.

### DIFF
--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -52,6 +52,7 @@ pub async fn project(args: ArgsRef<ProjectArgs>, resources: ResourcesMut) {
     }
 
     console.print_entry("Language", format!("{}", &project.language))?;
+    console.print_entry("Stack", format!("{}", &project.stack))?;
     console.print_entry("Type", format!("{}", &project.type_of))?;
 
     if !config.tags.is_empty() {

--- a/crates/cli/src/commands/query.rs
+++ b/crates/cli/src/commands/query.rs
@@ -137,6 +137,9 @@ pub struct QueryProjectsArgs {
     language: Option<String>,
 
     #[arg(long, help = "Filter projects that match this source path")]
+    stack: Option<String>,
+
+    #[arg(long, help = "Filter projects of this tech stack")]
     source: Option<String>,
 
     #[arg(long, help = "Filter projects that have the following tags")]
@@ -159,6 +162,7 @@ pub async fn projects(args: ArgsRef<QueryProjectsArgs>, resources: ResourcesMut)
         json: args.json,
         language: args.language,
         query: args.query,
+        stack: args.stack,
         source: args.source,
         tags: args.tags,
         tasks: args.tasks,
@@ -187,7 +191,12 @@ pub async fn projects(args: ArgsRef<QueryProjectsArgs>, resources: ResourcesMut)
         console.out.write_line(
             projects
                 .iter()
-                .map(|p| format!("{} | {} | {} | {}", p.id, p.source, p.type_of, p.language))
+                .map(|p| {
+                    format!(
+                        "{} | {} | {} | {} | {}",
+                        p.id, p.source, p.stack, p.type_of, p.language
+                    )
+                })
                 .collect::<Vec<_>>()
                 .join("\n"),
         )?;

--- a/crates/cli/src/queries/projects.rs
+++ b/crates/cli/src/queries/projects.rs
@@ -26,6 +26,7 @@ pub struct QueryProjectsOptions {
     pub json: bool,
     pub language: Option<String>,
     pub query: Option<String>,
+    pub stack: Option<String>,
     pub source: Option<String>,
     pub tags: Option<String>,
     pub tasks: Option<String>,
@@ -130,6 +131,7 @@ pub async fn query_projects(
     let alias_regex = convert_to_regex("alias", &options.alias)?;
     let id_regex = convert_to_regex("id", &options.id)?;
     let language_regex = convert_to_regex("language", &options.language)?;
+    let stack_regex = convert_to_regex("stack", &options.stack)?;
     let source_regex = convert_to_regex("source", &options.source)?;
     let tags_regex = convert_to_regex("tags", &options.tags)?;
     let tasks_regex = convert_to_regex("tasks", &options.tasks)?;
@@ -179,6 +181,12 @@ pub async fn query_projects(
 
         if let Some(regex) = &language_regex {
             if !regex.is_match(&project.language.to_string()) {
+                continue;
+            }
+        }
+
+        if let Some(regex) = &stack_regex {
+            if !regex.is_match(&project.stack.to_string()) {
                 continue;
             }
         }

--- a/crates/cli/tests/query_test.rs
+++ b/crates/cli/tests/query_test.rs
@@ -345,7 +345,7 @@ mod projects {
 
         assert_eq!(
             assert.output(),
-            "advanced | advanced | application | typescript\nnoConfig | no-config | unknown | unknown\n\n"
+            "advanced | advanced | frontend | application | typescript\nnoConfig | no-config | unknown | unknown | unknown\n\n"
         );
     }
 
@@ -548,6 +548,31 @@ mod projects {
 
         assert_eq!(ids, string_vec!["advanced", "foo"]);
         assert_eq!(json.options.type_of.unwrap(), "app".to_string());
+    }
+
+    #[test]
+    fn can_filter_by_stack() {
+        let (workspace_config, toolchain_config, tasks_config) = get_projects_fixture_configs();
+
+        let sandbox = create_sandbox_with_config(
+            "projects",
+            Some(workspace_config),
+            Some(toolchain_config),
+            Some(tasks_config),
+        );
+
+        let assert = sandbox.run_moon(|cmd| {
+            cmd.arg("query")
+                .arg("projects")
+                .arg("--json")
+                .args(["--stack", "frontend"]);
+        });
+
+        let json: QueryProjectsResult = serde_json::from_str(&assert.output()).unwrap();
+        let ids: Vec<String> = json.projects.iter().map(|p| p.id.to_string()).collect();
+
+        assert_eq!(ids, string_vec!["advanced"]);
+        assert_eq!(json.options.stack.unwrap(), "frontend".to_string());
     }
 
     mod mql {

--- a/crates/cli/tests/snapshots/project_test__advanced_config.snap
+++ b/crates/cli/tests/snapshots/project_test__advanced_config.snap
@@ -8,6 +8,7 @@ expression: assert.output()
 Project: advanced
 Source: advanced
 Language: typescript
+Stack: frontend
 Type: application
 Tags: react
 Name: Advanced

--- a/crates/cli/tests/snapshots/project_test__basic_config.snap
+++ b/crates/cli/tests/snapshots/project_test__basic_config.snap
@@ -8,6 +8,7 @@ expression: assert.output()
 Project: basic
 Source: basic
 Language: javascript
+Stack: unknown
 Type: unknown
 Tags: vue
 

--- a/crates/cli/tests/snapshots/project_test__depends_on_paths.snap
+++ b/crates/cli/tests/snapshots/project_test__depends_on_paths.snap
@@ -8,6 +8,7 @@ expression: assert.output_standardized()
 Project: foo
 Source: deps/foo
 Language: javascript
+Stack: unknown
 Type: application
 Tags: react
 

--- a/crates/cli/tests/snapshots/project_test__empty_config.snap
+++ b/crates/cli/tests/snapshots/project_test__empty_config.snap
@@ -8,6 +8,7 @@ expression: assert.output()
 Project: emptyConfig
 Source: empty-config
 Language: unknown
+Stack: unknown
 Type: unknown
 
  FILE GROUPS 

--- a/crates/cli/tests/snapshots/project_test__no_config.snap
+++ b/crates/cli/tests/snapshots/project_test__no_config.snap
@@ -8,6 +8,7 @@ expression: assert.output()
 Project: noConfig
 Source: no-config
 Language: unknown
+Stack: unknown
 Type: unknown
 
  FILE GROUPS 

--- a/crates/cli/tests/snapshots/project_test__root_level.snap
+++ b/crates/cli/tests/snapshots/project_test__root_level.snap
@@ -9,6 +9,7 @@ Project: root
 Alias: test-cases
 Source: .
 Language: typescript
+Stack: unknown
 Type: unknown
 
  TASKS 

--- a/crates/cli/tests/snapshots/project_test__with_tasks.snap
+++ b/crates/cli/tests/snapshots/project_test__with_tasks.snap
@@ -8,6 +8,7 @@ expression: assert.output()
 Project: tasks
 Source: tasks
 Language: typescript
+Stack: unknown
 Type: unknown
 
  TASKS 

--- a/crates/cli/tests/snapshots/query_test__projects__returns_all_by_default.snap
+++ b/crates/cli/tests/snapshots/query_test__projects__returns_all_by_default.snap
@@ -1,15 +1,15 @@
 ---
 source: crates/cli/tests/query_test.rs
-expression: assert.output()
+expression: assert.output_standardized()
 ---
-advanced | advanced | application | typescript
-bar | deps/bar | unknown | unknown
-basic | basic | unknown | javascript
-baz | deps/baz | unknown | unknown
-emptyConfig | empty-config | unknown | unknown
-foo | deps/foo | application | javascript
-noConfig | no-config | unknown | unknown
-platforms | platforms | unknown | unknown
-tasks | tasks | unknown | typescript
+advanced | advanced | frontend | application | typescript
+bar | deps/bar | unknown | unknown | unknown
+basic | basic | unknown | unknown | javascript
+baz | deps/baz | unknown | unknown | unknown
+emptyConfig | empty-config | unknown | unknown | unknown
+foo | deps/foo | unknown | application | javascript
+noConfig | no-config | unknown | unknown | unknown
+platforms | platforms | unknown | unknown | unknown
+tasks | tasks | unknown | unknown | typescript
 
 

--- a/crates/cli/tests/snapshots/run_bun_test__bun__infer_tasks__inherits_tasks.snap
+++ b/crates/cli/tests/snapshots/run_bun_test__bun__infer_tasks__inherits_tasks.snap
@@ -9,6 +9,7 @@ Project: scripts
 Alias: test-bun-scripts
 Source: scripts
 Language: javascript
+Stack: unknown
 Type: unknown
 
  TASKS 

--- a/nextgen/config/src/project_config.rs
+++ b/nextgen/config/src/project_config.rs
@@ -25,12 +25,27 @@ fn validate_channel<D, C>(
 }
 
 derive_enum!(
+    /// The technology stack of the project, for categorizing.
+    #[derive(ConfigEnum, Copy, Default)]
+    pub enum ProjectStack {
+        Backend,
+        Frontend,
+        Infrastructure,
+        Systems,
+        #[default]
+        Unknown,
+    }
+);
+
+derive_enum!(
     /// The type of project, for categorizing.
     #[derive(ConfigEnum, Copy, Default)]
     pub enum ProjectType {
         Application,
         Automation,
+        Configuration,
         Library,
+        Scaffolding,
         Tool,
         #[default]
         Unknown,
@@ -117,6 +132,9 @@ cacheable!(
         /// Expanded information about the project.
         #[setting(nested)]
         pub project: Option<ProjectMetadataConfig>,
+
+        /// The technology stack of the project, for categorizing.
+        pub stack: ProjectStack,
 
         /// A list of tags that this project blongs to, for categorizing,
         /// boundary enforcement, and task inheritance.

--- a/nextgen/config/tests/project_config_test.rs
+++ b/nextgen/config/tests/project_config_test.rs
@@ -14,7 +14,7 @@ mod project_config {
 
     #[test]
     #[should_panic(
-        expected = "unknown field `unknown`, expected one of `$schema`, `dependsOn`, `env`, `fileGroups`, `id`, `language`, `owners`, `platform`, `project`, `tags`, `tasks`, `toolchain`, `type`, `workspace`"
+        expected = "unknown field `unknown`, expected one of `$schema`, `dependsOn`, `env`, `fileGroups`, `id`, `language`, `owners`, `platform`, `project`, `stack`, `tags`, `tasks`, `toolchain`, `type`, `workspace`"
     )]
     fn error_unknown_field() {
         test_load_config(CONFIG_PROJECT_FILENAME, "unknown: 123", |path| {

--- a/nextgen/project-builder/src/project_builder.rs
+++ b/nextgen/project-builder/src/project_builder.rs
@@ -223,6 +223,7 @@ impl<'app> ProjectBuilder<'app> {
 
         let config = self.local_config.take().unwrap_or_default();
 
+        project.stack = config.stack;
         project.type_of = config.type_of;
         project.config = config;
 

--- a/nextgen/project-constraints/src/lib.rs
+++ b/nextgen/project-constraints/src/lib.rs
@@ -49,7 +49,11 @@ pub fn enforce_project_type_relationships(
 
             matches!(
                 dependency.type_of,
-                ProjectType::Library | ProjectType::Tool | ProjectType::Unknown
+                ProjectType::Configuration
+                    | ProjectType::Scaffolding
+                    | ProjectType::Library
+                    | ProjectType::Tool
+                    | ProjectType::Unknown
             )
         }
         ProjectType::Automation => {
@@ -64,7 +68,10 @@ pub fn enforce_project_type_relationships(
 
             matches!(
                 dependency.type_of,
-                ProjectType::Library | ProjectType::Unknown
+                ProjectType::Configuration
+                    | ProjectType::Scaffolding
+                    | ProjectType::Library
+                    | ProjectType::Unknown
             )
         }
         ProjectType::Configuration | ProjectType::Scaffolding => {

--- a/nextgen/project-constraints/src/lib.rs
+++ b/nextgen/project-constraints/src/lib.rs
@@ -37,7 +37,10 @@ pub fn enforce_project_type_relationships(
     source: &Project,
     dependency: &Project,
 ) -> miette::Result<()> {
-    let mut allowed = vec![];
+    let mut allowed = vec![
+        ProjectType::Configuration.to_string(),
+        ProjectType::Scaffolding.to_string(),
+    ];
 
     let valid = match source.type_of {
         ProjectType::Application => {
@@ -62,6 +65,12 @@ pub fn enforce_project_type_relationships(
             matches!(
                 dependency.type_of,
                 ProjectType::Library | ProjectType::Unknown
+            )
+        }
+        ProjectType::Configuration | ProjectType::Scaffolding => {
+            matches!(
+                dependency.type_of,
+                ProjectType::Configuration | ProjectType::Scaffolding
             )
         }
         ProjectType::Unknown => {

--- a/nextgen/project-constraints/tests/constraints_test.rs
+++ b/nextgen/project-constraints/tests/constraints_test.rs
@@ -43,6 +43,24 @@ mod by_type {
     }
 
     #[test]
+    fn app_use_config() {
+        enforce_project_type_relationships(
+            &create_project("foo", ProjectType::Application),
+            &create_project("bar", ProjectType::Configuration),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn app_use_scaffold() {
+        enforce_project_type_relationships(
+            &create_project("foo", ProjectType::Application),
+            &create_project("bar", ProjectType::Scaffolding),
+        )
+        .unwrap();
+    }
+
+    #[test]
     fn app_use_unknown() {
         enforce_project_type_relationships(
             &create_project("foo", ProjectType::Application),
@@ -76,6 +94,24 @@ mod by_type {
         enforce_project_type_relationships(
             &create_project("foo", ProjectType::Library),
             &create_project("bar", ProjectType::Library),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn lib_use_config() {
+        enforce_project_type_relationships(
+            &create_project("foo", ProjectType::Library),
+            &create_project("bar", ProjectType::Configuration),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn lib_use_scaffold() {
+        enforce_project_type_relationships(
+            &create_project("foo", ProjectType::Library),
+            &create_project("bar", ProjectType::Scaffolding),
         )
         .unwrap();
     }
@@ -124,6 +160,24 @@ mod by_type {
         enforce_project_type_relationships(
             &create_project("foo", ProjectType::Tool),
             &create_project("bar", ProjectType::Library),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn tool_use_config() {
+        enforce_project_type_relationships(
+            &create_project("foo", ProjectType::Tool),
+            &create_project("bar", ProjectType::Configuration),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn tool_use_scaffold() {
+        enforce_project_type_relationships(
+            &create_project("foo", ProjectType::Tool),
+            &create_project("bar", ProjectType::Scaffolding),
         )
         .unwrap();
     }
@@ -195,6 +249,24 @@ mod by_type {
     }
 
     #[test]
+    fn e2e_use_config() {
+        enforce_project_type_relationships(
+            &create_project("foo", ProjectType::Automation),
+            &create_project("bar", ProjectType::Configuration),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn e2e_use_scaffold() {
+        enforce_project_type_relationships(
+            &create_project("foo", ProjectType::Automation),
+            &create_project("bar", ProjectType::Scaffolding),
+        )
+        .unwrap();
+    }
+
+    #[test]
     fn e2e_use_unknown() {
         enforce_project_type_relationships(
             &create_project("foo", ProjectType::Automation),
@@ -211,6 +283,138 @@ mod by_type {
             &create_project("bar", ProjectType::Automation),
         )
         .unwrap();
+    }
+
+    mod config {
+        use super::*;
+
+        #[test]
+        fn config_use_config() {
+            enforce_project_type_relationships(
+                &create_project("foo", ProjectType::Configuration),
+                &create_project("bar", ProjectType::Configuration),
+            )
+            .unwrap();
+        }
+
+        #[test]
+        fn config_use_scaffold() {
+            enforce_project_type_relationships(
+                &create_project("foo", ProjectType::Configuration),
+                &create_project("bar", ProjectType::Scaffolding),
+            )
+            .unwrap();
+        }
+
+        #[test]
+        #[should_panic(
+            expected = "Invalid project relationship. Project foo of type configuration"
+        )]
+        fn config_cant_use_app() {
+            enforce_project_type_relationships(
+                &create_project("foo", ProjectType::Configuration),
+                &create_project("bar", ProjectType::Application),
+            )
+            .unwrap();
+        }
+
+        #[test]
+        #[should_panic(
+            expected = "Invalid project relationship. Project foo of type configuration"
+        )]
+        fn config_cant_use_e2e() {
+            enforce_project_type_relationships(
+                &create_project("foo", ProjectType::Configuration),
+                &create_project("bar", ProjectType::Automation),
+            )
+            .unwrap();
+        }
+
+        #[test]
+        #[should_panic(
+            expected = "Invalid project relationship. Project foo of type configuration"
+        )]
+        fn config_cant_use_lib() {
+            enforce_project_type_relationships(
+                &create_project("foo", ProjectType::Configuration),
+                &create_project("bar", ProjectType::Library),
+            )
+            .unwrap();
+        }
+
+        #[test]
+        #[should_panic(
+            expected = "Invalid project relationship. Project foo of type configuration"
+        )]
+        fn config_cant_use_tool() {
+            enforce_project_type_relationships(
+                &create_project("foo", ProjectType::Configuration),
+                &create_project("bar", ProjectType::Tool),
+            )
+            .unwrap();
+        }
+    }
+
+    mod scaffold {
+        use super::*;
+
+        #[test]
+        fn scaffold_use_config() {
+            enforce_project_type_relationships(
+                &create_project("foo", ProjectType::Scaffolding),
+                &create_project("bar", ProjectType::Configuration),
+            )
+            .unwrap();
+        }
+
+        #[test]
+        fn scaffold_use_scaffold() {
+            enforce_project_type_relationships(
+                &create_project("foo", ProjectType::Scaffolding),
+                &create_project("bar", ProjectType::Scaffolding),
+            )
+            .unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "Invalid project relationship. Project foo of type scaffolding")]
+        fn scaffold_cant_use_app() {
+            enforce_project_type_relationships(
+                &create_project("foo", ProjectType::Scaffolding),
+                &create_project("bar", ProjectType::Application),
+            )
+            .unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "Invalid project relationship. Project foo of type scaffolding")]
+        fn scaffold_cant_use_e2e() {
+            enforce_project_type_relationships(
+                &create_project("foo", ProjectType::Scaffolding),
+                &create_project("bar", ProjectType::Automation),
+            )
+            .unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "Invalid project relationship. Project foo of type scaffolding")]
+        fn scaffold_cant_use_lib() {
+            enforce_project_type_relationships(
+                &create_project("foo", ProjectType::Scaffolding),
+                &create_project("bar", ProjectType::Library),
+            )
+            .unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "Invalid project relationship. Project foo of type scaffolding")]
+        fn scaffold_cant_use_tool() {
+            enforce_project_type_relationships(
+                &create_project("foo", ProjectType::Scaffolding),
+                &create_project("bar", ProjectType::Tool),
+            )
+            .unwrap();
+        }
     }
 }
 

--- a/nextgen/project-expander/src/token_expander.rs
+++ b/nextgen/project-expander/src/token_expander.rs
@@ -449,6 +449,7 @@ impl<'graph, 'query> TokenExpander<'graph, 'query> {
             },
             "projectRoot" => Cow::Owned(path::to_string(&project.root)?),
             "projectSource" => Cow::Borrowed(project.source.as_str()),
+            "projectStack" => Cow::Owned(project.stack.to_string()),
             "projectType" => Cow::Owned(project.type_of.to_string()),
             // Task
             "target" => Cow::Borrowed(task.target.as_str()),

--- a/nextgen/project-graph/tests/project_graph_test.rs
+++ b/nextgen/project-graph/tests/project_graph_test.rs
@@ -1067,9 +1067,7 @@ mod project_graph {
         }
 
         #[tokio::test]
-        #[should_panic(
-            expected = "Invalid project relationship. Project app of type application cannot"
-        )]
+        #[should_panic(expected = "Invalid project relationship. Project app of type application")]
         async fn app_cannot_use_app() {
             generate_type_constraints_project_graph(|sandbox| {
                 append_file(
@@ -1103,9 +1101,7 @@ mod project_graph {
         }
 
         #[tokio::test]
-        #[should_panic(
-            expected = "Invalid project relationship. Project library of type library cannot"
-        )]
+        #[should_panic(expected = "Invalid project relationship. Project library of type library")]
         async fn library_cannot_use_app() {
             generate_type_constraints_project_graph(|sandbox| {
                 append_file(sandbox.path().join("library/moon.yml"), "dependsOn: [app]");
@@ -1114,9 +1110,7 @@ mod project_graph {
         }
 
         #[tokio::test]
-        #[should_panic(
-            expected = "Invalid project relationship. Project library of type library cannot"
-        )]
+        #[should_panic(expected = "Invalid project relationship. Project library of type library")]
         async fn library_cannot_use_tool() {
             generate_type_constraints_project_graph(|sandbox| {
                 append_file(sandbox.path().join("library/moon.yml"), "dependsOn: [tool]");
@@ -1141,7 +1135,7 @@ mod project_graph {
         }
 
         #[tokio::test]
-        #[should_panic(expected = "Invalid project relationship. Project tool of type tool cannot")]
+        #[should_panic(expected = "Invalid project relationship. Project tool of type tool")]
         async fn tool_cannot_use_app() {
             generate_type_constraints_project_graph(|sandbox| {
                 append_file(sandbox.path().join("tool/moon.yml"), "dependsOn: [app]");
@@ -1150,7 +1144,7 @@ mod project_graph {
         }
 
         #[tokio::test]
-        #[should_panic(expected = "Invalid project relationship. Project tool of type tool cannot")]
+        #[should_panic(expected = "Invalid project relationship. Project tool of type tool")]
         async fn tool_cannot_use_tool() {
             generate_type_constraints_project_graph(|sandbox| {
                 append_file(
@@ -1230,7 +1224,7 @@ mod project_graph {
         }
 
         #[tokio::test]
-        #[should_panic(expected = "Invalid tag relationship. Project a with tag #warrior cannot")]
+        #[should_panic(expected = "Invalid tag relationship. Project a with tag #warrior")]
         async fn errors_for_no_source_tag_match() {
             generate_tag_constraints_project_graph(|sandbox| {
                 append_file(
@@ -1255,7 +1249,7 @@ mod project_graph {
         }
 
         #[tokio::test]
-        #[should_panic(expected = "Invalid tag relationship. Project a with tag #warrior cannot")]
+        #[should_panic(expected = "Invalid tag relationship. Project a with tag #warrior")]
         async fn errors_for_no_allowed_tag_match() {
             generate_tag_constraints_project_graph(|sandbox| {
                 append_file(
@@ -1268,7 +1262,7 @@ mod project_graph {
         }
 
         #[tokio::test]
-        #[should_panic(expected = "Invalid tag relationship. Project a with tag #mage cannot")]
+        #[should_panic(expected = "Invalid tag relationship. Project a with tag #mage")]
         async fn errors_for_depon_empty_tags() {
             generate_tag_constraints_project_graph(|sandbox| {
                 append_file(

--- a/nextgen/project/src/lib.rs
+++ b/nextgen/project/src/lib.rs
@@ -1,7 +1,7 @@
 mod project;
 mod project_error;
 
-pub use moon_config::{ProjectConfig, ProjectType};
+pub use moon_config::{ProjectConfig, ProjectStack, ProjectType};
 pub use moon_file_group::FileGroup;
 pub use project::*;
 pub use project_error::*;

--- a/nextgen/project/src/project.rs
+++ b/nextgen/project/src/project.rs
@@ -218,6 +218,7 @@ impl PartialEq for Project {
             && self.language == other.language
             && self.root == other.root
             && self.source == other.source
+            && self.stack == other.stack
             && self.tasks == other.tasks
             && self.type_of == other.type_of
     }

--- a/nextgen/project/src/project.rs
+++ b/nextgen/project/src/project.rs
@@ -1,7 +1,8 @@
 use crate::project_error::ProjectError;
 use moon_common::{cacheable, path::WorkspaceRelativePathBuf, Id};
 use moon_config::{
-    DependencyConfig, InheritedTasksResult, LanguageType, PlatformType, ProjectConfig, ProjectType,
+    DependencyConfig, InheritedTasksResult, LanguageType, PlatformType, ProjectConfig,
+    ProjectStack, ProjectType,
 };
 use moon_file_group::FileGroup;
 use moon_query::{Condition, Criteria, Field, LogicalOperator, Queryable};
@@ -37,6 +38,9 @@ cacheable!(
 
         /// Default platform to run tasks against.
         pub platform: PlatformType,
+
+        /// The technology stack of the project.
+        pub stack: ProjectStack,
 
         /// Absolute path to the project's root folder.
         pub root: PathBuf,
@@ -152,6 +156,7 @@ impl Queryable for Project {
                         Field::ProjectSource(sources) => {
                             condition.matches(sources, self.source.as_str())
                         }
+                        Field::ProjectStack(types) => condition.matches_enum(types, &self.stack),
                         Field::ProjectType(types) => condition.matches_enum(types, &self.type_of),
                         Field::Tag(tags) => condition.matches_list(
                             tags,

--- a/nextgen/query/src/builder.rs
+++ b/nextgen/query/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::parser::{parse_query, AstNode, ComparisonOperator, LogicalOperator};
 use crate::query_error::QueryError;
-use moon_config::{LanguageType, PlatformType, ProjectType, TaskType};
+use moon_config::{LanguageType, PlatformType, ProjectStack, ProjectType, TaskType};
 use starbase_utils::glob::GlobSet;
 use std::borrow::Cow;
 use std::cmp::PartialEq;
@@ -16,6 +16,7 @@ pub enum Field<'l> {
     ProjectAlias(FieldValues<'l>),
     ProjectName(FieldValues<'l>),
     ProjectSource(FieldValues<'l>),
+    ProjectStack(Vec<ProjectStack>),
     ProjectType(Vec<ProjectType>),
     Tag(FieldValues<'l>),
     Task(FieldValues<'l>),
@@ -120,6 +121,9 @@ fn build_criteria(ast: Vec<AstNode<'_>>) -> miette::Result<Criteria<'_>> {
                     "projectAlias" => Field::ProjectAlias(value),
                     "projectName" => Field::ProjectName(value),
                     "projectSource" => Field::ProjectSource(value),
+                    "projectStack" => Field::ProjectStack(build_criteria_enum::<ProjectStack>(
+                        &field, &op, value,
+                    )?),
                     "projectType" => {
                         Field::ProjectType(build_criteria_enum::<ProjectType>(&field, &op, value)?)
                     }

--- a/nextgen/query/tests/builder_test.rs
+++ b/nextgen/query/tests/builder_test.rs
@@ -1,4 +1,4 @@
-use moon_config::{LanguageType, PlatformType, ProjectType, TaskType};
+use moon_config::{LanguageType, PlatformType, ProjectStack, ProjectType, TaskType};
 use moon_query::{
     build_query, ComparisonOperator, Condition, Criteria, Field, FieldValues, LogicalOperator,
 };
@@ -474,6 +474,65 @@ mod mql_build {
         )]
         fn errors_for_not_like() {
             build_query("projectType!~tool").unwrap();
+        }
+    }
+
+    mod project_stack {
+        use super::*;
+
+        #[test]
+        fn valid_value() {
+            assert_eq!(
+                build_query("projectStack=frontend").unwrap(),
+                Criteria {
+                    op: LogicalOperator::And,
+                    conditions: vec![Condition::Field {
+                        field: Field::ProjectStack(vec![ProjectStack::Frontend]),
+                        op: ComparisonOperator::Equal,
+                    }],
+                    input: Some("projectStack=frontend".into())
+                }
+            );
+        }
+
+        #[test]
+        fn valid_value_list() {
+            assert_eq!(
+                build_query("projectStack!=[frontend, backend]").unwrap(),
+                Criteria {
+                    op: LogicalOperator::And,
+                    conditions: vec![Condition::Field {
+                        field: Field::ProjectStack(vec![
+                            ProjectStack::Frontend,
+                            ProjectStack::Backend
+                        ]),
+                        op: ComparisonOperator::NotEqual,
+                    }],
+                    input: Some("projectStack!=[frontend, backend]".into())
+                }
+            );
+        }
+
+        #[test]
+        #[should_panic(expected = "Unknown query value midend for field projectStack.")]
+        fn invalid_value() {
+            build_query("projectStack=midend").unwrap();
+        }
+
+        #[test]
+        #[should_panic(
+            expected = "Like operators (~ and !~) are not supported for field projectStack."
+        )]
+        fn errors_for_like() {
+            build_query("projectStack~systems").unwrap();
+        }
+
+        #[test]
+        #[should_panic(
+            expected = "Like operators (~ and !~) are not supported for field projectStack."
+        )]
+        fn errors_for_not_like() {
+            build_query("projectStack!~systems").unwrap();
         }
     }
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -19,7 +19,11 @@
 - Added a `stack` setting to `moon.yml`, for categorizing which tech stack it belongs to.
   - Supports `frontend`, `backend`, `infrastructure`, and `systems`.
   - Added a `projectStack` field to the query language (MQL).
-- Updated `envFile` task option to support a list of file paths.
+  - Added a `$projectStack` token variable for tasks.
+  - Updated the `moon query projects` command to support a `--stack` option, and include the stack
+    in the output.
+  - Updated the `moon project` command to include the stack in the output.
+- Updated the `envFile` task option to support a list of file paths.
 
 ## 1.21.3
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 #### 🚀 Updates
 
+- Added `configuration` and `scaffolding` variants to the project `type` setting in `moon.yml`.
+  - Updated project constraints to support these new variants.
+- Added a `stack` setting to `moon.yml`, for categorizing which tech stack it belongs to.
+  - Supports `frontend`, `backend`, `infrastructure`, and `systems`.
+  - Added a `projectStack` field to the query language (MQL).
 - Updated `envFile` task option to support a list of file paths.
 
 ## 1.21.3

--- a/tests/fixtures/projects/advanced/moon.yml
+++ b/tests/fixtures/projects/advanced/moon.yml
@@ -7,5 +7,6 @@ project:
 
 type: 'application'
 language: 'typescript'
+stack: 'frontend'
 
 tags: ['react']

--- a/website/docs/commands/project.mdx
+++ b/website/docs/commands/project.mdx
@@ -30,6 +30,9 @@ ID: runtime
 Alias: @moonrepo/runtime
 Source: packages/runtime
 Root: /Projects/moon/packages/runtime
+Language: typescript
+Stack: unknown
+Type: library
 
 TASKS
 

--- a/website/docs/commands/query/projects.mdx
+++ b/website/docs/commands/query/projects.mdx
@@ -23,10 +23,10 @@ $ moon query projects "task=[lint,build]"
 ```
 
 By default, this will output a list of projects in the format of
-`<id> | <source> | <type> | <language>`, separated by new lines.
+`<id> | <source> | <stack> | <type> | <language>`, separated by new lines.
 
 ```
-web | apps/web | application | typescript
+web | apps/web | frontend | application | typescript
 ```
 
 The projects can also be output in JSON ([which contains all data](/api/types/interface/Project)) by
@@ -71,6 +71,7 @@ All option values are case-insensitive regex patterns.
 - `--id <regex>` - Filter projects that match this ID/name.
 - `--language <regex>` - Filter projects of this programming language.
 - `--source <regex>` - Filter projects that match this source path.
+- `--stack <regex>` - Filter projects of the tech stack.
 - `--tags <regex>` - Filter projects that have the following tags.
 - `--tasks <regex>` - Filter projects that have the following tasks.
 - `--type <regex>` - Filter project of this type.

--- a/website/docs/concepts/query-lang.mdx
+++ b/website/docs/concepts/query-lang.mdx
@@ -104,7 +104,8 @@ projectAlias~@scope/*
 
 ### `projectName`
 
-Name of the project, as defined in [`.moon/workspace.yml`](../config/workspace).
+Name of the project, as defined in [`.moon/workspace.yml`](../config/workspace), or `id` in
+[`moon.yml`](../config/project#id).
 
 ```
 project=server
@@ -117,6 +118,14 @@ Relative file path from the workspace root to the project root, as defined in
 
 ```
 projectSource~packages/*
+```
+
+### `projectStack`<VersionLabel version="1.22.0" />
+
+The stack of the project, as defined in [`moon.yml`](../config/project#stack).
+
+```
+projectStack=frontend
 ```
 
 ### `projectType`

--- a/website/docs/concepts/token.mdx
+++ b/website/docs/concepts/token.mdx
@@ -243,6 +243,14 @@ tasks:
     command: 'vite build'
     inputs:
       - '@envs(sources)'
+
+
+# Resolves to
+tasks:
+  build:
+    command: 'vite build'
+    inputs:
+      - '$NODE_ENV'
 ```
 
 ### Inputs & outputs
@@ -449,6 +457,27 @@ tasks:
       - 'example'
       - '--cache-dir'
       - '../../.cache/apps/web'
+```
+
+### `$projectStack`<VersionLabel version="1.22.0" />
+
+The stack of the project, as defined in [`moon.yml`](../config/project#stack). If the project has
+not defined the [`stack`](../config/project#stack) setting, or does not have a config, this defaults
+to "unknown".
+
+```yaml
+# Configured as
+tasks:
+  build:
+    command: 'example debug $projectStack'
+
+# Resolves to
+tasks:
+  build:
+    command:
+      - 'example'
+      - 'debug'
+      - 'backend'
 ```
 
 ### `$projectType`

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -252,9 +252,26 @@ A human readable name of the project. This is _different_ from the unique projec
 The team or organization that owns the project. Can be a title, LDAP name, GitHub team, etc. We
 suggest _not_ listing people/developers as the owner, use [maintainers](#maintainers) instead.
 
+## `stack`<VersionLabel version="1.22.0" />
+
+<HeadingApiLink to="/api/types/interface/ProjectConfig#stack" />
+
+The technology stack this project belongs to, primarily for categorization. Supports the following
+values:
+
+- `frontend` - Client-side user interfaces, etc.
+- `backend` - Server-side APIs, database layers, etc.
+- `infrastructure` - Cloud/server infrastructure, Docker, etc.
+- `systems` - Low-level systems programming.
+- `unknown` (default) - When not configured.
+
+```yaml title="moon.yml"
+stack: 'frontend'
+```
+
 ## `tags`
 
-<HeadingApiLink to="/api/types/interface/ProjectMetadataConfig#tags" />
+<HeadingApiLink to="/api/types/interface/ProjectConfig#tags" />
 
 Tags are a simple mechanism for categorizing projects. They can be used to group projects together
 for [easier querying](../commands/query/projects), enforcing of
@@ -269,14 +286,18 @@ tags:
 
 ## `type`
 
-<HeadingApiLink to="/api/types/interface/ProjectMetadataConfig#type" />
+<HeadingApiLink to="/api/types/interface/ProjectConfig#type" />
 
 The type of project. Supports the following values:
 
-- `application` - A backend, frontend, or CLI application.
-- `automation` - Automated testing suite, like E2E, integration, or visual tests.
+- `application` - An application of any kind.
+- `automation` - An automated testing suite, like E2E, integration, or visual tests.
   <VersionLabel version="1.16.0" />
+- `configuration` - Configuration files or infrastructure.
+  <VersionLabel version="1.22.0" />
 - `library` - A self-contained, shareable, and publishable set of code.
+- `scaffolding` - Templates or generators for scaffolding.
+  <VersionLabel version="1.22.0" />
 - `tool` - An internal tool, one-off script, etc.
 - `unknown` (default) - When not configured.
 

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -166,10 +166,11 @@ Enforces allowed relationships between a project its dependencies based on the p
 error will be thrown when attempting to run a task. The following relationships are enforced when
 this setting is enabled, which defaults to `true`.
 
-- Applications can _only_ depend on libraries or tools.
+- Applications can depend on all types _except other_ applications or automation.
 - Automation can depend on all types _except other_ automation.
-- Libraries can _only_ depend on other libraries.
-- Tools can _only_ depend on libraries.
+- Libraries can _only_ depend on other libraries, configuration, or scaffolding.
+- Tools can _only_ depend on libraries, configuration, or scaffolding.
+- Configuration and scaffolding can _only_ depend on other configuration and scaffolding.
 
 ```yaml title=".moon/workspace.yml" {2}
 constraints:

--- a/website/src/components/ComparisonTable.tsx
+++ b/website/src/components/ComparisonTable.tsx
@@ -42,7 +42,7 @@ const workspaceRows: Comparison[] = [
 		feature: 'Project list configured in',
 		support: {
 			moon: '`.moon/workspace.yml`',
-			nx: '`workspace.json`',
+			nx: '`workspace.json` / `package.json` workspaces',
 			turborepo: '`package.json` workspaces',
 		},
 	},
@@ -122,7 +122,7 @@ const toolchainRows: Comparison[] = [
 	{
 		feature: 'Supported toolchain languages (automatic dev envs)',
 		support: {
-			moon: 'Bun, Deno*, Node.js, Rust',
+			moon: 'Bun, Deno, Node.js, Rust',
 		},
 	},
 	{
@@ -172,8 +172,14 @@ const projectsRows: Comparison[] = [
 	{
 		feature: 'Project type (app, lib, etc)',
 		support: {
-			moon: [SUPPORTED, 'app, lib, tool, automation'],
+			moon: [SUPPORTED, 'app, lib, tool, automation, config, scaffold'],
 			nx: [SUPPORTED, 'app, lib'],
+		},
+	},
+	{
+		feature: 'Project tech stack',
+		support: {
+			moon: [SUPPORTED, 'frontend, backend, infra, systems'],
 		},
 	},
 	{
@@ -244,7 +250,7 @@ const tasksRows: Comparison[] = [
 		feature: 'Can define tasks globally',
 		support: {
 			moon: [SUPPORTED, 'with `.moon/tasks.yml`'],
-			nx: [SUPPORTED, 'with `targetDefaults`'],
+			nx: [PARTIALLY_SUPPORTED, 'with `targetDefaults`'],
 		},
 	},
 	{
@@ -271,7 +277,7 @@ const tasksRows: Comparison[] = [
 		},
 	},
 	{
-		feature: 'Supports pipes, redirects, etc',
+		feature: 'Supports pipes, redirects, etc, in configured tasks',
 		support: {
 			moon: [PARTIALLY_SUPPORTED, 'encapsulated in a file'],
 			nx: [PARTIALLY_SUPPORTED, 'within the executor or script'],
@@ -334,7 +340,7 @@ const tasksRows: Comparison[] = [
 	{
 		feature: 'Environment variables',
 		support: {
-			moon: [SUPPORTED, 'via `env`'],
+			moon: [SUPPORTED, 'via `env`, `envFile`'],
 			nx: [SUPPORTED, 'automatically via `.env` files and/or inherited from shell'],
 			turborepo: [PARTIALLY_SUPPORTED, 'within the script'],
 		},
@@ -350,9 +356,9 @@ const tasksRows: Comparison[] = [
 	{
 		feature: 'Outputs',
 		support: {
-			moon: [SUPPORTED, 'files'],
+			moon: [SUPPORTED, 'files, globs'],
 			nx: [SUPPORTED, 'files, globs'],
-			turborepo: [SUPPORTED, 'files'],
+			turborepo: [SUPPORTED, 'files, globs'],
 		},
 	},
 	{


### PR DESCRIPTION
This will better categorize projects in VSCode, and introduces more metadata for consumers.