### PR TITLE
feat: Detect subcommand and apply shell on them

### DIFF
--- a/crates/env-var/src/env_substitutor.rs
+++ b/crates/env-var/src/env_substitutor.rs
@@ -25,9 +25,53 @@ pub static ENV_VAR_SUBSTITUTE_BRACKETS: LazyLock<Regex> = LazyLock::new(|| {
     .unwrap()
 });
 
+// $(command)
+pub static SUBCOMMAND_SUBSTITUTE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\$\([^)]+\)").unwrap()
+});
+
+// $((arithmetic))
+pub static ARITHMETIC_EXPANSION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\$\(\([^)]+\)\)").unwrap()
+});
+
+// <(command) or >(command)
+pub static PROCESS_SUBSTITUTION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"[<>]\([^)]+\)").unwrap()
+});
+
+// `command`
+pub static COMMAND_SUBSTITUTION_ADVANCED: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"`[^`]+`").unwrap()
+});
+
 pub fn contains_env_var(value: impl AsRef<str>) -> bool {
     ENV_VAR_SUBSTITUTE.is_match(value.as_ref())
         || ENV_VAR_SUBSTITUTE_BRACKETS.is_match(value.as_ref())
+}
+
+pub fn contains_subcommand(value: impl AsRef<str>) -> bool {
+    SUBCOMMAND_SUBSTITUTE.is_match(value.as_ref())
+}
+
+pub fn contains_arithmetic_expansion(value: impl AsRef<str>) -> bool {
+    ARITHMETIC_EXPANSION.is_match(value.as_ref())
+}
+
+pub fn contains_process_substitution(value: impl AsRef<str>) -> bool {
+    PROCESS_SUBSTITUTION.is_match(value.as_ref())
+}
+
+pub fn contains_command_substitution_advanced(value: impl AsRef<str>) -> bool {
+    COMMAND_SUBSTITUTION_ADVANCED.is_match(value.as_ref())
+}
+
+pub fn contains_shell_expansion(value: impl AsRef<str>) -> bool {
+    let val = value.as_ref();
+    contains_subcommand(val)
+        || contains_arithmetic_expansion(val)
+        || contains_process_substitution(val)
+        || contains_command_substitution_advanced(val)
 }
 
 pub fn rebuild_env_var(caps: &Captures) -> String {

--- a/crates/env-var/tests/env_substitutor_test.rs
+++ b/crates/env-var/tests/env_substitutor_test.rs
@@ -155,3 +155,137 @@ mod env_substitutor {
         assert_eq!(sub.substitute("$SOURCE"), "$SOURCE");
     }
 }
