### PR TITLE
docs(vcs-hooks.mdx): use $@, which is compatible with unix-like shells and powershell

### DIFF
--- a/website/docs/guides/vcs-hooks.mdx
+++ b/website/docs/guides/vcs-hooks.mdx
@@ -33,7 +33,7 @@ vcs:
       - 'pre-commit run'
       - 'moon run :lint --affected'
     commit-msg:
-      - 'pre-commit run --hook-stage commit-msg --commit-msg-filename $1'
+      - 'pre-commit run --hook-stage commit-msg --commit-msg-filename $@'
 ```
 
 :::info


### PR DESCRIPTION
the previously used `$1` syntax worked only on linux-like shells and broke the hook execution on windows computers with powershell.

`$@` works for both of them.