### PR TITLE
docs: python-build-standalone governance has been passed to Astral-sh

### DIFF
--- a/website/docs/config/toolchain.mdx
+++ b/website/docs/config/toolchain.mdx
@@ -1243,7 +1243,7 @@ python:
 :::info
 
 Python installation's are based on pre-built binaries provided by
-[indygreg/python-build-standalone](https://github.com/indygreg/python-build-standalone).
+[astral-sh/python-build-standalone](https://github.com/astral-sh/python-build-standalone).
 
 :::
 

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -552,7 +552,7 @@ notifier:
 
 <HeadingApiLink to="/api/types/interface/NotifierConfig#acknowledge" />
 
-When enabled, webhook notfier will wait for request result and validates the return code for 2xx.
+When enabled, webhook notifier will wait for request result and validates the return code for 2xx.
 Defaults to `false`.
 
 :::warning


### PR DESCRIPTION
See https://astral.sh/blog/python-build-standalone