### PR TITLE
new: Add `moon run --eager` to disable fail-fast behavior and execute as many tasks as possible

### DIFF
--- a/crates/app/src/components.rs
+++ b/crates/app/src/components.rs
@@ -40,7 +40,7 @@ pub async fn run_action_pipeline(
             pipeline.summarize = true;
         }
         Commands::Run(cmd) => {
-            pipeline.bail = true;
+            pipeline.bail = !cmd.no_bail;
             pipeline.summarize = cmd.summary;
         }
         _ => {}

--- a/website/docs/commands/run.mdx
+++ b/website/docs/commands/run.mdx
@@ -42,6 +42,15 @@ CI, and what options are provided. The following scenarios are possible:
 
 :::
 
+:::info
+
+The default behavior for `moon run` is to "fail fast", meaning that any failed task will
+immediately abort execution of the entire action graph.  Pass `--no-bail` to execute as many
+tasks as safely possible (tasks with upstream failures will be skipped to avoid side effects).
+This is the default behavior for `moon ci`, and is also useful for pre-commit hooks.
+
+:::
+
 ### Arguments
 
 - `...<target>` - [Targets](../concepts/target) or project relative tasks to run.
@@ -59,6 +68,8 @@ CI, and what options are provided. The following scenarios are possible:
   [a query statement](../concepts/query-lang). <VersionLabel version="1.3.0" />
 - `--summary` - Display a summary and stats of the current run. <VersionLabel version="1.25.0" />
 - `-u`, `--updateCache` - Bypass cache and force update any existing items.
+- `-n`, `--no-bail` - When a task fails, continue executing other tasks instead of aborting immediately
+
 
 #### Affected
 

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -731,7 +731,7 @@ name. [Learn more about Git hooks](https://git-scm.com/book/en/v2/Customizing-Gi
 vcs:
   hooks:
     pre-commit:
-      - 'moon run :lint :format --affected --status=staged'
+      - 'moon run :lint :format --affected --status=staged --no-bail'
       - 'another-command'
 ```
 


### PR DESCRIPTION
The `--eager` flag makes moon run behave more like moon ci.

Fixes #1770 
