### PR TITLE
docs: Align the doc to `moon run --help` cli prompt.

### DIFF
--- a/website/docs/commands/run.mdx
+++ b/website/docs/commands/run.mdx
@@ -66,17 +66,20 @@ behavior for `moon ci`, and is also useful for pre-commit hooks.
 - `-f`, `--force` - Force run and ignore touched files and affected status. Will not query VCS.
 - `--dependents` - Run downstream dependent targets (of the same task name) as well.
 - `-i`, `--interactive` - Run the target in an interactive mode.
-- `--profile <type>` - Record and [generate a profile](../guides/profile) for ran tasks.
-  - Types: `cpu`, `heap`
 - `--query` - Filter projects to run targets against using
   [a query statement](../concepts/query-lang). <VersionLabel version="1.3.0" />
-- `--summary` - Display a summary and stats of the current run. <VersionLabel version="1.25.0" />
+- `-s`, `--summary` - Display a summary and stats of the current run. <VersionLabel version="1.25.0" />
 - `-u`, `--updateCache` - Bypass cache and force update any existing items.
 - `--no-actions` - Run the task without running [other actions](../how-it-works/action-graph) in the
   pipeline.
   <VersionLabel version="1.34.0" />
 - `-n`, `--no-bail` - When a task fails, continue executing other tasks instead of aborting
   immediately
+
+#### Debugging
+
+- `--profile <type>` - Record and [generate a profile](../guides/profile) for ran tasks.
+  - Types: `cpu`, `heap`
 
 #### Affected
 


### PR DESCRIPTION
- Add shorten arg for `summary` 
- Move `--profile` arg to debugging section