### PR TITLE
docs: Fix typos in intro.mdx (#1)

### DIFF
--- a/website/docs/intro.mdx
+++ b/website/docs/intro.mdx
@@ -19,7 +19,7 @@ for the web ecosystem, written in Rust. Many of the concepts within moon are hea
 Bazel and other popular build systems, but tailored for our
 [supported languages](#supported-languages).
 
-You can think of a moon as a tool that sits firmly in the middle between be Bazel (high complexity,
+You can think of a moon as a tool that sits firmly in the middle between Bazel (high complexity,
 full structure), and make/just/etc scripts (low complexity, no structure).
 
 ### Why use moon?
@@ -56,7 +56,7 @@ in unison. This is a lofty vision that requires a massive amount of time and res
 and as such, is not available on initial release, but will gradually be supported over time.
 
 To help achieve this vision, language support is broken down into 4 tiers, allowing us to
-incremental integrate and improve them over time. The 4 tiers are as follows:
+incrementally integrate and improve them over time. The 4 tiers are as follows:
 
 - &nbsp;<Label text="Tier 0" variant="failure" /> &nbsp; **No direct integration** - Tool is not
   directly supported in moon, but can still be ran using the


### PR DESCRIPTION
👋 Hopefully this is not so minor to be a nuisance. Saw a couple of things that could be cleaned up on the introduction page in the docs.

Had an extra word and a missing "ly."