### PR TITLE
docs: Updating tools.node bundled-npm configuration docs

### DIFF
--- a/website/docs/proto/config.mdx
+++ b/website/docs/proto/config.mdx
@@ -255,6 +255,8 @@ As an example, let's configure [Node.js](https://github.com/moonrepo/node-plugin
 identifier).
 
 ```toml title=".prototools"
+npm = "bundler" # use bundled npm instead of specific version
+
 [tools.node]
 bundled-npm = true
 

--- a/website/docs/proto/config.mdx
+++ b/website/docs/proto/config.mdx
@@ -255,7 +255,7 @@ As an example, let's configure [Node.js](https://github.com/moonrepo/node-plugin
 identifier).
 
 ```toml title=".prototools"
-npm = "bundler" # use bundled npm instead of specific version
+npm = "bundled" # use bundled npm instead of specific version
 
 [tools.node]
 bundled-npm = true


### PR DESCRIPTION
Adding npm version config to use `bundled` npm from node instead of other version. 

I've added this configuration near

```toml
[tools.node]
bundled-npm = true
```

Because I think they are related, and using `bundled-npm = true` without `npm = "bundled"` does not make sense.

This was missing in docs and I barely figured out this from [debug-env](https://moonrepo.dev/docs/proto/commands/debug/config) docs, so I am making this change.