### PR TITLE
docs: update text about monorepo.tools website

### DIFF
--- a/website/docs/comparison.mdx
+++ b/website/docs/comparison.mdx
@@ -22,8 +22,7 @@ date, but represent a good starting point for investigation. If something is not
 
 Before diving into our comparisons below, we highly suggest reading
 [monorepo.tools](https://monorepo.tools/) for a deeper insight into monorepos and available tooling.
-Although moon is not included, it's a great resource for learning about the current state of things
-and the ecosystem.
+It's a great resource for learning about the current state of things and the ecosystem.
 
 :::info
 


### PR DESCRIPTION
moon has been already included, so the sentence needed updating.

![image](https://github.com/user-attachments/assets/1485d5c7-70b8-4b5c-ba06-2b0e9934db11)
