### PR TITLE
fix: correct issue where the global version is not delegating to the local version

### DIFF
--- a/crates/cli/src/lookup.rs
+++ b/crates/cli/src/lookup.rs
@@ -94,18 +94,16 @@ pub fn has_locally_installed(home_dir: &Path, current_dir: &Path) -> Option<Path
 
                 // 2. Real Path (pnpm, Bun, Yarn Berry)
                 // If it's a symlink, resolve it to find the real location in the store or cache.
-                if let Ok(real_path) = fs::canonicalize(&cli_dir) {
-                    if real_path != cli_dir {
-                        search_paths.push(real_path.clone()); // Inside the package itself
-                        if let Some(parent) = real_path.parent() {
-                            search_paths.push(parent.to_path_buf()); // Sibling in store
-                        }
-                        if let Some(grandparent) = real_path.parent().and_then(|p| p.parent()) {
-                            search_paths.push(grandparent.to_path_buf()); // Parent of scope
-                        }
-                        // Check for dependencies inside the package (unhoisted)
-                        search_paths.push(real_path.join("node_modules").join("@moonrepo"));
+                if let Some(real_path) = fs::canonicalize(&cli_dir).ok().filter(|p| p != &cli_dir) {
+                    search_paths.push(real_path.clone()); // Inside the package itself
+                    if let Some(parent) = real_path.parent() {
+                        search_paths.push(parent.to_path_buf()); // Sibling in store
                     }
+                    if let Some(grandparent) = real_path.parent().and_then(|p| p.parent()) {
+                        search_paths.push(grandparent.to_path_buf()); // Parent of scope
+                    }
+                    // Check for dependencies inside the package (unhoisted)
+                    search_paths.push(real_path.join("node_modules").join("@moonrepo"));
                 }
 
                 // Scan all potential locations


### PR DESCRIPTION
There was a strange behaviour where if you have a global version and a packaged version of moon installed, moon commands you execute will not delegate over to the local version.

The root cause seems to be in the `has_locally_installed` function where it tries to look for the `moon` binary on Linux/macOS or `moon.exe` on Windows as part of the packaged version lookup.

However, in a pnpm workspace setup I am using, I do not see the binary:

<img width="431" height="576" alt="Screenshot 2026-01-03 at 6 57 09 PM" src="https://github.com/user-attachments/assets/20d66431-f2cd-4d09-bc48-3dbcacc8d35c" />

It is to my knowledge that the `moon` binary would reside in a platform-specific package like `@moonrepo/core-macos-arm64`, but as you can see in my `node_modules` directory, it may not appear at the same level as my other dependencies; it resides in `node_modules/.pnpm/`.

The fix for this is to directly check for the binary from the platform's package, and resolve any symlinks when needed.