### PR TITLE
Fix Git hooks not created with trailing newlines

### DIFF
--- a/.yarn/versions/18cba9f6.yml
+++ b/.yarn/versions/18cba9f6.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/nextgen/vcs-hooks/src/hooks_generator.rs
+++ b/nextgen/vcs-hooks/src/hooks_generator.rs
@@ -210,6 +210,7 @@ impl<'app> HooksGenerator<'app> {
         for command in commands {
             contents.push(command);
         }
+        contents.push("\n");
 
         self.create_file(file_path, contents.join("\n"))?;
 

--- a/nextgen/vcs-hooks/tests/hooks_generator_test.rs
+++ b/nextgen/vcs-hooks/tests/hooks_generator_test.rs
@@ -140,6 +140,22 @@ mod unix {
     }
 
     #[tokio::test]
+    async fn creates_hook_files_with_trailing_newline() {
+        let sandbox = create_empty_sandbox();
+        sandbox.enable_git();
+
+        run_generator(sandbox.path()).await;
+
+        let pre_commit = sandbox.path().join(".moon/hooks/pre-commit.sh");
+
+        assert!(pre_commit.exists());
+        assert_eq!(
+            fs::read_to_string(pre_commit).unwrap().chars().last(),
+            Some('\n')
+        )
+    }
+
+    #[tokio::test]
     async fn links_git_hooks() {
         let sandbox = create_empty_sandbox();
         sandbox.enable_git();


### PR DESCRIPTION
These files could create spurious diffs if someone were to open them with an editor that automatically fixes new lines, or when running with something to automatically fix missing new lines, e.g. a pre-commit hook[1]

[1] https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#end-of-file-fixer