### PR TITLE
docs: Add fish shell install command

### DIFF
--- a/website/docs/proto/install.mdx
+++ b/website/docs/proto/install.mdx
@@ -47,6 +47,12 @@ then open an interactive prompt to complete the installation.
 bash <(curl -fsSL https://moonrepo.dev/install/proto.sh)
 ```
 
+For Fish shell, use process substitution with `psub` to execute the installer.
+
+```shell
+bash (curl -fsSL https://moonrepo.dev/install/proto.sh | psub)
+```
+
 Furthermore, the version of proto to install can be passed as an argument to the install script. We
 also accept `--no-profile` to avoid modifying your shell profile, and `--yes` to avoid interactive
 prompts.


### PR DESCRIPTION
Adds a `psub` example for Fish users.
The standard `<(...)` syntax is not supported in Fish, and simple piping (`| bash`) breaks the interactive prompts.

Fixes https://github.com/moonrepo/proto/issues/905