### PR TITLE
docs(workspace.mdx): fix typo notfier -> notifier

### DIFF
--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -552,7 +552,7 @@ notifier:
 
 <HeadingApiLink to="/api/types/interface/NotifierConfig#acknowledge" />
 
-When enabled, webhook notfier will wait for request result and validates the return code for 2xx.
+When enabled, webhook notifier will wait for request result and validates the return code for 2xx.
 Defaults to `false`.
 
 :::warning


### PR DESCRIPTION
just a fix for a typo in the documentation