### PR TITLE
fix: Fix proto falling back to any version.

### DIFF
--- a/.yarn/versions/41d19279.yml
+++ b/.yarn/versions/41d19279.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/bun/tool/src/bun_tool.rs
+++ b/crates/bun/tool/src/bun_tool.rs
@@ -149,9 +149,6 @@ impl DependencyManager<()> for BunTool {
             cmd.env("PROTO_BUN_VERSION", version);
         }
 
-        // Tell proto to resolve instead of failing
-        cmd.env_if_missing("PROTO_BUN_VERSION", "*");
-
         Ok(cmd)
     }
 

--- a/crates/core/runner/src/runner.rs
+++ b/crates/core/runner/src/runner.rs
@@ -424,68 +424,43 @@ impl<'a> Runner<'a> {
 
         // Pin versions for each tool in the toolchain
         if let Some(bun_config) = &self.workspace.toolchain_config.bun {
-            command.env_if_missing(
-                "PROTO_BUN_VERSION",
-                bun_config
-                    .version
-                    .as_ref()
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "*".into()),
-            );
+            if let Some(version) = &bun_config.version {
+                command.env_if_missing("PROTO_BUN_VERSION", version.to_string());
+            }
+        }
+
+        if let Some(deno_config) = &self.workspace.toolchain_config.deno {
+            if let Some(version) = &deno_config.version {
+                command.env_if_missing("PROTO_DENO_VERSION", version.to_string());
+            }
         }
 
         if let Some(node_config) = &self.workspace.toolchain_config.node {
-            command.env_if_missing(
-                "PROTO_NODE_VERSION",
-                node_config
-                    .version
-                    .as_ref()
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "*".into()),
-            );
+            if let Some(version) = &node_config.version {
+                command.env_if_missing("PROTO_NODE_VERSION", version.to_string());
+            }
 
-            command.env_if_missing(
-                "PROTO_NPM_VERSION",
-                node_config
-                    .npm
-                    .version
-                    .as_ref()
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "*".into()),
-            );
+            if let Some(version) = &node_config.npm.version {
+                command.env_if_missing("PROTO_NPM_VERSION", version.to_string());
+            }
 
             if let Some(pnpm_config) = &node_config.pnpm {
-                command.env_if_missing(
-                    "PROTO_PNPM_VERSION",
-                    pnpm_config
-                        .version
-                        .as_ref()
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| "*".into()),
-                );
+                if let Some(version) = &pnpm_config.version {
+                    command.env_if_missing("PROTO_PNPM_VERSION", version.to_string());
+                }
             }
 
             if let Some(yarn_config) = &node_config.yarn {
-                command.env_if_missing(
-                    "PROTO_YARN_VERSION",
-                    yarn_config
-                        .version
-                        .as_ref()
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| "*".into()),
-                );
+                if let Some(version) = &yarn_config.version {
+                    command.env_if_missing("PROTO_YARN_VERSION", version.to_string());
+                }
             }
-        }
 
-        // Pin a version for all plugins so that global/system tasks work well
-        for plugin in self.workspace.proto_config.plugins.keys() {
-            command.env_if_missing(
-                format!(
-                    "PROTO_{}_VERSION",
-                    plugin.as_str().to_uppercase().replace('-', "_")
-                ),
-                "*",
-            );
+            if let Some(bunpm_config) = &node_config.bun {
+                if let Some(version) = &bunpm_config.version {
+                    command.env_if_missing("PROTO_BUN_VERSION", version.to_string());
+                }
+            }
         }
 
         Ok(())

--- a/crates/deno/tool/src/deno_tool.rs
+++ b/crates/deno/tool/src/deno_tool.rs
@@ -159,7 +159,6 @@ impl DependencyManager<()> for DenoTool {
             cmd.env("PROTO_DENO_VERSION", version);
         }
 
-
         Ok(cmd)
     }
 

--- a/crates/deno/tool/src/deno_tool.rs
+++ b/crates/deno/tool/src/deno_tool.rs
@@ -159,8 +159,6 @@ impl DependencyManager<()> for DenoTool {
             cmd.env("PROTO_DENO_VERSION", version);
         }
 
-        // Tell proto to resolve instead of failing
-        cmd.env_if_missing("PROTO_DENO_VERSION", "*");
 
         Ok(cmd)
     }

--- a/crates/node/tool/src/bun_tool.rs
+++ b/crates/node/tool/src/bun_tool.rs
@@ -63,9 +63,6 @@ impl BunTool {
             cmd.env("PROTO_BUN_VERSION", version);
         }
 
-        // Tell proto to resolve instead of failing
-        cmd.env_if_missing("PROTO_BUN_VERSION", "*");
-
         Ok(cmd)
     }
 }
@@ -158,10 +155,6 @@ impl DependencyManager<NodeTool> for BunTool {
         if let Some(version) = get_proto_version_env(&node.tool) {
             cmd.env("PROTO_NODE_VERSION", version);
         }
-
-        // Tell proto to resolve instead of failing
-        cmd.env_if_missing("PROTO_BUN_VERSION", "*");
-        cmd.env_if_missing("PROTO_NODE_VERSION", "*");
 
         Ok(cmd)
     }

--- a/crates/node/tool/src/node_tool.rs
+++ b/crates/node/tool/src/node_tool.rs
@@ -141,9 +141,6 @@ impl NodeTool {
                     cmd.env("PROTO_NODE_VERSION", version);
                 }
 
-                // Tell proto to resolve instead of failing
-                cmd.env_if_missing("PROTO_NODE_VERSION", "*");
-
                 if !self.global {
                     cmd.env(
                         "PATH",

--- a/crates/node/tool/src/npm_tool.rs
+++ b/crates/node/tool/src/npm_tool.rs
@@ -137,10 +137,6 @@ impl DependencyManager<NodeTool> for NpmTool {
             cmd.env("PROTO_NODE_VERSION", version);
         }
 
-        // Tell proto to resolve instead of failing
-        cmd.env_if_missing("PROTO_NPM_VERSION", "*");
-        cmd.env_if_missing("PROTO_NODE_VERSION", "*");
-
         Ok(cmd)
     }
 

--- a/crates/node/tool/src/pnpm_tool.rs
+++ b/crates/node/tool/src/pnpm_tool.rs
@@ -145,10 +145,6 @@ impl DependencyManager<NodeTool> for PnpmTool {
             cmd.env("PROTO_NODE_VERSION", version);
         }
 
-        // Tell proto to resolve instead of failing
-        cmd.env_if_missing("PROTO_PNPM_VERSION", "*");
-        cmd.env_if_missing("PROTO_NODE_VERSION", "*");
-
         Ok(cmd)
     }
 

--- a/crates/node/tool/src/yarn_tool.rs
+++ b/crates/node/tool/src/yarn_tool.rs
@@ -207,10 +207,6 @@ impl DependencyManager<NodeTool> for YarnTool {
             cmd.env("PROTO_NODE_VERSION", version);
         }
 
-        // Tell proto to resolve instead of failing
-        cmd.env_if_missing("PROTO_YARN_VERSION", "*");
-        cmd.env_if_missing("PROTO_NODE_VERSION", "*");
-
         Ok(cmd)
     }
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,12 @@
   - More accurately monitors signals (ctrl+c) and shutdowns.
   - Tasks can now be configured with a timeout.
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where versions in `.prototools` weren't being respected.
+
 ## 1.24.0
 
 #### 🚀 Updates


### PR DESCRIPTION
This causes `.prototools` to be ignored.