### PR TITLE
Add Shebang to packages/cli/moon to Resolve Exec Format Error on Linux

### DIFF
--- a/packages/cli/moon
+++ b/packages/cli/moon
@@ -1,3 +1,8 @@
 #!/bin/sh
 
+# This script is a placeholder used by package managers for linking the core binary.
+# To run the moon tool directly from the repository, use the following command:
+# cargo run
+
 echo "This file is necessary for package managers to link the core binary!"
+echo "If you want to run moon from the repo, please use: cargo run"

--- a/packages/cli/moon
+++ b/packages/cli/moon
@@ -1,1 +1,3 @@
-This file is necessary for package managers to link the core binary!
+#!/bin/sh
+
+echo "This file is necessary for package managers to link the core binary!"


### PR DESCRIPTION
After cloning the moonrepo repository, I noticed that the contents of `packages/cli/moon` are in plain text and do not include a shebang line. This absence leads to an "Exec format error (os error 8)" when trying to execute the script on Linux, making it difficult to understand the error. 

However, the script merely outputs text when run on macOS. To address this issue and clarify the script's purpose across different operating systems, I have added a shebang line to the script.
