### PR TITLE
new: Add possibility to moon init from remote url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3019,6 +3019,7 @@ dependencies = [
  "serde",
  "serial_test",
  "starbase",
+ "starbase_archive",
  "starbase_events",
  "starbase_sandbox",
  "starbase_shell",

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -57,6 +57,7 @@ schematic = { workspace = true, features = ["config"] }
 semver = { workspace = true }
 serde = { workspace = true }
 starbase = { workspace = true }
+starbase_archive = { workspace = true }
 starbase_events = { workspace = true }
 starbase_shell = { workspace = true }
 starbase_styles = { workspace = true }


### PR DESCRIPTION
This implementation gives the user the possibility to initialize the `.moon` folder from a template
stored on a remote https server.
It will take the complete archive and extract
this into the `.moon` destination.

Changelog: new