### PR TITLE
fix: Always fail interrupted processes.

### DIFF
--- a/.yarn/versions/e6803309.yml
+++ b/.yarn/versions/e6803309.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where interrupting (ctrl+c) a task that exits with a 0 code would treat is as
+  succesful, resulting in an invalid cache.
+
 ## 1.35.2
 
 #### 🚀 Updates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,9 +955,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2937,9 +2937,9 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iocraft"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b43b8702c8ed79da475dd3b42593658863023eb885e2e7b53b35b3ab268020c3"
+checksum = "8bf8193e6d644dda2ec6ea2e7fa0a88e73f7cbb32bc3123b278d6457bc08e609"
 dependencies = [
  "any_key",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/cli"]
 async-recursion = "1.1.1"
 async-trait = "0.1.88"
 cached = "0.55.1"
-chrono = { version = "0.4.40", features = ["serde"] }
+chrono = { version = "0.4.41", features = ["serde"] }
 cd_env = "0.3.0"
 ci_env = "0.4.0"
 clap = { version = "4.5.37", default-features = false, features = [
@@ -36,7 +36,7 @@ convert_case = "0.8.0"
 dirs = "6.0.0"
 futures = "0.3.31"
 indexmap = "2.9.0"
-iocraft = "0.7.7"
+iocraft = "0.7.8"
 md5 = "0.7.0"
 miette = "7.6.0"
 pathdiff = "0.2.3"

--- a/crates/action-pipeline/src/job.rs
+++ b/crates/action-pipeline/src/job.rs
@@ -49,7 +49,7 @@ impl Job {
         }
         // Cancel if we receive a shutdown signal
         else if self.context.cancel_token.is_cancelled() {
-            trace!(index = self.node_index, "Job cancelled (via signal)");
+            trace!(index = self.node_index, "Job cancelled (because a signal)");
 
             action.finish(ActionStatus::Skipped);
         }

--- a/crates/process/Cargo.toml
+++ b/crates/process/Cargo.toml
@@ -23,7 +23,7 @@ tracing = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "signal", "sync"] }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.170"
+libc = "0.2.172"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59.0", default-features = false, features = [

--- a/crates/process/src/output.rs
+++ b/crates/process/src/output.rs
@@ -3,7 +3,7 @@ use crate::shared_child::ChildExit;
 use std::process::ExitStatus;
 pub use std::process::Output as NativeOutput;
 
-#[derive(PartialEq, Eq, Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Output {
     pub exit: ChildExit,
     pub stdout: Vec<u8>,

--- a/crates/process/src/output.rs
+++ b/crates/process/src/output.rs
@@ -23,7 +23,7 @@ impl Output {
     }
 
     pub fn success(&self) -> bool {
-        self.status().map_or(false, |status| status.success())
+        self.status().is_some_and(|status| status.success())
     }
 
     pub fn to_error(&self, bin: impl AsRef<str>, with_message: bool) -> ProcessError {

--- a/crates/process/src/output.rs
+++ b/crates/process/src/output.rs
@@ -1,6 +1,66 @@
 use crate::process_error::ProcessError;
+use crate::shared_child::ChildExit;
+use std::process::ExitStatus;
+pub use std::process::Output as NativeOutput;
 
-pub use std::process::Output;
+#[derive(PartialEq, Eq, Clone)]
+pub struct Output {
+    pub exit: ChildExit,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+impl Output {
+    pub fn code(&self) -> Option<i32> {
+        self.status().and_then(|status| status.code())
+    }
+
+    pub fn status(&self) -> Option<ExitStatus> {
+        match self.exit {
+            ChildExit::Completed(status) => Some(status),
+            _ => None,
+        }
+    }
+
+    pub fn success(&self) -> bool {
+        self.status().map_or(false, |status| status.success())
+    }
+
+    pub fn to_error(&self, bin: impl AsRef<str>, with_message: bool) -> ProcessError {
+        let bin = bin.as_ref().to_owned();
+
+        let status = match &self.exit {
+            ChildExit::Completed(status) => match status.code() {
+                Some(code) => format!("exit code {code}"),
+                None => status.to_string(),
+            },
+            ChildExit::Interrupted => "interrupted".into(),
+            ChildExit::Killed => "killed".into(),
+            ChildExit::Terminated => "terminated".into(),
+        };
+
+        if !with_message {
+            return ProcessError::ExitNonZero { bin, status };
+        }
+
+        let mut message = output_to_trimmed_string(&self.stderr);
+
+        if message.is_empty() {
+            message = output_to_trimmed_string(&self.stdout);
+        }
+
+        // Make error message nicer to look at
+        if !message.is_empty() {
+            message = format!("\n\n{message}");
+        }
+
+        ProcessError::ExitNonZeroWithOutput {
+            bin,
+            status,
+            output: message,
+        }
+    }
+}
 
 #[inline]
 pub fn output_to_string(data: &[u8]) -> String {
@@ -10,32 +70,4 @@ pub fn output_to_string(data: &[u8]) -> String {
 #[inline]
 pub fn output_to_trimmed_string(data: &[u8]) -> String {
     output_to_string(data).trim().to_owned()
-}
-
-pub fn output_to_error(bin: String, output: &Output, with_message: bool) -> ProcessError {
-    let status = match output.status.code() {
-        Some(code) => format!("exit code {code}"),
-        None => output.status.to_string(),
-    };
-
-    if !with_message {
-        return ProcessError::ExitNonZero { bin, status };
-    }
-
-    let mut message = output_to_trimmed_string(&output.stderr);
-
-    if message.is_empty() {
-        message = output_to_trimmed_string(&output.stdout);
-    }
-
-    // Make error message nicer to look at
-    if !message.is_empty() {
-        message = format!("\n\n{message}");
-    }
-
-    ProcessError::ExitNonZeroWithOutput {
-        bin,
-        status,
-        output: message,
-    }
 }

--- a/crates/process/src/shared_child.rs
+++ b/crates/process/src/shared_child.rs
@@ -2,7 +2,7 @@ use crate::output::Output;
 use crate::signal::*;
 use std::io;
 use std::process::ExitStatus;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout};
 use tokio::sync::Mutex;
 
@@ -17,6 +17,7 @@ pub enum ChildExit {
 #[derive(Clone)]
 pub struct SharedChild {
     inner: Arc<Mutex<Child>>,
+    signal: Arc<OnceLock<SignalType>>,
     pid: u32,
     #[cfg(windows)]
     handle: RawHandle,
@@ -28,6 +29,7 @@ impl SharedChild {
         Self {
             pid: child.id().unwrap(),
             inner: Arc::new(Mutex::new(child)),
+            signal: Arc::new(OnceLock::new()),
         }
     }
 
@@ -37,6 +39,7 @@ impl SharedChild {
             pid: child.id().unwrap(),
             handle: RawHandle(child.raw_handle().unwrap()),
             inner: Arc::new(Mutex::new(child)),
+            signal: Arc::new(OnceLock::new()),
         }
     }
 
@@ -65,6 +68,8 @@ impl SharedChild {
     }
 
     pub async fn kill_with_signal(&self, signal: SignalType) -> io::Result<ChildExit> {
+        self.signal.get_or_init(|| signal);
+
         #[cfg(unix)]
         {
             kill(self.pid, signal)?;
@@ -85,7 +90,7 @@ impl SharedChild {
         let mut child = self.inner.lock().await;
         let status = child.wait().await?;
 
-        Ok(convert_exit_status(status))
+        Ok(convert_exit_status(status, self.signal.clone()))
     }
 
     // This method re-implements the tokio `wait_with_output` method
@@ -117,14 +122,14 @@ impl SharedChild {
         drop(stderr_pipe);
 
         Ok(Output {
-            exit: convert_exit_status(status),
+            exit: convert_exit_status(status, self.signal.clone()),
             stdout,
             stderr,
         })
     }
 }
 
-fn convert_exit_status(status: ExitStatus) -> ChildExit {
+fn convert_exit_status(status: ExitStatus, raw_signal: Arc<OnceLock<SignalType>>) -> ChildExit {
     #[cfg(unix)]
     {
         use std::os::unix::process::ExitStatusExt;
@@ -138,7 +143,16 @@ fn convert_exit_status(status: ExitStatus) -> ChildExit {
         }
     }
 
-    // How to handle Windows???
+    // The Unix signal above sometimes doesn't capture the correct
+    // wait status, so to support those edges, and Windows in general,
+    // we'll read the raw signal that we explicitly used
+    if let Some(signal) = raw_signal.get() {
+        return match signal {
+            SignalType::Interrupt => ChildExit::Interrupted,
+            SignalType::Kill => ChildExit::Killed,
+            _ => ChildExit::Terminated,
+        };
+    }
 
     ChildExit::Completed(status)
 }

--- a/crates/task-runner/src/command_executor.rs
+++ b/crates/task-runner/src/command_executor.rs
@@ -4,10 +4,9 @@ use moon_app_context::AppContext;
 use moon_common::{is_ci, is_test_env};
 use moon_config::TaskOutputStyle;
 use moon_console::TaskReportItem;
-use moon_process::{Command, CommandLine, args::join_args};
+use moon_process::{Command, CommandLine, Output, args::join_args};
 use moon_project::Project;
 use moon_task::Task;
-use std::process::Output;
 use std::time::Duration;
 use tokio::task::{self, JoinHandle};
 use tokio::time::{sleep, timeout};
@@ -151,16 +150,16 @@ impl<'task> CommandExecutor<'task> {
                     let mut is_success = false;
 
                     if let Some(output) = maybe_output {
-                        is_success = output.status.success();
+                        is_success = output.success();
 
                         debug!(
                             task_target = self.task.target.as_str(),
                             command = self.command.bin.to_str(),
-                            exit_code = output.status.code(),
+                            exit_code = output.code(),
                             "Ran task, checking conditions",
                         );
 
-                        attempt.finish_from_output(output);
+                        attempt.finish_from_output(output.status(), output.stdout, output.stderr);
                     } else {
                         debug!(
                             task_target = self.task.target.as_str(),

--- a/crates/vcs/src/process_cache.rs
+++ b/crates/vcs/src/process_cache.rs
@@ -1,11 +1,10 @@
 use moon_common::is_test_env;
-use moon_process::{Command, output_to_string};
+use moon_process::{Command, Output, output_to_string};
 use rustc_hash::FxHashMap;
 use scc::HashCache;
 use scc::hash_cache::Entry;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
-use std::process::Output;
 use std::sync::Arc;
 
 #[derive(Debug)]


### PR DESCRIPTION
Currently if we send a SIGINT the child process can exit with code 0, which results in a successful task, and in turn it will be cached. This is actually wrong since it never completed.