### PR TITLE
fix: Adapt remote git regex for templates

### DIFF
--- a/crates/codegen/src/codegen.rs
+++ b/crates/codegen/src/codegen.rs
@@ -210,8 +210,8 @@ impl<'app> CodeGenerator<'app> {
                     remote_url,
                     revision,
                 } => {
-                    let base_url = remote_url.trim_start_matches('/').trim_end_matches(".git");
-                    let url = format!("https://{base_url}.git");
+                    let base_url = remote_url.trim_start_matches('/');
+                    let url = format!("https://{base_url}");
                     let template_location = self.moon_env.templates_dir.join(base_url);
 
                     futures.push(spawn(clone_and_checkout_git_repository(

--- a/crates/codegen/tests/codegen_test.rs
+++ b/crates/codegen/tests/codegen_test.rs
@@ -133,7 +133,6 @@ mod codegen {
                 .join("github.com")
                 .join("moonrepo")
                 .join("moon-configs")
-                .join(".git")
                 .exists());
         }
 

--- a/crates/codegen/tests/codegen_test.rs
+++ b/crates/codegen/tests/codegen_test.rs
@@ -132,7 +132,7 @@ mod codegen {
                 .templates_dir
                 .join("github.com")
                 .join("moonrepo")
-                .join("moon-configs")
+                .join("moon-configs.git")
                 .exists());
         }
 

--- a/crates/codegen/tests/codegen_test.rs
+++ b/crates/codegen/tests/codegen_test.rs
@@ -119,7 +119,7 @@ mod codegen {
             let env = Arc::new(MoonEnvironment::new_testing(sandbox.path()));
             let config = GeneratorConfig {
                 templates: vec![TemplateLocator::Git {
-                    remote_url: "github.com/moonrepo/moon-configs".into(),
+                    remote_url: "github.com/moonrepo/moon-configs.git".into(),
                     revision: "master".into(),
                 }],
             };

--- a/crates/config/src/template/template_locator.rs
+++ b/crates/config/src/template/template_locator.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::str::FromStr;
 
 static GIT: Lazy<Regex> = Lazy::new(|| {
-    Regex::new("^(?<url>[a-z0-9.]+/[a-zA-Z0-9-_./]+)#(?<revision>[a-z0-9-_.@]+)$").unwrap()
+    Regex::new("^(?<url>[a-zA-Z@0-9.-]+/[a-zA-Z0-9-_./]+)#(?<revision>[a-z0-9-_.@]+)$").unwrap()
 });
 
 static NPM: Lazy<Regex> = Lazy::new(|| {


### PR DESCRIPTION
This change would allow to work with remote templates in a remote git repository which are hosted on different uri formats rather than github.

For example:

- `my-gitlab.cooperate-domain.com` - which was not working due to `-` in hostname
- `IDENT@my-gitlab.cooperate-domain.com` - which was not working due to `@` (for identity) and upper case letters 

Additional the automatic appending postfix `.git` to the git clone url is removed and is now in the user responsibility to add the correct url.