### PR TITLE
fix(proto, install): explicitely unzip without junk path to avoid duplicating the folder name in the extracted file path

### DIFF
--- a/website/static/install/proto.sh
+++ b/website/static/install/proto.sh
@@ -111,10 +111,7 @@ curl --fail --location --progress-bar --output "$download_file" "$download_url"
 if [[ "$ext" == ".zip" ]]; then
 	req_archive "unzip"
 
-	unzip -d "$temp_dir" "$download_file"
-
-	# Unzip doesnt remove components folder
-	temp_dir="$temp_dir/$target"
+	unzip -j -d "$temp_dir" "$download_file"
 else
 	req_archive "gzip"
 	req_archive "xz" "xz" "xz-utils"


### PR DESCRIPTION
## Bug

Installing `proto` on a Windows computer using [git bash](https://git-scm.com/downloads/win) with the current following command fails with the given logs:

```sh
# command run from a git bash terminal on a Windows computer
$ bash <(curl -fsSL https://moonrepo.dev/install/proto.sh)

Archive:  /c/Users/{username}/.proto/temp/proto/proto_cli-x86_64-pc-windows-msvc.zip
extracting: /c/Users/{username}/.proto/temp/proto/proto_cli-x86_64-pc-windows-msvc/CHANGELOG.md  
extracting: /c/Users/{username}/.proto/temp/proto/proto_cli-x86_64-pc-windows-msvc/LICENSE  
extracting: /c/Users/{username}/.proto/temp/proto/proto_cli-x86_64-pc-windows-msvc/proto-shim.exe
extracting: /c/Users/{username}/.proto/temp/proto/proto_cli-x86_64-pc-windows-msvc/proto.exe  
extracting: /c/Users/{username}/.proto/temp/proto/proto_cli-x86_64-pc-windows-msvc/README.md

mv: cannot stat '/c/Users/{username}/.proto/temp/proto/proto_cli-x86_64-pc-windows-msvc/proto_cli-x86_64-pc-windows-msvc/proto.exe': No such file or directory
```

As we can see, [these `mv` commands](https://github.com/moonrepo/moon/blob/master/website/static/install/proto.sh#L131-L135) expect the tmp_dir to have a [duplicated target](https://github.com/moonrepo/moon/blob/master/website/static/install/proto.sh#L111-L117) in the file path of the extracted zip archive (see `.../proto_cli-x86_64-pc-windows-msvc/proto_cli-x86_64-pc-windows-msvc/proto.exe`), because unzip is supposed to wrap the archived contents in a folder of the archive zip file:

```sh
curl --fail --location --progress-bar --output "$download_file" "$download_url"

if [[ "$ext" == ".zip" ]]; then
	req_archive "unzip"

	unzip -d "$temp_dir" "$download_file"

	# Unzip doesnt remove components folder
	temp_dir="$temp_dir/$target"
# [...]

mv "$temp_dir/$bin" "$bin_path"
```

## Proposed solution

According to the logs, `unzip` seems not to duplicate the target in the extracted path when using git bash on a Windows computer. I downloaded the installation script and commented out the line `temp_dir="$temp_dir/$target"`, then executed the script which worked fine.

I also saw that `unzip` has a `-j` flag to **avoid** creating the "junk folder" (see [unzip doc](https://linux.die.net/man/1/unzip)), I explicitly added it in the PR.

Installation scripts are a sensitive issue, I recommend to test the script in as many environments as we can. zip archive files are downloaded only on Windows computers.