### PR TITLE
Add moonx binary entry to package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,8 @@
   "author": "Miles Johnson",
   "license": "MIT",
   "bin": {
-    "moon": "moon.js"
+    "moon": "moon.js",
+    "moonx": "moonx.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Link moonx for folks who install via a node package manager.