### PR TITLE
typo: monorepo.dev -> moonrepo.dev

### DIFF
--- a/.yarn/versions/42a4d275.yml
+++ b/.yarn/versions/42a4d275.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/cli/src/commands/init/mod.rs
+++ b/crates/cli/src/commands/init/mod.rs
@@ -258,7 +258,7 @@ pub async fn init(
 
     stdout.write_line(format!(
         "  Learn more: {}",
-        color::url("https://monorepo.dev/docs")
+        color::url("https://moonrepo.dev/docs")
     ))?;
 
     stdout.write_line(format!(


### PR DESCRIPTION
Currently when you create a new repo it spits out 

![image](https://github.com/moonrepo/moon/assets/1617878/657c1606-a78c-4cd7-8667-4905965774f5)

This link does not exist. Must have meant https://moonrepo.dev/docs 😄 
