### PR TITLE
build: Update cargo CLI to use nightly/canary versions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
   # Uncomment to test in PRs (its safe)
-  pull_request:
+  # pull_request:
 
 permissions:
   contents: write
@@ -39,9 +39,9 @@ jobs:
       - id: plan-step
         run: bash ./scripts/release/planRelease.sh
         env:
-          # CANARY: ${{ github.event_name == 'push' && contains(github.ref, 'develop-') }}
-          # NIGHTLY: ${{ github.event_name == 'schedule' }}
-          CANARY: true
+          CANARY: ${{ github.event_name == 'push' && contains(github.ref, 'develop-') }}
+          NIGHTLY: ${{ github.event_name == 'schedule' }}
+          # CANARY: true
 
   build:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
   # Uncomment to test in PRs (its safe)
-  # pull_request:
+  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,17 @@ jobs:
         ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ||
         github.event_name == 'push' && contains(github.ref, 'develop-') }}
       npm-channel: ${{ steps.plan-step.outputs.npm-channel }}
+      cli-version: ${{ steps.plan-step.outputs.cli-version }}
+      cli-version-base: ${{ steps.plan-step.outputs.cli-version-base }}
+      cli-version-build: ${{ steps.plan-step.outputs.cli-version-build }}
     steps:
       - uses: actions/checkout@v4
       - id: plan-step
         run: bash ./scripts/release/planRelease.sh
         env:
-          CANARY: ${{ github.event_name == 'push' && contains(github.ref, 'develop-') }}
-          NIGHTLY: ${{ github.event_name == 'schedule' }}
-          # CANARY: true
+          # CANARY: ${{ github.event_name == 'push' && contains(github.ref, 'develop-') }}
+          # NIGHTLY: ${{ github.event_name == 'schedule' }}
+          CANARY: true
 
   build:
     strategy:
@@ -108,6 +111,8 @@ jobs:
         env:
           BINARY: ${{ matrix.binary }}
           TARGET: ${{ matrix.target }}
+          CLI_VERSION: ${{ needs.plan.outputs.cli-version }}
+          CLI_VERSION_BASE: ${{ needs.plan.outputs.cli-version-base }}
       - name: Install Depot CLI
         if: ${{ matrix.docker-target }}
         uses: depot/setup-action@v1
