### PR TITLE
feat: add --hide-cached

### DIFF
--- a/crates/app-macros/src/lib.rs
+++ b/crates/app-macros/src/lib.rs
@@ -48,6 +48,17 @@ pub fn with_shared_exec_args(attr: TokenStream, item: TokenStream) -> TokenStrea
             )]
             pub summary: Option<Option<crate::app_options::SummaryOption>>
         },
+        quote! {
+            #[arg(
+                long,
+                short = 'x',
+                global = true,
+                env = "MOON_HIDE_CACHED",
+                help = "Hide all stdout/stderr from succesful cached tasks",
+                help_heading = super::HEADING_WORKFLOW,
+            )]
+            pub hide_cached: bool
+        },
         // GRAPH
         quote! {
             #[arg(

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -351,6 +351,28 @@ pub struct Cli {
 }
 
 impl Cli {
+    pub fn get_reporter_config(&self) -> moon_console::MoonReporterConfig {
+        // The way the reporter is designed makes this awkward introspection
+        // into the CLI args necessary.
+        //
+        // The traditional approach would be to configure the MoonReporter with
+        // the individual commands directly, but because the reporter is aware of
+        // task execution, and is created as shared immutable before we start
+        // subcommand execution, we have to introspect into the CLI args to extract
+        // the MoonReporter's config from the CLI args.
+        let hide_cached = match &self.command {
+            Commands::Check(args) => args.hide_cached,
+            Commands::Ci(args) => args.hide_cached,
+            Commands::Exec(args) => args.hide_cached,
+            Commands::Run(args) => args.hide_cached,
+            _ => false,
+        };
+
+        moon_console::MoonReporterConfig {
+            hide_cached: !hide_cached,
+        }
+    }
+
     pub fn setup_env_vars(&self) {
         bootstrap::setup_colors(self.color);
 

--- a/crates/app/src/session.rs
+++ b/crates/app/src/session.rs
@@ -279,7 +279,8 @@ impl MoonSession {
 impl AppSession for MoonSession {
     /// Setup initial state for the session. Order is very important!!!
     async fn startup(&mut self) -> AppResult {
-        self.console.set_reporter(MoonReporter::default());
+        self.console
+            .set_reporter(MoonReporter::new(self.cli.get_reporter_config()));
         self.console.set_theme(create_console_theme());
 
         // Determine paths


### PR DESCRIPTION
Adds --hide-cached to the `exec` family of commands. This is used to configure the MoonReporter's behaviour for a given command run.

At present the only way to configure task reporting is with the individual task's reporting settings. This change adds a new mechanism to configure the reporter behaviour from command line flags.

A "clean" separation of concerns might complicate this by making a separate MoonTaskReporter that is aware of tasks, and initialize it in each of the exec-family commands. However, because the MoonReporter is aware of tasks and configured before subcommand execution, we need to read the CLI commands outside of the individual subcommands in order to initialize it before descending into subcommand execution.

I'm not 100% happy with this design, but I tried plumbing overrides through TaskReportItem, and I didn't like that design because it conflated transient, global CLI config with persistent config from individual task configs. I think this is a reasonable compromise that doesn't involve rewriting the MoonReporter to be more "pure" and harder to maintain.

Closes #1930