### PR TITLE
Don't require xz for installing from tarballs in proto.sh

### DIFF
--- a/website/static/install/proto.sh
+++ b/website/static/install/proto.sh
@@ -112,10 +112,13 @@ if [[ "$ext" == ".zip" ]]; then
 	req_archive "unzip"
 
 	unzip -j -d "$temp_dir" "$download_file"
-else
-	req_archive "gzip"
-	req_archive "xz" "xz" "xz-utils"
-
+else 
+	if [[ "$ext" == ".gz"]]; then
+		req_archive "gzip"
+	else if [[ "$ext" == ".xz"]]; then
+		req_archive "xz" "xz" "xz-utils"
+	fi
+	
 	tar xf "$download_file" --strip-components 1 -C "$temp_dir"
 fi
 


### PR DESCRIPTION
In situations where xz is not available on a system, trying to install from a tarball should not prompt the user to install xz.

Specific error, when running setup-toolchain in GHA inside Docker image where xz was not installed:
```
Run moonrepo/setup-toolchain@v0
  with:
    auto-install: false
    auto-setup: false
    cache: true
/usr/bin/docker exec  91337ca829800decafc7bba560348b42cc2b1e5cff083edd020f5b84a535c1aa sh -c "cat /etc/*release | grep ^ID"
Added /github/home/.proto/shims and /github/home/.proto/bin to PATH
Installing `proto` globally
Downloading installation script
Downloaded script to /github/home/.proto/temp/proto.sh
Executing installation script
Error: Error: Command failed with exit code 1: /github/home/.proto/temp/proto.sh
#=#=#                                                                          
##O#-#                                                                         

######################################################################## 100.0%
xz is required for unpacking archives and using proto!
Install with your package manager, such as `apt install xz-utils`
```