### PR TITLE
docs: Update telemetry link in config documentation

### DIFF
--- a/website/docs/proto/config.mdx
+++ b/website/docs/proto/config.mdx
@@ -274,7 +274,7 @@ telemetry = false
 ```
 
 > The data we track is publicly available and
-> [can be found here](https://github.com/moonrepo/proto/blob/master/legacy/cli/src/telemetry.rs).
+> [can be found here](https://github.com/moonrepo/proto/blob/master/crates/cli/src/telemetry.rs).
 
 #### `unstable-lockfile`<VersionLabel version="0.51.0" />
 


### PR DESCRIPTION
Spotted this broken link while reading https://moonrepo.dev/docs/proto/config