### PR TITLE
Replace --updateCache w/ --force in task debugging docs

### DIFF
--- a/website/docs/guides/debug-task.mdx
+++ b/website/docs/guides/debug-task.mdx
@@ -87,7 +87,7 @@ as follows:
 If all went well, you should see a log entry that looks like this:
 
 ```
-Generated hash <hash> for target <target>
+moon_task_runner::task_runner  Generated a unique hash  task_target="<task>" hash="<hash>"
 ```
 
 The important piece is the hash, which is a 64-character SHA256 hash, and represents the unique hash


### PR DESCRIPTION
While debugging moonrepo, I noticed that as of [this change](https://moonrepo.dev/docs/migrate/2.0#moon-ci) --update-cache (formerly --updateCache) has been renamed to --force.

This change updates the documentation to match