### PR TITLE
new: add environment variables for a few run arguments

### DIFF
--- a/crates/app/src/commands/check.rs
+++ b/crates/app/src/commands/check.rs
@@ -21,6 +21,7 @@ pub struct CheckArgs {
     #[arg(
         long,
         short = 's',
+        env = "MOON_SUMMARY",
         help = "Include a summary of all actions that were processed in the pipeline"
     )]
     pub summary: bool,

--- a/crates/app/src/commands/run.rs
+++ b/crates/app/src/commands/run.rs
@@ -42,6 +42,7 @@ pub struct RunArgs {
     #[arg(
         long,
         short = 's',
+        env = "MOON_SUMMARY",
         help = "Include a summary of all actions that were processed in the pipeline"
     )]
     pub summary: bool,
@@ -55,6 +56,7 @@ pub struct RunArgs {
 
     #[arg(
         long,
+        env = "MOON_NO_ACTIONS",
         help = "Run the task without including sync and setup related actions in the graph"
     )]
     pub no_actions: bool,
@@ -62,6 +64,7 @@ pub struct RunArgs {
     #[arg(
         long,
         short = 'n',
+        env = "MOON_NO_BAIL",
         help = "When a task fails, continue executing other tasks instead of aborting immediately"
     )]
     pub no_bail: bool,
@@ -78,6 +81,7 @@ pub struct RunArgs {
     // Affected
     #[arg(
         long,
+        env = "MOON_AFFECTED",
         help = "Only run target if affected by touched files or the environment",
         help_heading = HEADING_AFFECTED,
         group = "affected-args"


### PR DESCRIPTION
Added environment variables to control `--summary`, `--no-actions`, `--no-bail`,  and `--affected`. 

Fixes https://github.com/moonrepo/moon/issues/1929