### PR TITLE
fix: Fix bun version discrepancies.

### DIFF
--- a/.yarn/versions/5614e87e.yml
+++ b/.yarn/versions/5614e87e.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,6 +3447,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "starbase_sandbox",
  "tracing",
  "version_spec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ scc = "2.1.1"
 schematic = { version = "0.16.3", default-features = false, features = [
 	"schema",
 ] }
+serial_test = "3.1.1"
 semver = "1.0.23"
 serde = { version = "1.0.202", features = ["derive"] }
 serde_json = "1.0.117"

--- a/crates/cache-item/Cargo.toml
+++ b/crates/cache-item/Cargo.toml
@@ -15,7 +15,7 @@ starbase_utils = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-serial_test = "3.1.1"
+serial_test = { workspace = true }
 starbase_sandbox = { workspace = true }
 
 [lints]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -48,6 +48,7 @@ tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 httpmock = "0.7.0"
+serial_test = { workspace = true }
 starbase_sandbox = { workspace = true }
 
 [features]

--- a/crates/config/src/toolchain_config.rs
+++ b/crates/config/src/toolchain_config.rs
@@ -200,9 +200,9 @@ impl ToolchainConfig {
             // version takes precedence!
             match (&mut self.bun, &mut node_config.bun) {
                 (Some(bun_config), Some(bunpm_config)) => {
-                    if bun_config.version.is_some() {
+                    if bun_config.version.is_some() && bunpm_config.version.is_none() {
                         bunpm_config.version = bun_config.version.clone();
-                    } else if bunpm_config.version.is_some() {
+                    } else if bunpm_config.version.is_some() && bun_config.version.is_none() {
                         bun_config.version = bunpm_config.version.clone();
                     }
                 }

--- a/crates/config/tests/toolchain_config_test.rs
+++ b/crates/config/tests/toolchain_config_test.rs
@@ -3,6 +3,7 @@ mod utils;
 use httpmock::prelude::*;
 use moon_config::{BinConfig, BinEntry, NodePackageManager, NodeVersionFormat, ToolchainConfig};
 use proto_core::{Id, PluginLocator, ProtoConfig, UnresolvedVersionSpec};
+use serial_test::serial;
 use starbase_sandbox::{create_empty_sandbox, create_sandbox};
 use std::env;
 use utils::*;
@@ -188,6 +189,7 @@ deno: {{}}
         }
 
         #[test]
+        #[serial]
         fn proto_version_doesnt_override() {
             let config = test_load_config(
                 FILENAME,
@@ -214,6 +216,7 @@ bun:
         }
 
         #[test]
+        #[serial]
         fn inherits_version_from_env_var() {
             env::set_var("MOON_BUN_VERSION", "1.0.0");
 
@@ -221,7 +224,7 @@ bun:
                 FILENAME,
                 r"
 bun:
-    version: 3.0.0
+  version: 3.0.0
 ",
                 |path| {
                     let mut proto = ProtoConfig::default();
@@ -238,6 +241,31 @@ bun:
 
             assert_eq!(
                 config.bun.unwrap().version.unwrap(),
+                UnresolvedVersionSpec::parse("1.0.0").unwrap()
+            );
+        }
+
+        #[test]
+        fn inherits_version_from_node_pm() {
+            let config = test_load_config(
+                FILENAME,
+                r"
+bun: {}
+node:
+  packageManager: bun
+  bun:
+    version: 1.0.0
+",
+                |path| ToolchainConfig::load_from(path, &ProtoConfig::default()),
+            );
+
+            assert_eq!(
+                config.bun.unwrap().version.unwrap(),
+                UnresolvedVersionSpec::parse("1.0.0").unwrap()
+            );
+
+            assert_eq!(
+                config.node.unwrap().bun.unwrap().version.unwrap(),
                 UnresolvedVersionSpec::parse("1.0.0").unwrap()
             );
         }
@@ -341,6 +369,7 @@ deno:
         }
 
         #[test]
+        #[serial]
         fn proto_version_doesnt_override() {
             let config = test_load_config(
                 FILENAME,
@@ -367,6 +396,7 @@ deno:
         }
 
         #[test]
+        #[serial]
         fn inherits_version_from_env_var() {
             env::set_var("MOON_DENO_VERSION", "1.20.0");
 
@@ -466,6 +496,7 @@ node:
         }
 
         #[test]
+        #[serial]
         fn proto_version_doesnt_override() {
             let config = test_load_config(
                 FILENAME,
@@ -492,6 +523,7 @@ node:
         }
 
         #[test]
+        #[serial]
         fn inherits_version_from_env_var() {
             env::set_var("MOON_NODE_VERSION", "19.0.0");
 
@@ -524,6 +556,7 @@ node:
             use super::*;
 
             #[test]
+            #[serial]
             fn proto_version_doesnt_override() {
                 let config = test_load_config(
                     FILENAME,
@@ -567,6 +600,7 @@ node:
             }
 
             #[test]
+            #[serial]
             fn inherits_version_from_env_var() {
                 env::set_var("MOON_NPM_VERSION", "10.0.0");
 
@@ -682,6 +716,7 @@ node:
             }
 
             #[test]
+            #[serial]
             fn proto_version_doesnt_override() {
                 let config = test_load_config(
                     FILENAME,
@@ -708,6 +743,7 @@ node:
             }
 
             #[test]
+            #[serial]
             fn inherits_version_from_env_var() {
                 env::set_var("MOON_PNPM_VERSION", "10.0.0");
 
@@ -806,6 +842,7 @@ node:
             }
 
             #[test]
+            #[serial]
             fn proto_version_doesnt_override() {
                 let config = test_load_config(
                     FILENAME,
@@ -832,6 +869,7 @@ node:
             }
 
             #[test]
+            #[serial]
             fn inherits_version_from_env_var() {
                 env::set_var("MOON_YARN_VERSION", "10.0.0");
 
@@ -930,6 +968,7 @@ node:
             }
 
             #[test]
+            #[serial]
             fn proto_version_doesnt_override() {
                 let config = test_load_config(
                     FILENAME,
@@ -956,6 +995,7 @@ node:
             }
 
             #[test]
+            #[serial]
             fn inherits_version_from_env_var() {
                 env::set_var("MOON_BUN_VERSION", "1.0.0");
 
@@ -978,6 +1018,31 @@ node:
                 );
 
                 env::remove_var("MOON_BUN_VERSION");
+
+                assert_eq!(
+                    config.node.unwrap().bun.unwrap().version.unwrap(),
+                    UnresolvedVersionSpec::parse("1.0.0").unwrap()
+                );
+            }
+
+            #[test]
+            #[serial]
+            fn inherits_version_from_bun_tool() {
+                let config = test_load_config(
+                    FILENAME,
+                    r"
+bun:
+  version: 1.0.0
+node:
+  packageManager: bun
+",
+                    |path| ToolchainConfig::load_from(path, &ProtoConfig::default()),
+                );
+
+                assert_eq!(
+                    config.bun.unwrap().version.unwrap(),
+                    UnresolvedVersionSpec::parse("1.0.0").unwrap()
+                );
 
                 assert_eq!(
                     config.node.unwrap().bun.unwrap().version.unwrap(),
@@ -1112,6 +1177,7 @@ rust:
         }
 
         #[test]
+        #[serial]
         fn proto_version_doesnt_override() {
             let config = test_load_config(
                 FILENAME,
@@ -1138,15 +1204,16 @@ rust:
         }
 
         #[test]
+        #[serial]
         fn inherits_version_from_env_var() {
             env::set_var("MOON_RUST_VERSION", "1.70.0");
 
             let config = test_load_config(
                 FILENAME,
                 r"
-        rust:
-          version: 1.60.0
-        ",
+rust:
+  version: 1.60.0
+",
                 |path| {
                     let mut proto = ProtoConfig::default();
                     proto.versions.insert(

--- a/legacy/cli/Cargo.toml
+++ b/legacy/cli/Cargo.toml
@@ -98,7 +98,7 @@ moon_notifier = { path = "../core/notifier" }
 moon_task_runner = { path = "../../crates/task-runner" }
 moon_test_utils = { path = "../core/test-utils" }
 httpmock = "0.7.0"
-serial_test = "3.1.1"
+serial_test = { workspace = true }
 starbase_archive = { workspace = true }
 
 [lints]

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,13 @@
   - More accurately monitors signals (ctrl+c) and shutdowns.
   - Tasks can now be configured with a timeout.
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Updated `bun.version` and `node.bun.version` to stay in sync when one is defined and the other
+  isn't. This helps to avoid tool discrepancies.
+
 ## 1.25.3
 
 #### 🚀 Updates


### PR DESCRIPTION
Fixes https://github.com/moonrepo/moon/issues/1486

Is caused by `bun.version` and `node.bun.version` not being the same/or set.