### PR TITLE
docs: Add "Closest project" scope in run and exec command pages

### DIFF
--- a/website/docs/commands/exec.mdx
+++ b/website/docs/commands/exec.mdx
@@ -27,8 +27,8 @@ $ moon exec :test
 $ moonx :test
 
 # Run `test` in the closest project, relative to the current working directory
-$ moon exec ~:test
-$ moonx ~:test
+$ moon exec '~:test'
+$ moonx '~:test'
 
 # Run `test` in all projects with tag `frontend`
 $ moon exec '#frontend:test'

--- a/website/docs/commands/run.mdx
+++ b/website/docs/commands/run.mdx
@@ -20,7 +20,7 @@ $ moon run client:dev server:dev
 $ moon run :test
 
 # Run `test` in the closest project, relative to the current working directory
-$ moon run ~:test
+$ moon run '~:test'
 
 # Run `test` in all projects with tag `frontend`
 $ moon run '#frontend:test'


### PR DESCRIPTION
I have never used the closest scope before, but intuitively I assumed moon must have a feature for running tasks in the current working directory.

I looked through issues and found https://github.com/moonrepo/moon/issues/1828, which thankfully also had a linked [PR](https://github.com/moonrepo/moon/pull/1853/).

This very useful command is hard to find by just reading the documentation.

This may not be the best place to mention this scope, but since those pages contain quick summaries of those commands (run & exec), I assumed it would be useful to have the "closest" scope mentioned there.

Let me know if you'd also like me to re-write some other section of the documentation to make this clearer to users.