### PR TITLE
docs(task-inheritance): merge example mixed command with args

### DIFF
--- a/website/docs/concepts/task-inheritance.mdx
+++ b/website/docs/concepts/task-inheritance.mdx
@@ -98,6 +98,7 @@ tasks:
   build:
     command:
       - 'webpack'
+    args:
       - '--mode'
       - 'production'
       - '--color'
@@ -126,6 +127,7 @@ tasks:
   build:
     command:
       - 'webpack'
+    args:
       - '--mode'
       - 'production'
       - '--color'


### PR DESCRIPTION
The doc on task inheritance is showing a merge between `command` and `args` between a global and a local task.

I think the correct example should be this one. What do you think?