### PR TITLE
fix: Improve CI job handling.

### DIFF
--- a/.yarn/versions/15d6e39f.yml
+++ b/.yarn/versions/15d6e39f.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/app/src/commands/ci.rs
+++ b/crates/app/src/commands/ci.rs
@@ -175,7 +175,7 @@ fn distribute_targets_across_jobs(
 
     let job_index = args.job.unwrap_or_default();
     let job_total = args.job_total.unwrap_or_default();
-    let batch_size = targets.len() / job_total;
+    let batch_size = (targets.len() + job_total - 1) / job_total;
     let batched_targets;
 
     console.print_header("Distributing targets across jobs")?;

--- a/crates/app/src/commands/ci.rs
+++ b/crates/app/src/commands/ci.rs
@@ -180,7 +180,7 @@ fn distribute_targets_across_jobs(
 
     console.print_header("Distributing targets across jobs")?;
     console.write_line(format!("Job index: {job_index}"))?;
-    console.write_line(format!("Job total: {job_index}"))?;
+    console.write_line(format!("Job total: {job_total}"))?;
     console.write_line(format!("Batch size: {batch_size}"))?;
     console.write_line("Batched targets:")?;
 


### PR DESCRIPTION
This PR aims to make some small improvements to moon's CI command based on production experience.

- [x] FIX: The "Job total" log prints `job_index` instead of `job_total` 
- [x] FIX: Uneven weight on the last job index's batched targets 
      (i.e. 10 total jobs, 45 total targets - the last job will have 9 targets instead of 4)
- [ ] ~FEAT: Discuss (& implement if in agreement) whether targets should be distributed based on the action graph~