### PR TITLE
docs: update ci guide with new community offering

### DIFF
--- a/website/docs/guides/ci.mdx
+++ b/website/docs/guides/ci.mdx
@@ -297,3 +297,4 @@ The following GitHub actions are provided by the community:
 
 - [`appthrust/moon-ci-retrospect`](https://github.com/appthrust/moon-ci-retrospect) - Displays the
   results of a `moon ci` run in a more readable fashion.
+- [`kymckay/moon-ci-booster`](https://github.com/kymckay/moon-ci-booster) - Displays failing `moon ci` tasks as comments with error logs directly on your pull request.


### PR DESCRIPTION
Adding the new github action I spun out to speed up iterating on failing tasks in PRs.

We're using this at my workplace and so incentivised to maintain it.