+
+#[test]
+fn contains_subcommand_positive() {
+    assert!(contains_subcommand("$(echo hello)"));
+    assert!(contains_subcommand("prefix $(command) suffix"));
+    assert!(contains_subcommand("$(git rev-parse HEAD)"));
+    assert!(contains_subcommand("$(date +%Y%m%d)"));
+    assert!(contains_subcommand("multiple $(cmd1) and $(cmd2)"));
+}
+
+#[test]
+fn contains_subcommand_negative() {
+    assert!(!contains_subcommand("$VAR"));
+    assert!(!contains_subcommand("${VAR}"));
+    assert!(!contains_subcommand("regular text"));
+    assert!(!contains_subcommand("$("));
+    assert!(!contains_subcommand("$)"));
+    assert!(!contains_subcommand("$ (command)"));
+}
+
+#[test]
+fn subcommand_regex_matches() {
+    let matches: Vec<&str> = SUBCOMMAND_SUBSTITUTE
+        .find_iter("$(echo hello) and $(date) with text")
+        .map(|m| m.as_str())
+        .collect();
+    
+    assert_eq!(matches, vec!["$(echo hello)", "$(date)"]);
+}
+
+#[test]
+fn contains_arithmetic_expansion_positive() {
+    assert!(contains_arithmetic_expansion("$((1 + 2))"));
+    assert!(contains_arithmetic_expansion("result=$((10 * 5))"));
+    assert!(contains_arithmetic_expansion("$((count++))"));
+    assert!(contains_arithmetic_expansion("prefix $((2 ** 8)) suffix"));
+}
+
+#[test]
+fn contains_arithmetic_expansion_negative() {
+    assert!(!contains_arithmetic_expansion("$(command)"));
+    assert!(!contains_arithmetic_expansion("$VAR"));
+    assert!(!contains_arithmetic_expansion("((expression))"));
+    assert!(!contains_arithmetic_expansion("$(("));
+    assert!(!contains_arithmetic_expansion("regular text"));
+}
+
+#[test]
+fn arithmetic_expansion_regex_matches() {
+    let matches: Vec<&str> = ARITHMETIC_EXPANSION
+        .find_iter("$((1 + 2)) and $((x * y)) calculation")
+        .map(|m| m.as_str())
+        .collect();
+    
+    assert_eq!(matches, vec!["$((1 + 2))", "$((x * y))"]);
+}
+
+#[test]
+fn contains_process_substitution_positive() {
+    assert!(contains_process_substitution("diff <(ls dir1) <(ls dir2)"));
+    assert!(contains_process_substitution("cat file >(sort)"));
+    assert!(contains_process_substitution("cmd <(echo test)"));
+    assert!(contains_process_substitution(">(tee output.log)"));
+}
+
+#[test]
+fn contains_process_substitution_negative() {
+    assert!(!contains_process_substitution("$(command)"));
+    assert!(!contains_process_substitution("<file.txt"));
+    assert!(!contains_process_substitution(">output.txt"));
+    assert!(!contains_process_substitution("< (command)"));
+    assert!(!contains_process_substitution("regular text"));
+}
+
+#[test]
+fn process_substitution_regex_matches() {
+    let matches: Vec<&str> = PROCESS_SUBSTITUTION
+        .find_iter("diff <(sort file1) >(grep pattern)")
+        .map(|m| m.as_str())
+        .collect();
+    
+    assert_eq!(matches, vec!["<(sort file1)", ">(grep pattern)"]);
+}
+
+#[test]
+fn contains_command_substitution_advanced_positive() {
+    assert!(contains_command_substitution_advanced("`date`"));
+    assert!(contains_command_substitution_advanced("echo `pwd`"));
+    assert!(contains_command_substitution_advanced("result=`ls -la`"));
+    assert!(contains_command_substitution_advanced("prefix `cmd` suffix"));
+}
+
+#[test]
+fn contains_command_substitution_advanced_negative() {
+    assert!(!contains_command_substitution_advanced("$(command)"));
+    assert!(!contains_command_substitution_advanced("'backtick'"));
+    assert!(!contains_command_substitution_advanced("`"));
+    assert!(!contains_command_substitution_advanced("regular text"));
+}
+
+#[test]
+fn command_substitution_advanced_regex_matches() {
+    let matches: Vec<&str> = COMMAND_SUBSTITUTION_ADVANCED
+        .find_iter("echo `date` and `pwd` here")
+        .map(|m| m.as_str())
+        .collect();
+    
+    assert_eq!(matches, vec!["`date`", "`pwd`"]);
+}
+
+#[test]
+fn contains_shell_expansion_comprehensive() {
+    // Should detect subcommands
+    assert!(contains_shell_expansion("$(echo test)"));
+    
+    // Should detect arithmetic expansion
+    assert!(contains_shell_expansion("$((1 + 2))"));
+    
+    // Should detect process substitution
+    assert!(contains_shell_expansion("<(sort file)"));
+    assert!(contains_shell_expansion(">(tee log)"));
+    
+    // Should detect backticks
+    assert!(contains_shell_expansion("`date`"));
+    
+    // Should not detect regular env vars or text
+    assert!(!contains_shell_expansion("$VAR"));
+    assert!(!contains_shell_expansion("${VAR}"));
+    assert!(!contains_shell_expansion("regular text"));
+    
+    // Should detect mixed cases
+    assert!(contains_shell_expansion("echo $(date) > log-`date +%Y%m%d`.txt"));
+    assert!(contains_shell_expansion("result=$((count + 1)) && echo `pwd`"));
+}

--- a/crates/task-builder/tests/__fixtures__/builder/shell-expansion/moon.yml
+++ b/crates/task-builder/tests/__fixtures__/builder/shell-expansion/moon.yml
@@ -1,0 +1,42 @@
+tasks:
+  command-no-expansion:
+    command: './file.sh'
+    options:
+      shell: false
+  command-with-subcommand:
+    command: 'echo $(date)'
+    options:
+      shell: false
+  args-with-subcommand:
+    args: ['--date', '$(date +%Y%m%d)']
+    options:
+      shell: false
+  command-with-arithmetic:
+    command: 'echo $((1 + 2))'
+    options:
+      shell: false
+  args-with-arithmetic:
+    args: ['--count', '$((10 * 5))']
+    options:
+      shell: false
+  command-with-process-substitution:
+    command: 'diff <(ls dir1) <(ls dir2)'
+    options:
+      shell: false
+  args-with-process-substitution:
+    args: ['<(sort file.txt)', '>(tee output.log)']
+    options:
+      shell: false
+  command-with-backticks:
+    command: 'echo `pwd`'
+    options:
+      shell: false
+  args-with-backticks:
+    args: ['--path', '`realpath .`']
+    options:
+      shell: false
+  mixed-expansions:
+    command: 'backup'
+    args: ['--name', '$(date +%Y%m%d)-v$((count + 1)).tar', '`pwd`/src', '<(find . -name "*.js")']
+    options:
+      shell: false 


### PR DESCRIPTION
I have encounter an annoying behaviour when trying to use moon

When i added the following command to my target:
```
command: docker run --rm -e HOME="/tmp" -u "$(id -u):$(id -g)"  ...
````

It didn't automaticly changed it into shell, like moon does when it sees a '*', as for `if task.args.iter().any(|arg| is_glob_like(arg))` 

So i thought it will be a good idea to just set it into shell in those cases