### PR TITLE
feat: add mutex option to task configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,6 +3059,7 @@ name = "moon_action_context"
 version = "0.0.1"
 dependencies = [
  "clap",
+ "dashmap",
  "moon_common",
  "moon_target",
  "relative-path",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3064,6 +3064,7 @@ dependencies = [
  "relative-path",
  "rustc-hash",
  "serde",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ clap = { version = "4.5.4", default-features = false, features = [
 ] }
 clap_complete = "4.5.2"
 console = "0.15.8"
+dashmap = "5.5.3"
 dirs = "5.0.1"
 miette = "7.2.0"
 once_cell = "1.19.0"

--- a/crates/core/action-context/Cargo.toml
+++ b/crates/core/action-context/Cargo.toml
@@ -11,3 +11,4 @@ clap = { workspace = true }
 relative-path = { workspace = true, features = ["serde"] }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
+tokio = { workspace = true }

--- a/crates/core/action-context/Cargo.toml
+++ b/crates/core/action-context/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 moon_common = { path = "../../../nextgen/common" }
 moon_target = { path = "../../../nextgen/target" }
 clap = { workspace = true }
+dashmap = { workspace = true }
 relative-path = { workspace = true, features = ["serde"] }
 rustc-hash = { workspace = true }
 serde = { workspace = true }

--- a/crates/core/action-context/src/lib.rs
+++ b/crates/core/action-context/src/lib.rs
@@ -31,35 +31,7 @@ pub struct TaskNamedMutexes {
     mutexes: Arc<std::sync::Mutex<FxHashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
 }
 
-impl<'de> Deserialize<'de> for TaskNamedMutexes {
-    fn deserialize<D>(_: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        // We don't care about unserializing this, but we need to satisfy the
-        // trait requirements.
-        Ok(TaskNamedMutexes::new())
-    }
-}
-
-impl Serialize for TaskNamedMutexes {
-    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        // We don't care about serializing this, but we need to satisfy the
-        // trait requirements.
-        FxHashMap::<String, ()>::default().serialize(_serializer)
-    }
-}
-
 impl TaskNamedMutexes {
-    fn new() -> Self {
-        TaskNamedMutexes {
-            mutexes: Arc::new(std::sync::Mutex::new(FxHashMap::default())),
-        }
-    }
-
     pub fn get(&self, name: &str) -> Arc<tokio::sync::Mutex<()>> {
         // TODO: Check how to remove that `unwrap`
         let mut mutexes = self.mutexes.lock().unwrap();
@@ -77,6 +49,7 @@ pub struct ActionContext {
 
     pub initial_targets: FxHashSet<TargetLocator>,
 
+    #[serde(skip)]
     pub named_mutexes: TaskNamedMutexes,
 
     pub passthrough_args: Vec<String>,

--- a/crates/core/action-pipeline/src/actions/run_task.rs
+++ b/crates/core/action-pipeline/src/actions/run_task.rs
@@ -94,34 +94,34 @@ pub async fn run_task(
             .insert(target.clone(), TargetState::Passthrough);
     }
 
-    let attempts_result = if is_cache_enabled {
-        if let Some(mutex_name) = &task.options.mutex {
-            let context = context.read().await;
-
-            let named_mutex = context.named_mutexes.get(mutex_name);
-            let _guard = named_mutex.lock().await;
-
-            runner.create_and_run_command(&context, runtime).await
+    let attempts_result = {
+        let _ctx: Arc<RwLock<ActionContext>>;
+        let ctx = if is_cache_enabled {
+            &context
         } else {
-            let context = context.read().await;
+            // Concurrent long-running tasks will cause a deadlock, as some threads will
+            // attempt to write to context while others are reading from it, and long-running
+            // tasks may never release the lock. Unfortuantely we have to clone here to work
+            // around it, so revisit in the future.
+            _ctx = Arc::new(RwLock::new(context.read().await.clone()));
+            &_ctx
+        };
+        let ctx = ctx.read().await;
 
-            runner.create_and_run_command(&context, runtime).await
+        if let Some(mutex_name) = &task.options.mutex {
+            if let Some(named_mutex) = ctx.named_mutexes.get(mutex_name) {
+                let _guard = named_mutex.lock().await;
+
+                runner.create_and_run_command(&ctx, runtime).await
+            } else {
+                Result::Err(miette::Report::msg(format!(
+                    "Unable to acquire named mutex \"{}\"",
+                    mutex_name
+                )))
+            }
+        } else {
+            runner.create_and_run_command(&ctx, runtime).await
         }
-    } else if let Some(mutex_name) = &task.options.mutex {
-        let context = (context.read().await).clone();
-
-        let named_mutex = context.named_mutexes.get(mutex_name);
-        let _guard = named_mutex.lock().await;
-
-        runner.create_and_run_command(&context, runtime).await
-    } else {
-        // Concurrent long-running tasks will cause a deadlock, as some threads will
-        // attempt to write to context while others are reading from it, and long-running
-        // tasks may never release the lock. Unfortuantely we have to clone here to work
-        // around it, so revisit in the future.
-        let context = (context.read().await).clone();
-
-        runner.create_and_run_command(&context, runtime).await
     };
 
     match attempts_result {

--- a/nextgen/config/src/project/task_options_config.rs
+++ b/nextgen/config/src/project/task_options_config.rs
@@ -201,6 +201,10 @@ cacheable!(
         /// The strategy to use when merging `outputs` with an inherited task.
         pub merge_outputs: Option<TaskMergeStrategy>,
 
+        /// Creates an exclusive lock on a virtual resource, preventing other
+        /// tasks using the same resource from running concurrently.
+        pub mutex: Option<String>,
+
         /// The style in which task output will be printed to the console.
         #[setting(env = "MOON_OUTPUT_STYLE")]
         pub output_style: Option<TaskOutputStyle>,

--- a/nextgen/task-builder/src/tasks_builder.rs
+++ b/nextgen/task-builder/src/tasks_builder.rs
@@ -516,6 +516,10 @@ impl<'proj> TasksBuilder<'proj> {
                 options.merge_outputs = *merge_outputs;
             }
 
+            if let Some(mutex) = &config.mutex {
+                options.mutex = Some(mutex.clone());
+            }
+
             if let Some(output_style) = &config.output_style {
                 options.output_style = Some(*output_style);
             }

--- a/nextgen/task/src/task_options.rs
+++ b/nextgen/task/src/task_options.rs
@@ -31,6 +31,8 @@ cacheable!(
 
         pub merge_outputs: TaskMergeStrategy,
 
+        pub mutex: Option<String>,
+
         pub output_style: Option<TaskOutputStyle>,
 
         pub persistent: bool,
@@ -67,6 +69,7 @@ impl Default for TaskOptions {
             merge_env: TaskMergeStrategy::Append,
             merge_inputs: TaskMergeStrategy::Append,
             merge_outputs: TaskMergeStrategy::Append,
+            mutex: None,
             output_style: None,
             persistent: false,
             retry_count: 0,

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -39,6 +39,7 @@ export interface TaskOptions {
 	mergeInputs: TaskMergeStrategy;
 	mergeOutputs: TaskMergeStrategy;
 	outputStyle: TaskOutputStyle | null;
+	mutex: string | null;
 	persistent: boolean;
 	retryCount: number;
 	runDepsInParallel: boolean;

--- a/packages/types/src/tasks-config.ts
+++ b/packages/types/src/tasks-config.ts
@@ -89,6 +89,11 @@ export interface TaskOptionsConfig {
 	 */
 	mergeOutputs: TaskMergeStrategy | null;
 	/**
+	 * Creates an exclusive lock on a virtual resource, preventing other tasks
+	 * using the same resource from running concurrently.
+	 */
+	mutex: string | null;
+	/**
 	 * The style in which task output will be printed to the console.
 	 *
 	 * @default 'buffer'
@@ -302,6 +307,11 @@ export interface PartialTaskOptionsConfig {
 	 * @default 'append'
 	 */
 	mergeOutputs?: TaskMergeStrategy | null;
+	/**
+	 * Creates an exclusive lock on a virtual resource, preventing other tasks
+	 * using the same resource from running concurrently.
+	 */
+	mutex?: string | null;
 	/**
 	 * The style in which task output will be printed to the console.
 	 *

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -980,6 +980,32 @@ The [strategy](../concepts/task-inheritance#merge-strategies) to use when mergin
 The [strategy](../concepts/task-inheritance#merge-strategies) to use when merging the
 [`outputs`](#outputs) list with an inherited task. Defaults to "append".
 
+#### `mutex`
+
+<HeadingApiLink to="/api/types/interface/TaskOptionsConfig#mutex" />
+
+Creates an exclusive lock on a "virtual resource", preventing other tasks using
+the same "virtual resource" from running concurrently.
+
+If you have many tasks that require exclusive access to a resource that can't be
+tracked by Moon (like a database, an ignored file, a file that's not part of
+the project, or a remote resource) you can use the `mutex` option to prevent them
+from running at the same time.
+
+```yaml title="moon.yml" {5}
+tasks:
+  task_a:
+    # ...
+    options:
+      mutex: 'virtual_resource_name'
+
+  # task_b doesn't necessarily have to be in the same project
+  task_b:
+    # ...
+    options:
+      mutex: 'virtual_resource_name'
+```
+
 #### `outputStyle`
 
 <HeadingApiLink to="/api/types/interface/TaskOptionsConfig#outputStyle" />

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -984,13 +984,12 @@ The [strategy](../concepts/task-inheritance#merge-strategies) to use when mergin
 
 <HeadingApiLink to="/api/types/interface/TaskOptionsConfig#mutex" />
 
-Creates an exclusive lock on a "virtual resource", preventing other tasks using
-the same "virtual resource" from running concurrently.
+Creates an exclusive lock on a "virtual resource", preventing other tasks using the same "virtual
+resource" from running concurrently.
 
-If you have many tasks that require exclusive access to a resource that can't be
-tracked by Moon (like a database, an ignored file, a file that's not part of
-the project, or a remote resource) you can use the `mutex` option to prevent them
-from running at the same time.
+If you have many tasks that require exclusive access to a resource that can't be tracked by Moon
+(like a database, an ignored file, a file that's not part of the project, or a remote resource) you
+can use the `mutex` option to prevent them from running at the same time.
 
 ```yaml title="moon.yml" {5}
 tasks:

--- a/website/static/schemas/project.json
+++ b/website/static/schemas/project.json
@@ -1098,6 +1098,19 @@
           ],
           "markdownDescription": "The strategy to use when merging `outputs` with an inherited task."
         },
+        "mutex": {
+          "title": "mutex",
+          "description": "Creates an exclusive lock on a virtual resource, preventing other tasks using the same resource from running concurrently.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "Creates an exclusive lock on a virtual resource, preventing other tasks using the same resource from running concurrently."
+        },
         "outputStyle": {
           "title": "outputStyle",
           "description": "The style in which task output will be printed to the console.",

--- a/website/static/schemas/tasks.json
+++ b/website/static/schemas/tasks.json
@@ -503,6 +503,19 @@
           ],
           "markdownDescription": "The strategy to use when merging `outputs` with an inherited task."
         },
+        "mutex": {
+          "title": "mutex",
+          "description": "Creates an exclusive lock on a virtual resource, preventing other tasks using the same resource from running concurrently.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "Creates an exclusive lock on a virtual resource, preventing other tasks using the same resource from running concurrently."
+        },
         "outputStyle": {
           "title": "outputStyle",
           "description": "The style in which task output will be printed to the console.",

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": ["../tsconfig.options.json", "@docusaurus/tsconfig"],
+  "extends": [
+    "../tsconfig.options.json",
+    "@docusaurus/tsconfig"
+  ],
   "compilerOptions": {
     "emitDeclarationOnly": true,
     "noEmit": false,
@@ -7,7 +10,9 @@
     "verbatimModuleSyntax": false,
     "baseUrl": ".",
     "paths": {
-      "@site/*": ["./*"]
+      "@site/*": [
+        "./*"
+      ]
     }
   },
   "include": [


### PR DESCRIPTION
## Description

This PR introduces a new `mutex` option to task options. This new option is intended to allow telling Moon when two or more tasks can't be executed at the same time.

Example:

```yaml
tasks:
  task_a:
    command: 'do something'
    options:
      # this is an "abstract mutex", not tied to the filesystem, so we
      # don't risk problems related to ignored files, and also allows us
      # to "protect" remote resources that can't be modelled by Moon.
      mutex: 'resource_1'
  task_b:
    command: 'do something else'
    options:
      mutex: 'resource_1' # task_a and task_b won't run at the same time
```

Closes #1415 .

## Pending tasks
- [X] Complete PR description
- [x] Remove some `unwrap` calls
- [ ] Add new automated tests
- [x] Exhaustive manual testing (I already did some testing with good results, but I didn't stress the tool too much yet).
