### PR TITLE
docs: Add black plugin

### DIFF
--- a/website/src/data/proto-tools.tsx
+++ b/website/src/data/proto-tools.tsx
@@ -182,6 +182,19 @@ export const THIRD_PARTY_TOOLS: Record<string, ProtoTool | ProtoTool[]> = {
 		pluginType: 'toml',
 		repoUrl: 'https://github.com/Phault/proto-toml-plugins',
 	},
+	black: {
+		author: 'appthrust',
+		bins: ['black'],
+		description:
+			'The uncompromising Python code formatter',
+		homepageUrl: 'https://black.readthedocs.io/en/stable/',
+		name: 'Black',
+		noIcon: true,
+		pluginLocator:
+			'source:https://raw.githubusercontent.com/appthrust/proto-toml-plugins/main/black/plugin.toml',
+		pluginType: 'toml',
+		repoUrl: 'https://github.com/appthrust/proto-toml-plugins',
+	},
 	buf: {
 		author: 'stk0vrfl0w',
 		bins: ['buf'],

--- a/website/src/data/proto-tools.tsx
+++ b/website/src/data/proto-tools.tsx
@@ -185,8 +185,7 @@ export const THIRD_PARTY_TOOLS: Record<string, ProtoTool | ProtoTool[]> = {
 	black: {
 		author: 'appthrust',
 		bins: ['black'],
-		description:
-			'The uncompromising Python code formatter',
+		description: 'The uncompromising Python code formatter',
 		homepageUrl: 'https://black.readthedocs.io/en/stable/',
 		name: 'Black',
 		noIcon: true,


### PR DESCRIPTION
This pull request introduces a new plugin for [Black](https://black.readthedocs.io/en/stable/), a widely-used Python code formatter. 