### PR TITLE
fix: Fix platform detection for JS/TS projects.

### DIFF
--- a/crates/cli/src/commands/docker/prune.rs
+++ b/crates/cli/src/commands/docker/prune.rs
@@ -123,10 +123,16 @@ pub async fn prune(workspace: ResourceMut<Workspace>) {
 
     let project_graph = generate_project_graph(workspace).await?;
     let manifest: DockerManifest = json::read_file(manifest_path)?;
+    let enabled_platforms = workspace.toolchain_config.get_enabled_platforms();
     let mut platforms = FxHashSet::<PlatformType>::default();
 
     for project_id in &manifest.focused_projects {
-        platforms.insert(project_graph.get(project_id)?.language.clone().into());
+        let project = project_graph.get(project_id)?;
+
+        platforms.insert(PlatformType::from_language(
+            &project.language,
+            &enabled_platforms,
+        ));
     }
 
     // Do this later so we only run once for each platform instead of per project

--- a/crates/cli/src/commands/docker/prune.rs
+++ b/crates/cli/src/commands/docker/prune.rs
@@ -123,16 +123,10 @@ pub async fn prune(workspace: ResourceMut<Workspace>) {
 
     let project_graph = generate_project_graph(workspace).await?;
     let manifest: DockerManifest = json::read_file(manifest_path)?;
-    let enabled_platforms = workspace.toolchain_config.get_enabled_platforms();
     let mut platforms = FxHashSet::<PlatformType>::default();
 
     for project_id in &manifest.focused_projects {
-        let project = project_graph.get(project_id)?;
-
-        platforms.insert(PlatformType::from_language(
-            &project.language,
-            &enabled_platforms,
-        ));
+        platforms.insert(project_graph.get(project_id)?.platform);
     }
 
     // Do this later so we only run once for each platform instead of per project

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -83,6 +83,10 @@ pub async fn project(args: ArgsRef<ProjectArgs>, resources: ResourcesMut) {
         console.print_entry("Root", color::path(&project.root))?;
     }
 
+    if project.platform.is_javascript() {
+        console.print_entry("Platform", format!("{}", &project.platform))?;
+    }
+
     console.print_entry("Language", format!("{}", &project.language))?;
     console.print_entry("Stack", format!("{}", &project.stack))?;
     console.print_entry("Type", format!("{}", &project.type_of))?;

--- a/crates/cli/tests/snapshots/project_test__advanced_config.snap
+++ b/crates/cli/tests/snapshots/project_test__advanced_config.snap
@@ -6,6 +6,7 @@ expression: assert.output()
 
 Project: advanced
 Source: advanced
+Platform: node
 Language: typescript
 Stack: frontend
 Type: application

--- a/crates/cli/tests/snapshots/project_test__basic_config.snap
+++ b/crates/cli/tests/snapshots/project_test__basic_config.snap
@@ -6,6 +6,7 @@ expression: assert.output()
 
 Project: basic
 Source: basic
+Platform: node
 Language: javascript
 Stack: unknown
 Type: unknown

--- a/crates/cli/tests/snapshots/project_test__depends_on_paths.snap
+++ b/crates/cli/tests/snapshots/project_test__depends_on_paths.snap
@@ -6,6 +6,7 @@ expression: assert.output_standardized()
 
 Project: foo
 Source: deps/foo
+Platform: node
 Language: javascript
 Stack: unknown
 Type: application

--- a/crates/cli/tests/snapshots/project_test__root_level.snap
+++ b/crates/cli/tests/snapshots/project_test__root_level.snap
@@ -7,6 +7,7 @@ expression: assert.output()
 Project: root
 Alias: test-cases
 Source: .
+Platform: node
 Language: typescript
 Stack: unknown
 Type: unknown

--- a/crates/cli/tests/snapshots/project_test__with_tasks.snap
+++ b/crates/cli/tests/snapshots/project_test__with_tasks.snap
@@ -6,6 +6,7 @@ expression: assert.output()
 
 Project: tasks
 Source: tasks
+Platform: node
 Language: typescript
 Stack: unknown
 Type: unknown

--- a/crates/cli/tests/snapshots/run_bun_test__bun__infer_tasks__inherits_tasks.snap
+++ b/crates/cli/tests/snapshots/run_bun_test__bun__infer_tasks__inherits_tasks.snap
@@ -7,6 +7,7 @@ expression: assert.output()
 Project: scripts
 Alias: test-bun-scripts
 Source: scripts
+Platform: bun
 Language: javascript
 Stack: unknown
 Type: unknown

--- a/nextgen/config/src/language_platform.rs
+++ b/nextgen/config/src/language_platform.rs
@@ -92,37 +92,6 @@ impl PlatformType {
     pub fn is_unknown(&self) -> bool {
         matches!(self, PlatformType::Unknown)
     }
-
-    pub fn from_language(language: &LanguageType, enabled: &[PlatformType]) -> Self {
-        match language {
-            LanguageType::Unknown => PlatformType::Unknown,
-            LanguageType::Bash | LanguageType::Batch => PlatformType::System,
-            LanguageType::JavaScript | LanguageType::TypeScript => {
-                if enabled.contains(&PlatformType::Deno) {
-                    PlatformType::Deno
-                } else if enabled.contains(&PlatformType::Bun) {
-                    PlatformType::Bun
-                } else if enabled.contains(&PlatformType::Node) {
-                    PlatformType::Node
-                } else {
-                    PlatformType::System
-                }
-            }
-            LanguageType::Rust => {
-                if enabled.contains(&PlatformType::Rust) {
-                    PlatformType::Rust
-                } else {
-                    PlatformType::System
-                }
-            }
-            // TODO: Move these to their own platform once it's been implemented!
-            LanguageType::Go
-            | LanguageType::Php
-            | LanguageType::Python
-            | LanguageType::Ruby
-            | LanguageType::Other(_) => PlatformType::System,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/nextgen/config/src/language_platform.rs
+++ b/nextgen/config/src/language_platform.rs
@@ -92,16 +92,29 @@ impl PlatformType {
     pub fn is_unknown(&self) -> bool {
         matches!(self, PlatformType::Unknown)
     }
-}
 
-impl From<LanguageType> for PlatformType {
-    fn from(language: LanguageType) -> Self {
+    pub fn from_language(language: &LanguageType, enabled: &[PlatformType]) -> Self {
         match language {
             LanguageType::Unknown => PlatformType::Unknown,
             LanguageType::Bash | LanguageType::Batch => PlatformType::System,
-            // Deno and Bun are not covered here!
-            LanguageType::JavaScript | LanguageType::TypeScript => PlatformType::Node,
-            LanguageType::Rust => PlatformType::Rust,
+            LanguageType::JavaScript | LanguageType::TypeScript => {
+                if enabled.contains(&PlatformType::Deno) {
+                    PlatformType::Deno
+                } else if enabled.contains(&PlatformType::Bun) {
+                    PlatformType::Bun
+                } else if enabled.contains(&PlatformType::Node) {
+                    PlatformType::Node
+                } else {
+                    PlatformType::System
+                }
+            }
+            LanguageType::Rust => {
+                if enabled.contains(&PlatformType::Rust) {
+                    PlatformType::Rust
+                } else {
+                    PlatformType::System
+                }
+            }
             // TODO: Move these to their own platform once it's been implemented!
             LanguageType::Go
             | LanguageType::Php

--- a/nextgen/config/src/toolchain_config.rs
+++ b/nextgen/config/src/toolchain_config.rs
@@ -1,6 +1,6 @@
 // .moon/toolchain.yml
 
-use crate::language_platform::PlatformType;
+use crate::language_platform::*;
 use crate::toolchain::*;
 use rustc_hash::FxHashMap;
 use schematic::{validate, Config};

--- a/nextgen/platform-detector/src/lib.rs
+++ b/nextgen/platform-detector/src/lib.rs
@@ -1,8 +1,10 @@
 mod language_files;
 mod languages;
 mod project_language;
+mod project_platform;
 mod task_platform;
 
 pub use language_files::*;
 pub use project_language::*;
+pub use project_platform::*;
 pub use task_platform::*;

--- a/nextgen/platform-detector/src/project_language.rs
+++ b/nextgen/platform-detector/src/project_language.rs
@@ -2,7 +2,7 @@ use crate::languages::*;
 use moon_config::LanguageType;
 use std::path::Path;
 
-fn has_language_files(root: &Path, files: StaticStringList) -> bool {
+pub fn has_language_files(root: &Path, files: StaticStringList) -> bool {
     files.iter().any(|file| root.join(file).exists())
 }
 

--- a/nextgen/platform-detector/src/project_platform.rs
+++ b/nextgen/platform-detector/src/project_platform.rs
@@ -1,0 +1,40 @@
+use crate::languages::DENO;
+use crate::project_language::has_language_files;
+use moon_config::{LanguageType, PlatformType};
+use std::path::Path;
+
+pub fn detect_project_platform(
+    root: &Path,
+    language: &LanguageType,
+    enabled_platforms: &[PlatformType],
+) -> PlatformType {
+    match language {
+        LanguageType::JavaScript | LanguageType::TypeScript => {
+            if enabled_platforms.contains(&PlatformType::Deno) && has_language_files(root, DENO) {
+                return PlatformType::Deno;
+            }
+
+            if enabled_platforms.contains(&PlatformType::Bun)
+                && enabled_platforms.contains(&PlatformType::Node)
+            {
+                return PlatformType::Node;
+            }
+
+            if enabled_platforms.contains(&PlatformType::Bun) {
+                PlatformType::Bun
+            } else if enabled_platforms.contains(&PlatformType::Node) {
+                PlatformType::Node
+            } else {
+                PlatformType::System
+            }
+        }
+        LanguageType::Rust => {
+            if enabled_platforms.contains(&PlatformType::Rust) {
+                PlatformType::Rust
+            } else {
+                PlatformType::System
+            }
+        }
+        _ => PlatformType::System,
+    }
+}

--- a/nextgen/project-builder/src/project_builder.rs
+++ b/nextgen/project-builder/src/project_builder.rs
@@ -6,7 +6,7 @@ use moon_config::{
     ToolchainConfig,
 };
 use moon_file_group::FileGroup;
-use moon_platform_detector::detect_project_language;
+use moon_platform_detector::{detect_project_language, detect_project_platform};
 use moon_project::Project;
 use moon_task::{TargetScope, Task};
 use moon_task_builder::{TasksBuilder, TasksBuilderContext};
@@ -117,7 +117,8 @@ impl<'app> ProjectBuilder<'app> {
 
         // Use configured platform or infer from language
         self.platform = config.platform.unwrap_or_else(|| {
-            let platform = PlatformType::from_language(
+            let platform = detect_project_platform(
+                &self.project_root,
                 &self.language,
                 &self.context.toolchain_config.get_enabled_platforms(),
             );

--- a/nextgen/project-builder/src/project_builder.rs
+++ b/nextgen/project-builder/src/project_builder.rs
@@ -117,13 +117,16 @@ impl<'app> ProjectBuilder<'app> {
 
         // Use configured platform or infer from language
         self.platform = config.platform.unwrap_or_else(|| {
-            let platform: PlatformType = self.language.clone().into();
+            let platform = PlatformType::from_language(
+                &self.language,
+                &self.context.toolchain_config.get_enabled_platforms(),
+            );
 
             trace!(
                 id = self.id.as_str(),
                 language = ?self.language,
                 platform = ?self.platform,
-                "Unknown tasks platform, inferring from language",
+                "Unknown tasks platform, inferring from language and toolchain",
             );
 
             platform

--- a/nextgen/project-builder/tests/project_builder_test.rs
+++ b/nextgen/project-builder/tests/project_builder_test.rs
@@ -21,11 +21,12 @@ struct Stub {
 
 impl Stub {
     pub fn new(id: &str, root: &Path) -> Self {
-        let mut toolchain_config = ToolchainConfig::default();
-
         // Enable platforms so that detection works
-        toolchain_config.node = Some(NodeConfig::default());
-        toolchain_config.rust = Some(RustConfig::default());
+        let toolchain_config = ToolchainConfig {
+            node: Some(NodeConfig::default()),
+            rust: Some(RustConfig::default()),
+            ..ToolchainConfig::default()
+        };
 
         Self {
             toolchain_config,

--- a/nextgen/project-builder/tests/project_builder_test.rs
+++ b/nextgen/project-builder/tests/project_builder_test.rs
@@ -2,7 +2,7 @@ use moon_common::path::WorkspaceRelativePathBuf;
 use moon_common::Id;
 use moon_config::{
     DependencyConfig, DependencyScope, DependencySource, InheritedTasksManager, LanguageType,
-    PlatformType, TaskArgs, TaskConfig, ToolchainConfig,
+    NodeConfig, PlatformType, RustConfig, TaskArgs, TaskConfig, ToolchainConfig,
 };
 use moon_file_group::FileGroup;
 use moon_project::Project;
@@ -21,8 +21,14 @@ struct Stub {
 
 impl Stub {
     pub fn new(id: &str, root: &Path) -> Self {
+        let mut toolchain_config = ToolchainConfig::default();
+
+        // Enable platforms so that detection works
+        toolchain_config.node = Some(NodeConfig::default());
+        toolchain_config.rust = Some(RustConfig::default());
+
         Self {
-            toolchain_config: ToolchainConfig::default(),
+            toolchain_config,
             workspace_root: root.to_path_buf(),
             id: Id::raw(id),
             source: WorkspaceRelativePathBuf::from(id),

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -31,7 +31,9 @@
 #### 🐞 Fixes
 
 - Fixed an issue where a project's `platform` was being detected as `node` (when not enabled), and
-  should have been `bun`.
+  should have been `bun`. If you're using both `bun` and `node` in the same workspace, moon has a
+  hard time detecting which should be used for what project. If you run into issues, explicitly set
+  the `platform` in the project's `moon.yml`.
 - Fixed an issue where template files couldn't import/include/extends files from extended templates.
 - Fixed template enum variable default values being able to use a non-supported value.
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 #### 🐞 Fixes
 
+- Fixed an issue where a project's `platform` was being detected as `node` (when not enabled), and
+  should have been `bun`.
 - Fixed an issue where template files couldn't import/include/extends files from extended templates.
 - Fixed template enum variable default values being able to use a non-supported value.
 


### PR DESCRIPTION
We would always default to node, but this logic works better.

It's still a bit iffy deducing deno/bun/node explicitly though.