@@ -241,6 +246,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CHANNEL: ${{ needs.plan.outputs.npm-channel }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          CLI_VERSION: ${{ needs.plan.outputs.cli-version }}
+          CLI_VERSION_BASE: ${{ needs.plan.outputs.cli-version-base }}
+          CLI_VERSION_BUILD: ${{ needs.plan.outputs.cli-version-build }}
       - if:
           ${{ needs.plan.outputs.npm-channel == 'latest' || needs.plan.outputs.npm-channel == 'next'
           }}
@@ -304,3 +312,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CHANNEL: ${{ needs.plan.outputs.npm-channel }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          CLI_VERSION: ${{ needs.plan.outputs.cli-version }}
+          CLI_VERSION_BASE: ${{ needs.plan.outputs.cli-version-base }}
+          CLI_VERSION_BUILD: ${{ needs.plan.outputs.cli-version-build }}

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Updated `bun.version` and `node.bun.version` to stay in sync when one is defined and the other
   isn't. This helps to avoid tool discrepancies.
 
+#### 🐞 Fixes
+
+- Fixed nightly and canary releases not showing the correct version in `moon --version`.
+
 ## 1.25.3
 
 #### 🚀 Updates

--- a/scripts/release/buildBinary.sh
+++ b/scripts/release/buildBinary.sh
@@ -7,10 +7,23 @@ export RUSTFLAGS="-C strip=symbols"
 source "$dir/../helpers.sh"
 
 target="$TARGET"
+oldVersion="$CLI_VERSION_BASE"
+newVersion="$CLI_VERSION"
+
+# Set the cli version before building (it may change for canary/nightly)
+
+echo "Old version: $oldVersion"
+echo "New version: $newVersion"
+
+if [[ "$oldVersion" != "$newVersion" ]]; then
+	toml=$(cat legacy/cli/Cargo.toml)
+	echo "${toml//$oldVersion/$newVersion}" > legacy/cli/Cargo.toml
+fi
+
+# Build the binary with the provided target
 
 echo "Target: $target"
 echo "Args: $@"
 
-# Build the binary with the provided target
 rustup target add "$target"
 cargo build --release --target "$target" $@

--- a/scripts/release/planRelease.sh
+++ b/scripts/release/planRelease.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Determine channel to publish to
+
 channel=latest
 
 if git log -1 --pretty=%B | grep -e "-alpha" -e "-beta" -e "-rc"; then
@@ -16,3 +18,19 @@ fi
 
 echo "Setting npm channel to $channel"
 echo "npm-channel=$channel" >> "$GITHUB_OUTPUT"
+
+# Extract the CLI version being published
+
+baseVersion=$(jq -r ".version" packages/cli/package.json)
+version="$baseVersion"
+build=""
+
+if [[ "$channel" == "canary" || "$channel" == "nightly" ]]; then
+	build="-$channel.$(date +%Y%m%d%H%M)"
+	version="$version$build"
+fi
+
+echo "Setting cli version to $version (base: $baseVersion, build: $build)"
+echo "cli-version=$version" >> "$GITHUB_OUTPUT"
+echo "cli-version-base=$baseVersion" >> "$GITHUB_OUTPUT"
+echo "cli-version-build=$build" >> "$GITHUB_OUTPUT"

--- a/scripts/release/publishBinaryPackages.sh
+++ b/scripts/release/publishBinaryPackages.sh
@@ -13,7 +13,7 @@ echo "Channel: $tag"
 for package in packages/cli packages/core-*; do
 	echo "$package"
 
-	if [[ -z "${GITHUB_TOKEN}" ]]; then
+	if [[ -z "$GITHUB_TOKEN" ]]; then
 		# Testing locally
 		echo "Not publishing"
 	else
@@ -25,8 +25,7 @@ for package in packages/cli packages/core-*; do
 done
 
 # Set the tag to use for GitHub releases
-version=$(cat packages/cli/package.json | jq -r '.version')
-tag="v$version"
+tag="v$CLI_VERSION"
 
 echo "Setting tag name to $tag"
 echo "npm-tag-name=$tag" >> "$GITHUB_OUTPUT"

--- a/scripts/release/setupNpm.sh
+++ b/scripts/release/setupNpm.sh
@@ -13,11 +13,8 @@ if [ -d ".yarn/versions" ]; then
 fi
 
 if [[ "$NPM_CHANNEL" == "canary" || "$NPM_CHANNEL" == "nightly" ]]; then
-	timestamp=$(date +%Y%m%d%H%M)
-	preid="-$NPM_CHANNEL.$timestamp"
-
-	echo "Detected \"$NPM_CHANNEL\" build, appending timestamp to versions"
-	echo "Prerelease: $preid"
+	echo "Detected \"$NPM_CHANNEL\" build, appending build metadata to versions"
+	echo "Build: $CLI_VERSION_BUILD"
 
 	for package in packages/*; do
 		echo "$package"
@@ -25,15 +22,12 @@ if [[ "$NPM_CHANNEL" == "canary" || "$NPM_CHANNEL" == "nightly" ]]; then
 
 		# For the cli package, replace itself and all dep versions
 		if [[ "$package" == *"cli"* ]]; then
-			baseVersion=$(jq -r ".version" package.json)
-			version="$baseVersion$preid"
-
 			pkg=$(cat package.json)
-			echo "${pkg//$baseVersion/$version}" > package.json
+			echo "${pkg//$CLI_VERSION_BASE/$CLI_VERSION}" > package.json
 
 		# For core packages, append the preid to the version
 		else
-			pkg=$(jq ".version += \"$preid\"" package.json)
+			pkg=$(jq ".version += \"$CLI_VERSION_BUILD\"" package.json)
 			echo "$pkg" > package.json
 		fi
 


### PR DESCRIPTION
This ensures `moon -V` reports the correct thing.