### PR TITLE
fix: Emit valid JSON Schema for MCP generate tool variables parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -497,6 +498,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +574,12 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 dependencies = [
  "allocator-api2",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1430,6 +1458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1687,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,6 +1885,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "faster-hex"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +1966,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,6 +2016,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -3750,6 +3825,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f29616f6e19415398eb186964fb7cbbeef572c79bede3622a8277667924bbe3"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "reqwest",
+ "rustls",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4710,6 +4814,7 @@ name = "moon_mcp"
 version = "0.0.1"
 dependencies = [
  "async-trait",
+ "jsonschema",
  "miette 7.6.0",
  "moon_action",
  "moon_action_graph",
@@ -5410,10 +5515,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -5668,6 +5843,12 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "owo-colors"
@@ -6506,6 +6687,41 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "referencing"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a618c14f8ba29d8193bb55e2bf13e4fb2b1115313ecb7ae94b43100c7ac7d5"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -8380,6 +8596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-id"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8516,6 +8738,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8556,6 +8788,12 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -30,5 +30,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+jsonschema = "0.45.0"
+rustc-hash = { workspace = true }
+serde_json = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -1,5 +1,5 @@
 mod mcp;
-mod tools;
+pub mod tools;
 
 pub use mcp::*;
 pub use rust_mcp_sdk::error::SdkResult;

--- a/crates/mcp/src/tools/codegen_tools.rs
+++ b/crates/mcp/src/tools/codegen_tools.rs
@@ -10,6 +10,33 @@ use rust_mcp_sdk::{
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::ops::Deref;
+
+/// Newtype wrapper around `FxHashMap<String, Value>` that provides a valid
+/// JSON Schema (`"type": "object"`) instead of the `"type": "unknown"` that
+/// the `rust-mcp-macros` `JsonSchema` derive emits for unrecognized generic types.
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct Variables(pub FxHashMap<String, serde_json::Value>);
+
+impl Variables {
+    pub fn json_schema() -> serde_json::Map<String, serde_json::Value> {
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "type".to_string(),
+            serde_json::Value::String("object".to_string()),
+        );
+        map
+    }
+}
+
+impl Deref for Variables {
+    type Target = FxHashMap<String, serde_json::Value>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 #[mcp_tool(
     name = "generate",
@@ -28,7 +55,7 @@ pub struct Generate {
     pub force: Option<bool>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub variables: Option<FxHashMap<String, serde_json::Value>>,
+    pub variables: Option<Variables>,
 }
 
 impl Generate {
@@ -54,7 +81,7 @@ impl Generate {
         {
             args.push("--".into());
 
-            for (key, value) in vars {
+            for (key, value) in vars.iter() {
                 let opt = format!("--{key}");
 
                 match value {

--- a/crates/mcp/tests/codegen_tools_test.rs
+++ b/crates/mcp/tests/codegen_tools_test.rs
@@ -1,0 +1,140 @@
+use moon_mcp::tools::codegen_tools::{Generate, Variables};
+use rustc_hash::FxHashMap;
+use serde_json::Value;
+
+fn assert_valid_json_schema_draft4(schema: &Value) {
+    let result = jsonschema::draft4::new(schema);
+    assert!(
+        result.is_ok(),
+        "Schema failed JSON Schema Draft 4 validation:\n{}\nSchema: {}",
+        result.unwrap_err(),
+        serde_json::to_string_pretty(schema).unwrap(),
+    );
+}
+
+fn assert_valid_json_schema_draft6(schema: &Value) {
+    let result = jsonschema::draft6::new(schema);
+    assert!(
+        result.is_ok(),
+        "Schema failed JSON Schema Draft 6 validation:\n{}\nSchema: {}",
+        result.unwrap_err(),
+        serde_json::to_string_pretty(schema).unwrap(),
+    );
+}
+
+fn assert_valid_json_schema_draft7(schema: &Value) {
+    let result = jsonschema::draft7::new(schema);
+    assert!(
+        result.is_ok(),
+        "Schema failed JSON Schema Draft 7 validation:\n{}\nSchema: {}",
+        result.unwrap_err(),
+        serde_json::to_string_pretty(schema).unwrap(),
+    );
+}
+
+fn assert_valid_json_schema_draft201909(schema: &Value) {
+    let result = jsonschema::draft201909::new(schema);
+    assert!(
+        result.is_ok(),
+        "Schema failed JSON Schema Draft 2019-09 validation:\n{}\nSchema: {}",
+        result.unwrap_err(),
+        serde_json::to_string_pretty(schema).unwrap(),
+    );
+}
+
+fn assert_valid_json_schema_draft202012(schema: &Value) {
+    let result = jsonschema::draft202012::new(schema);
+    assert!(
+        result.is_ok(),
+        "Schema failed JSON Schema Draft 2020-12 validation:\n{}\nSchema: {}",
+        result.unwrap_err(),
+        serde_json::to_string_pretty(schema).unwrap(),
+    );
+}
+
+/// Validate a schema against all commonly used JSON Schema drafts.
+fn assert_valid_json_schema_all_drafts(schema: &Value) {
+    assert_valid_json_schema_draft4(schema);
+    assert_valid_json_schema_draft6(schema);
+    assert_valid_json_schema_draft7(schema);
+    assert_valid_json_schema_draft201909(schema);
+    assert_valid_json_schema_draft202012(schema);
+}
+
+mod codegen_tools {
+    use super::*;
+
+    mod variables {
+        use super::*;
+
+        #[test]
+        fn schema_is_valid_all_drafts() {
+            let schema = Value::Object(Variables::json_schema());
+            assert_valid_json_schema_all_drafts(&schema);
+        }
+
+        #[test]
+        fn serde_roundtrip() {
+            let mut map = FxHashMap::default();
+            map.insert("name".to_string(), Value::String("test".to_string()));
+            map.insert("count".to_string(), Value::Number(42.into()));
+            let vars = Variables(map);
+
+            let json = serde_json::to_string(&vars).unwrap();
+            let deserialized: Variables = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized.len(), 2);
+            assert_eq!(deserialized.get("name").unwrap(), "test");
+        }
+    }
+
+    mod generate {
+        use super::*;
+
+        #[test]
+        fn schema_is_valid_all_drafts() {
+            let schema = Value::Object(Generate::json_schema());
+            assert_valid_json_schema_all_drafts(&schema);
+        }
+
+        #[test]
+        fn tool_input_schema_is_valid_all_drafts() {
+            let tool = Generate::tool();
+            let schema = serde_json::to_value(&tool.input_schema).unwrap();
+            assert_valid_json_schema_all_drafts(&schema);
+        }
+
+        #[test]
+        fn tool_input_schema_validates_sample_input() {
+            let tool = Generate::tool();
+            let schema = serde_json::to_value(&tool.input_schema).unwrap();
+            let validator = jsonschema::draft202012::new(&schema).unwrap();
+
+            let valid_input = serde_json::json!({
+                "template": "my-template",
+                "to": "./output",
+                "dry_run": true,
+                "variables": {"name": "test", "count": 42}
+            });
+            let result = validator.validate(&valid_input);
+            assert!(
+                result.is_ok(),
+                "Valid input rejected: {}",
+                result.unwrap_err(),
+            );
+        }
+
+        #[test]
+        fn tool_input_schema_rejects_missing_required() {
+            let tool = Generate::tool();
+            let schema = serde_json::to_value(&tool.input_schema).unwrap();
+            let validator = jsonschema::draft202012::new(&schema).unwrap();
+
+            // Missing required "template" and "to" fields
+            let invalid_input = serde_json::json!({"dry_run": true});
+            assert!(
+                validator.validate(&invalid_input).is_err(),
+                "Schema should reject input missing required fields"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- The `rust-mcp-macros` `JsonSchema` derive emits `"type": "unknown"` for generic types like `FxHashMap<String, Value>`, which is invalid per all JSON Schema drafts. This causes the Anthropic API (and other strict validators) to reject all tool registrations with a 400 error.
- Introduces a `Variables` newtype wrapper with a hand-written `json_schema()` method returning `{"type": "object"}`, preserving serde compatibility via `#[serde(transparent)]` and `Deref`.
- Adds integration tests validating the generated schemas against JSON Schema Drafts 4, 6, 7, 2019-09, and 2020-12.

Closes #2396

## Test plan

- [x] `Variables::json_schema()` produces a valid schema across all 5 JSON Schema drafts
- [x] `Variables` serde roundtrip (serialize → deserialize) preserves data
- [x] `Generate::json_schema()` is valid across all 5 drafts
- [x] `Generate::tool().input_schema` is valid across all 5 drafts
- [x] Sample input validates against the tool input schema
- [x] Missing required fields are rejected by the tool input schema
- [x] Verified regression: reverting fix to `"unknown"` causes 5/6 tests to fail