### PR TITLE
correct past participle in intro.mdx

### DIFF
--- a/website/docs/intro.mdx
+++ b/website/docs/intro.mdx
@@ -59,7 +59,7 @@ To help achieve this vision, language support is broken down into 4 tiers, allow
 incrementally integrate and improve them over time. The 4 tiers are as follows:
 
 - &nbsp;<Label text="Tier 0" variant="failure" /> &nbsp; **No direct integration** - Tool is not
-  directly supported in moon, but can still be ran using the
+  directly supported in moon, but can still be run using the
   ["system" task toolchain](/docs/faq#can-we-run-other-languages), which expects the tool to exist
   in the current environment.
 - &nbsp;<Label text="Tier 1" variant="warning" /> &nbsp; **Project categorization** - Projects can


### PR DESCRIPTION
"...can still be run" is the standard English way of saying this, because "run" is a past participle and "ran" is the simple past tense. Even though it is becoming more common to replace the past participle with the simple past tense, it is still generally considered an error by a majority of native speakers.

Here's some more information, although these may focus more on examples involving perfect tenses rather than passive voice (which is in use above):
- [An academic study of this phenomenon](https://www.academia.edu/110304820/Where_Have_All_the_Participles_Went_Using_Twitter_Data_to_Teach_About_Language)
- [Observations by some language bloggers](https://grammarphobia.com/blog/2011/12/participles.html)
- [An AI summary](https://duckduckgo.com/?q=where+have+all+the+participles+went%3F&ia=web&assist=true)