### PR TITLE
Fix: moon docker scaffold performance

### DIFF
--- a/.yarn/versions/8992253b.yml
+++ b/.yarn/versions/8992253b.yml
@@ -1,0 +1,9 @@
+releases:
+  "@moonrepo/cli": patch
+  "@moonrepo/core-linux-arm64-gnu": patch
+  "@moonrepo/core-linux-arm64-musl": patch
+  "@moonrepo/core-linux-x64-gnu": patch
+  "@moonrepo/core-linux-x64-musl": patch
+  "@moonrepo/core-macos-arm64": patch
+  "@moonrepo/core-macos-x64": patch
+  "@moonrepo/core-windows-x64-msvc": patch

--- a/crates/app/src/commands/docker/scaffold.rs
+++ b/crates/app/src/commands/docker/scaffold.rs
@@ -302,7 +302,13 @@ async fn scaffold_sources_project(
     docker_sources_root: &Path,
     project_id: &Id,
     manifest: &mut DockerManifest,
+    visited: &mut FxHashSet<Id>,
 ) -> AppResult {
+    // Skip if already visited
+    if !visited.insert(project_id.to_owned()) {
+        return Ok(None);
+    }
+
     manifest.focused_projects.insert(project_id.to_owned());
 
     let project = project_graph.get(project_id)?;
@@ -377,6 +383,7 @@ async fn scaffold_sources_project(
                 docker_sources_root,
                 &dep_cfg.id,
                 manifest,
+                visited,
             )
             .await?;
         }
@@ -405,6 +412,8 @@ async fn scaffold_sources(
         unfocused_projects: FxHashSet::default(),
     };
 
+    let mut visited = FxHashSet::default();
+
     // Copy all projects
     for project_id in project_ids {
         scaffold_sources_project(
@@ -413,6 +422,7 @@ async fn scaffold_sources(
             &docker_sources_root,
             project_id,
             &mut manifest,
+            &mut visited,
         )
         .await?;
     }


### PR DESCRIPTION
Fix for issue
https://github.com/moonrepo/moon/issues/2008

Currently `moon docker scaffold` command does a dependency graph traversal and copies the relevant files. But doesn't mark the node visited. Because of which same project gets processed twice i.e. copied twice.

We seen cases where this command takes more than 20 mins to run, where a single library gets copied over 105,000+ times. After this fix, the project now takes <30s for `moon docker scaffold` command to complete.