### PR TITLE
Add how to install requirements in RHEL-based

### DIFF
--- a/website/docs/proto/install.mdx
+++ b/website/docs/proto/install.mdx
@@ -18,8 +18,11 @@ The following guide can be used to install proto into your environment.
 # macOS
 brew install git unzip gzip xz
 
-# Linux
+# Ubuntu / Debian
 apt-get install git unzip gzip xz-utils
+
+# RHEL-based / Fedora
+dnf install git unzip gzip xz
 ```
 
 ## Installing


### PR DESCRIPTION
`apt` is only for Ubuntu / Debian.
We need to add a setup instruction for RHEL family.

```bash
docker run -it --rm almalinux # or fedora
dnf install git unzip gzip xz # Note: gzip & xz have already been installed
curl -fsSL https://moonrepo.dev/install/proto.sh | bash # choose Bash→~/.bash_profile
eval `tail -n 2 ~/.bash_profile`
proto install node 22
node --version
```

