### PR TITLE
docs: Update proto version token docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Updated `proto` documentation to reflect changes to version tokens: https://moonrepo.dev/docs/proto/non-wasm-plugin#platform-variations
+
 ## 1.32.1
 
 #### 🚀 Updates

--- a/website/docs/proto/non-wasm-plugin.mdx
+++ b/website/docs/proto/non-wasm-plugin.mdx
@@ -81,8 +81,8 @@ are available:
 
 - `{version}` - The currently resolved version, as a fully-qualified semantic or calendar version.
 - `{versionMajor}` / `{versionYear}` - Only the major version. <VersionLabel version="0.41.4" />
-- `{versionMajorMinor}` / `{versionYearMonth}` - Only the major + minor versions.
-  <VersionLabel version="0.41.4" />
+- `{versionMinor}` / `{versionMonth}` - Only the minor version. <VersionLabel version="0.45.2" />
+- `{versionPatch}` / `{versionDay}` - Only the patch version. <VersionLabel version="0.45.2" />
 - `{versionPrerelease}` - The prerelease identifier, if applicable. Returns an empty string
   otherwise. <VersionLabel version="0.41.4" />
 - `{versionBuild}` - The build identifier, if applicable. Returns an empty string otherwise.


### PR DESCRIPTION
See moonrepo/proto#711

Updates the documentation to reflect new version tokens added to `proto`.

This is dependant on moonrepo/proto#712 first being released, and assumes the released version is `0.45.2`. If this changes, this PR also needs updated.