### PR TITLE
feat: add moon-debug-task agent skill (#2433)

### DIFF
--- a/skills/debug-task/SKILL.md
+++ b/skills/debug-task/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: moon-debug-task
+name: debug-task
 description: >-
   Diagnose and fix moon tasks that are broken, misconfigured, or behaving
   unexpectedly. Use this skill when a moon task is failing, not running,
@@ -25,13 +25,17 @@ metadata:
   ecosystem: "moonrepo"
 ---
 
-# Moon Task Debugger
+# moon task debugger
 
 A workflow-oriented diagnostic skill for troubleshooting moon tasks. This is not
 a reference manual — it guides you through a structured debugging flow so you
 can isolate the problem quickly.
 
 For conceptual background, see the [moon documentation](https://moonrepo.dev/docs).
+
+**Before you start:** Ask the user for the `<project>:<task>` target to debug.
+If they haven't provided a specific target, prompt them for it — the diagnostic
+flow requires a concrete target to inspect.
 
 ---
 
@@ -42,7 +46,7 @@ Work through these steps in order. Most issues resolve by step 3.
 ### Step 1: Inspect the resolved task configuration
 
 The first thing to check is whether the task is configured the way the user
-expects. Moon merges configuration from multiple sources (global tasks, project
+expects. moon merges configuration from multiple sources (global tasks, project
 config, inheritance), so the resolved result can surprise people.
 
 ```bash
@@ -57,8 +61,8 @@ moon task <project>:<task> --json
 - `command` vs `script` — if the command contains pipes (`|`), redirects (`>`),
   or chained commands (`&&`), it must use `script`, not `command`
 - `inputs` — are they too broad (`**/*` captures everything) or too narrow
-  (missing source files)? Check `state.default_inputs` (true = using default
-  `**/*`) and `state.empty_inputs` (true = explicitly set to `[]`)
+  (missing source files)? Check `state.defaultInputs` (true = using default
+  `**/*`) and `state.emptyInputs` (true = explicitly set to `[]`)
 - `outputs` — are they declared for build tasks? Missing outputs means the cache
   can never hydrate artifacts
 - `toolchain` — is the correct toolchain assigned? An incorrect toolchain means
@@ -70,14 +74,14 @@ moon task <project>:<task> --json
 - `preset` — `server` or `utility` apply multiple option defaults at once
 
 **Red flags:**
-- `command: 'eslint . && prettier --check .'` — pipes/chains in `command` fail
-  silently or error. Use `script` instead
+- `command: 'eslint . && prettier --check .'` — shell syntax in `command` is a
+  parse error in v2. Use `script` instead
 - Empty `outputs` on a build task — cache will never restore artifacts
 - `inputs: ['**/*']` — too broad, cache invalidates on every change
-- A `persistent` task in a `deps` chain — downstream tasks hang forever because
-  the persistent process never "completes"
+- A `persistent` task in a `deps` chain — moon produces a hard error
+  (`PersistentDepRequirement`) at build time
 - `command: 'noop'` or `nop` / `no-op` — the task is intentionally a no-op and
-  does nothing. Moon treats these specially
+  does nothing. moon treats these specially
 - `runInCI: 'only'` — task runs in CI but NOT locally (common surprise)
 - `runInCI: 'skip'` — task is skipped in CI but relationships remain valid
 - `os` set to a platform the user isn't on — task silently skips
@@ -106,20 +110,11 @@ MOON_DEBUG_PROCESS_ENV=true MOON_DEBUG_PROCESS_INPUT=true \
 **Visualize the execution graph** to spot dependency issues:
 
 ```bash
-# Interactive graph visualization (opens in browser)
 moon action-graph <project>:<task>
-
-# Export to DOT format for external tools
-moon action-graph <project>:<task> --dot > graph.dot
-
-# JSON format for programmatic analysis
-moon action-graph <project>:<task> --json
+moon action-graph <project>:<task> --dot  # DOT format (useful for agents)
 ```
 
-Look for:
-- Circular dependencies
-- Missing dependencies (task runs before its prerequisite)
-- A persistent task node that downstream tasks depend on (they'll hang)
+> For all graph commands and output formats, see `references/environment-debug.md`.
 
 ### Step 3: Inspect cache state
 
@@ -137,15 +132,8 @@ moon hash <hash1> <hash2>
 moon hash 0b55b234 2388552f
 ```
 
-**Key cache locations:**
-- `.moon/cache/hashes/<hash>.json` — hash manifest (all sources used to generate the hash)
-- `.moon/cache/outputs/<hash>.tar.gz` — archived task outputs
-- `.moon/cache/states/<project>/snapshot.json` — project snapshot with resolved tasks
-- `.moon/cache/states/<project>/<task>/lastRun.json` — last run metadata (exit code, hash)
-- `.moon/cache/states/<project>/<task>/stdout.log` — captured stdout
-- `.moon/cache/states/<project>/<task>/stderr.log` — captured stderr
-
-> For deeper cache diagnosis, read `references/cache-issues.md`.
+> For cache file locations, hash interpretation, and the `--force` vs `--cache off`
+> comparison, see `references/cache-issues.md`.
 
 ### Step 4: Diagnose the problem type
 
@@ -153,13 +141,13 @@ Use this table to jump to the right reference:
 
 | Symptom | Likely cause | Quick check | Reference |
 |---------|-------------|-------------|-----------|
-| Task doesn't exist | Inheritance not applied — check `inheritedBy` conditions in `.moon/tasks/**/*` against project's `toolchain`, `stack`, `layer`, `tags` via `moon project <name> --json` | `moon task <target> --json` | `references/config-mistakes.md` |
+| Task doesn't exist | Inheritance not applied — check `inheritedBy` conditions in `.moon/tasks/**/*` against project's `toolchains`, `stack`, `layer`, `tags` via `moon project <name> --json` | `moon task <target> --json` | `references/config-mistakes.md` |
 | "Nothing to do" | `--affected` + no changes, `runInCI: false`, or `inheritedBy` mismatch (global task not inherited) | Check flags, `options.runInCI`, and `inheritedBy` | `references/decision-tree.md` |
 | Task errors on execution | Wrong `command`/`script`, bad toolchain | `moon run <target> --log debug` | `references/config-mistakes.md` |
 | Stale cache (cached when it shouldn't be) | Inputs too narrow, missing `env` vars | `moon hash <hash>` | `references/cache-issues.md` |
 | Cache miss (re-runs every time) | Inputs too broad, volatile outputs | `moon hash <h1> <h2>` | `references/cache-issues.md` |
 | Outputs not restored after cache hit | `outputs` misconfigured | Check `.moon/cache/outputs/` | `references/cache-issues.md` |
-| Task hangs / pipeline stuck | Persistent task in `deps` chain | `moon action-graph <target>` | `references/config-mistakes.md` |
+| Task hangs / pipeline stuck | Persistent task in `deps` chain (hard error in v2) | `moon action-graph <target>` | `references/config-mistakes.md` |
 | Task is slow | Dep chain bottleneck, no parallelism | `moon action-graph <target>` | `references/decision-tree.md` |
 | Task does nothing (no-op) | Command is `noop`/`nop`/`no-op` | `moon task <target> --json` | `references/config-mistakes.md` |
 | Task fails silently | `allowFailure: true` hiding errors | Check `options.allowFailure` | `references/config-mistakes.md` |
@@ -187,168 +175,24 @@ moon task <project>:<task> --json
 - `--force` ignores existing cache but **writes** new cache after execution
 - `--cache off` disables caching entirely — no reads, no writes
 
+> For all cache modes (`read`, `write`, `off`), see `references/cache-issues.md`.
+
 ---
 
-## Common anti-patterns
+## Common mistakes at a glance
 
-These are the mistakes that come up most often. If the user's problem matches
-one of these, you can skip the diagnostic flow and go straight to the fix.
+These are the issues that come up most often. For details and fixes, see
+`references/config-mistakes.md`.
 
-### Pipes or chains in `command`
-
-```yaml
-# WRONG: command only accepts a single binary
-tasks:
-  lint:
-    command: 'eslint . && prettier --check .'
-
-# RIGHT: use script for pipes, redirects, or chained commands
-tasks:
-  lint:
-    script: 'eslint . && prettier --check .'
-```
-
-`command` is for a single binary with arguments. It supports inheritance merge
-strategies (append, prepend, replace). `script` supports shell syntax but does
-not support merge strategies.
-
-### Missing outputs on build tasks
-
-```yaml
-# WRONG: no outputs declared — cache never hydrates artifacts
-tasks:
-  build:
-    command: 'vite build'
-
-# RIGHT: declare what the build produces
-tasks:
-  build:
-    command: 'vite build'
-    outputs:
-      - 'dist'
-```
-
-Without `outputs`, moon has nothing to archive or restore on cache hit.
-
-### Overly broad inputs
-
-```yaml
-# WRONG: **/* captures node_modules, .moon/cache, everything
-tasks:
-  test:
-    command: 'vitest'
-    inputs:
-      - '**/*'
-
-# RIGHT: be specific about what affects the task
-tasks:
-  test:
-    command: 'vitest'
-    inputs:
-      - 'src/**/*'
-      - 'tests/**/*'
-      - 'vitest.config.*'
-```
-
-Broad inputs mean the hash changes on every run, defeating the cache.
-
-### Volatile outputs that change every run
-
-If outputs include files with timestamps, absolute paths, or random content
-(like sourcemaps with absolute paths), the cache will always appear "stale."
-Exclude volatile files from `outputs` or normalize them.
-
-### Persistent task blocking the pipeline
-
-```yaml
-# WRONG: dev-server is persistent and blocks downstream tasks
-tasks:
-  dev-server:
-    command: 'vite dev'
-    preset: 'server'  # marks as persistent
-  integration-test:
-    command: 'cypress run'
-    deps:
-      - '~:dev-server'  # hangs forever waiting for dev-server to "finish"
-
-# RIGHT: persistent tasks should be leaf nodes, not dependencies
-# Or restructure so integration-test doesn't depend on dev-server
-```
-
-A persistent task (or one with `preset: 'server'`) never completes. If another
-task lists it in `deps`, the pipeline hangs. Diagnose with
-`moon action-graph <target>` and look for persistent nodes with dependents.
-
-Note: tasks named `dev`, `start`, or `serve` are automatically marked as
-`server` preset.
-
-### Confusing `--affected` with `--force`
-
-These are opposites:
-- `--affected` **restricts** execution to tasks whose inputs changed
-- `--force` **bypasses** cache and runs everything regardless
-
-Using `--affected` when you want to force a run (or vice versa) is a common
-source of "why didn't my task run?" confusion.
-
-### `allowFailure` masking real errors
-
-```yaml
-# DANGEROUS: task errors are silently swallowed
-tasks:
-  lint:
-    command: 'eslint src/'
-    options:
-      allowFailure: true
-```
-
-If a task has `allowFailure: true`, it will report success even when the
-underlying command fails. This is intentional for advisory tasks, but if the
-user doesn't realize it's set (e.g., inherited from a global task), real errors
-go unnoticed. Check `moon task <target> --json` and inspect `options.allowFailure`.
-To see the actual error output, check the captured stderr:
-
-```bash
-cat .moon/cache/states/<project>/<task>/stderr.log
-```
-
-### Mutex deadlocks between tasks
-
-```yaml
-# PROBLEM: two tasks share a mutex and depend on each other
-tasks:
-  build-a:
-    command: 'build-a'
-    options:
-      mutex: 'build-lock'
-  build-b:
-    command: 'build-b'
-    options:
-      mutex: 'build-lock'
-    deps: ['~:build-a']  # safe — sequential via deps
-```
-
-The `mutex` option ensures only one task with that mutex name runs at a time.
-This is useful for tasks that write to shared resources. But if combined
-incorrectly with `deps`, it can cause unexpected serialization or deadlocks.
-
-### Wrong `runInCI` variant
-
-```yaml
-tasks:
-  deploy:
-    command: 'deploy.sh'
-    options:
-      runInCI: 'only'    # ONLY runs in CI, skipped locally
-  e2e:
-    command: 'playwright test'
-    options:
-      runInCI: 'skip'    # Skipped in CI but runs locally, deps stay valid
-```
-
-The `runInCI` option accepts: `true`/`'affected'` (default — run if affected),
-`false` (never in CI), `'always'` (always in CI even if not affected),
-`'only'` (CI only, skip local), `'skip'` (skip CI, run local).
+- **Shell syntax in `command`** — pipes, `&&`, redirects require `script`; v2 rejects these as parse errors
+- **Missing `outputs` on build tasks** — cache can never hydrate artifacts
+- **Overly broad `inputs`** — `**/*` invalidates cache on every change; be specific
+- **Volatile outputs** — timestamps or absolute paths in build artifacts cause permanent cache misses
+- **Persistent task in `deps`** — hard error (`PersistentDepRequirement`); tasks named `dev`/`start`/`serve` auto-get `server` preset
+- **`--affected` vs `--force` confusion** — `--affected` restricts; `--force` bypasses cache (they're opposites)
+- **`allowFailure: true` hiding errors** — task reports success even when command fails; check stderr at `.moon/cache/states/<project>/<task>/stderr.log`
+- **`mutex` contention** — shared mutex serializes tasks; combined with deps can deadlock
+- **`runInCI: 'only'`** — task silently skips when run locally (most surprising variant)
 
 ---
 

--- a/skills/debug-task/references/cache-issues.md
+++ b/skills/debug-task/references/cache-issues.md
@@ -1,6 +1,6 @@
 # Cache Issues: Diagnosis and Fixes
 
-Moon's cache is powered by content-based hashing. Every task run generates a
+moon's cache is powered by content-based hashing. Every task run generates a
 hash from multiple sources (command, args, inputs, outputs, env, dependencies).
 If the hash matches a previous run, moon skips execution and restores the cached
 output.
@@ -82,6 +82,14 @@ tasks:
       NODE_ENV: 'production'
 ```
 
+Alternatively, you can track an env var in `inputs` using the `$` prefix:
+
+```yaml
+inputs:
+  - 'src/**/*'
+  - '$NODE_ENV'  # env var value is included in the hash
+```
+
 ### Quick fix
 
 ```bash
@@ -125,7 +133,8 @@ what's causing the cache miss.
 **Inputs too broad:**
 
 ```yaml
-# PROBLEM: **/* captures node_modules, .moon/cache, lock files, everything
+# PROBLEM: **/* matches too many irrelevant files in the project directory
+# (node_modules and .git are globally ignored, but everything else matches)
 inputs:
   - '**/*'
 
@@ -150,7 +159,8 @@ task. This is usually correct behavior, but can be surprising.
 
 **Git-ignored files leaking in:**
 
-Moon filters VCS-ignored files from `inputs`, but edge cases exist. If you
+moon filters VCS-ignored files from `inputs` (including `node_modules` and
+`.git` which are globally ignored), but edge cases exist. If you
 see unexpected files in the hash manifest, check `.gitignore` coverage.
 
 ### Quick fix
@@ -165,7 +175,7 @@ see unexpected files in the hash manifest, check `.gitignore` coverage.
 
 ## Outputs not restored
 
-**Symptom:** Moon says "cached" (cache hit), but the expected output files
+**Symptom:** moon says "cached" (cache hit), but the expected output files
 don't appear in the project directory.
 
 **Root cause:** The `outputs` configuration doesn't match the actual files the
@@ -187,11 +197,12 @@ tar tzf .moon/cache/outputs/<hash>.tar.gz
 
 ### Common causes
 
-**Outputs misconfigured — relative vs absolute paths:**
+**Outputs misconfigured — path relativity:**
 
-All output paths are relative to the project root (or workspace root if
-`runFromWorkspaceRoot` is true). If the build tool writes to an unexpected
-location, the paths won't match.
+Output paths can be project-relative or workspace-relative. By default they
+are project-relative, but you can use workspace-relative paths directly in
+the `outputs` config. If the build tool writes to an unexpected location,
+the paths won't match.
 
 ```yaml
 # PROBLEM: build writes to <workspace>/dist, not <project>/dist

--- a/skills/debug-task/references/config-mistakes.md
+++ b/skills/debug-task/references/config-mistakes.md
@@ -30,8 +30,9 @@ and how to fix it.
 
 This is the single most common configuration mistake.
 
-**`command`** accepts a single binary name with optional arguments. It supports
-task inheritance merge strategies (`mergeArgs: append|prepend|replace`).
+**`command`** accepts a single binary name with optional arguments — also known
+as a [simple command](https://www.gnu.org/software/bash/manual/html_node/Simple-Commands.html)
+in shell terminology. It supports task inheritance merge strategies.
 
 ```yaml
 tasks:
@@ -43,8 +44,9 @@ tasks:
       - 'src/'
 ```
 
-**`script`** accepts one or more shell commands with full shell syntax — pipes,
-redirects, `&&`, `||`, subshells. It does **not** support inheritance merging.
+**`script`** accepts [pipelines, compound commands](https://www.gnu.org/software/bash/manual/html_node/Shell-Commands.html),
+and full shell syntax — pipes, redirects, `&&`, `||`, subshells. It does **not**
+support inheritance merging.
 
 ```yaml
 tasks:
@@ -61,8 +63,8 @@ tasks:
     command: 'eslint . && prettier --check .'
 ```
 
-This either fails with a confusing error (moon tries to run `eslint` with
-literal arguments `. && prettier --check .`) or silently does the wrong thing.
+In v2 this is a **parse error** — moon rejects the configuration at build time
+with an `InvalidCommandSyntax` or `UnsupportedCommandSyntax` error.
 
 ### How to detect
 
@@ -70,8 +72,8 @@ literal arguments `. && prettier --check .`) or silently does the wrong thing.
 moon task <project>:<task> --json
 ```
 
-If the `command` field contains `&&`, `|`, `>`, `>>`, `;`, or backticks, it
-should be `script` instead.
+If the `command` field contains pipes, redirects, expressions, etc., it should
+be `script` instead.
 
 ### How to fix
 
@@ -97,7 +99,7 @@ tasks:
 
 ## Task inheritance bugs
 
-Moon's inheritance system lets you define tasks once in `.moon/tasks/**/*` and
+moon's inheritance system lets you define tasks once in `.moon/tasks/**/*` and
 have them inherited by matching projects. When inheritance goes wrong, the task
 either doesn't appear or appears with unexpected config.
 
@@ -126,7 +128,7 @@ Compare `toolchain`, `stack`, `layer`, `language`, and `tags` against the
 **Check for explicit exclusion:**
 
 ```yaml
-# moon.yml (project level)
+# moon.{json,jsonc,hcl,pkl,toml,yaml,yml} (project level)
 workspace:
   inheritedTasks:
     exclude: ['lint']  # This project opted out
@@ -153,6 +155,7 @@ strategies. The defaults are:
 | `env` | `append` (object merge) |
 | `inputs` | `append` |
 | `outputs` | `append` |
+| `toolchains` | `append` (via `mergeToolchains`) |
 
 ```yaml
 # Global: args = ['--check']
@@ -186,7 +189,7 @@ and in what order.
 
 ## Presets and automatic behavior
 
-Moon has two built-in presets that set multiple options at once:
+moon has two built-in presets that set multiple options at once:
 
 ### `server` preset
 
@@ -202,6 +205,7 @@ This sets:
 - `cache` -> off
 - `outputStyle` -> `stream`
 - `persistent` -> on
+- `priority` -> `'low'`
 - `runInCI` -> off
 
 ### `utility` preset
@@ -219,7 +223,7 @@ This sets:
 - `interactive` -> on
 - `outputStyle` -> `stream`
 - `persistent` -> off
-- `runInCI` -> skipped
+- `runInCI` -> `'skip'`
 
 ### Automatic preset assignment
 
@@ -258,16 +262,17 @@ tasks:
 
 A persistent task (`options.persistent: true` or `preset: 'server'`) is one
 that runs continuously — a dev server, a file watcher, a background process.
-Moon handles persistent tasks specially: they run **last** and **in parallel**,
+moon handles persistent tasks specially: they run **last** and **in parallel**,
 after all non-persistent dependencies complete.
 
 ### The problem
 
-If a non-persistent task lists a persistent task in `deps`, the pipeline hangs.
-The persistent task never "finishes," so the dependent task never starts.
+If a non-persistent task lists a persistent task in `deps`, moon produces a
+**hard error** (`PersistentDepRequirement`) at build time. moon validates dep
+chains and rejects this configuration before execution starts.
 
 ```yaml
-# PROBLEM: integration-test depends on dev-server, which never finishes
+# ERROR: integration-test depends on dev-server, which is persistent
 tasks:
   dev-server:
     command: 'vite dev'
@@ -275,7 +280,7 @@ tasks:
   integration-test:
     command: 'cypress run'
     deps:
-      - '~:dev-server'  # HANGS
+      - '~:dev-server'  # PersistentDepRequirement error
 ```
 
 ### How to detect
@@ -403,7 +408,7 @@ tasks:
 project (either defined locally or inherited). If it's not found, the extension
 silently fails or errors.
 
-**Circular extension:** Task A extends B, B extends A. Moon should catch this,
+**Circular extension:** Task A extends B, B extends A. moon should catch this,
 but it's worth checking if you see strange behavior.
 
 ### How to verify
@@ -419,7 +424,7 @@ overrides from the extending task.
 
 ## No-op tasks
 
-Moon treats tasks with command `noop`, `nop`, or `no-op` as intentional no-ops.
+moon treats tasks with command `noop`, `nop`, or `no-op` as intentional no-ops.
 These tasks execute successfully but do nothing. They're sometimes used as
 aggregation points — a task that only exists to declare `deps` on other tasks.
 
@@ -473,7 +478,7 @@ inputs changed.
 
 ```bash
 moon task <project>:<task> --json | grep -i runci
-# Also check state.set_run_in_ci — if true, it was explicitly configured
+# Also check state.setRunInCi — if true, it was explicitly configured
 ```
 
 ---
@@ -496,7 +501,7 @@ This is intentional for advisory tasks. But if it's inherited from a global
 task and the user doesn't realize it's set, real errors go unnoticed.
 
 **Gotcha with deps:** If task A has `allowFailure: true` and task B depends on
-A, B will execute even if A's command failed. Moon's task builder validates that
+A, B will execute even if A's command failed. moon's task builder validates that
 `allowFailure` deps are acceptable, but the runtime behavior can still surprise.
 
 ### How to detect
@@ -662,7 +667,7 @@ moon's tracking, or any "just bust the cache" scenario.
 
 ## Task builder validation errors
 
-Moon's task builder validates configuration at build time and produces specific
+moon's task builder validates configuration at build time and produces specific
 errors. If you see one of these, here's what it means:
 
 **`PersistentDepRequirement`** — a non-persistent task depends on a persistent
@@ -670,7 +675,7 @@ task. This is always a configuration error because the persistent task never
 finishes. Fix: remove the dependency or restructure the task graph.
 
 **`AllowFailureDepRequirement`** — a task depends on a task with
-`allowFailure: true`. Moon warns about this because a failing dependency will
+`allowFailure: true`. moon warns about this because a failing dependency will
 still let the dependent task run, which may produce incorrect results.
 
 **`RunInCiDepRequirement`** — a task that runs in CI depends on a task that

--- a/skills/debug-task/references/decision-tree.md
+++ b/skills/debug-task/references/decision-tree.md
@@ -1,4 +1,4 @@
-# Decision Tree: Moon Task Diagnostics
+# Decision Tree: moon task diagnostics
 
 A systematic walk-through for diagnosing any moon task issue. Start at the top
 and follow the branches. Each leaf gives you the exact commands to run and what
@@ -18,11 +18,12 @@ If this returns an error or exit code 1, the task does not exist in that project
 
 **Check 1: Is it defined in the project config?**
 
-Look in the project's `moon.yml` (or `moon.toml`, `moon.json`) under `tasks:`.
+Look in the project's config file (`moon.{json,jsonc,hcl,pkl,toml,yaml,yml}`)
+under `tasks:`.
 
 ```bash
 # Read the project's config file directly
-cat <project-root>/moon.yml
+cat <project-root>/moon.yml  # or moon.json, moon.toml, etc.
 ```
 
 **Check 2: Should it be inherited from global tasks?**
@@ -36,20 +37,25 @@ conditions matching the project's `toolchain`, `stack`, `layer`, `language`, or
 moon project <project> --json
 ```
 
-Compare the project's `toolchain`, `stack`, `layer`, and `tags` against the
-`inheritedBy` conditions in the global task file.
+Compare the project's `toolchains`, `stack`, `layer`, and `tags` (note:
+`toolchains` is plural in the JSON output) against the `inheritedBy` conditions
+in the global task file.
 
 Common inheritance failures:
-- Project doesn't have the right `toolchain` set (e.g., global task requires
+- Project doesn't have the right `toolchains` set (e.g., global task requires
   `toolchain: 'node'` but project doesn't declare it)
 - `inheritedBy` uses `and` clause that the project doesn't fully satisfy
 - Project explicitly excludes the task via `workspace.inheritedTasks.exclude`
 - Project renames the task via `workspace.inheritedTasks.rename`
+- Project doesn't `include` the global task file (check for `include` directives)
 
 **Check 3: Is the task ID spelled correctly?**
 
-Task IDs support camel/kebab/snake case and must start with a letter. Check for
-typos, especially with similar names (e.g., `build` vs `buildApp`).
+Task IDs must start with a letter and can contain `a-z`, `A-Z`, `0-9`, `-`,
+`_`, `/`, and `.` (see
+[id_regex.rs](https://github.com/moonrepo/starbase/blob/master/crates/id/src/id_regex.rs#L10)
+for the full pattern). Check for typos, especially with similar names
+(e.g., `build` vs `buildApp`).
 
 **Fix:** Add the task to the project config, fix the `inheritedBy` conditions,
 or correct the task ID.
@@ -76,21 +82,14 @@ moon run <project>:<task> --force
 
 **Check 2: Is `runInCI` blocking execution?**
 
-The `runInCI` option has multiple variants that can cause skipping:
-
-| `runInCI` value | Skipped locally? | Skipped in CI? |
-|-----------------|-----------------|---------------|
-| `false` | No | Yes |
-| `'only'` | **Yes** | No (if affected) |
-| `'skip'` | No | **Yes** (deps stay valid) |
-
 ```bash
 moon task <project>:<task> --json
-# Check options.runInCI and state.set_run_in_ci
+# Check options.runInCI and state.setRunInCi
 ```
 
-If `state.set_run_in_ci` is `false`, the value was not explicitly set and came
-from a preset or default.
+If `state.setRunInCi` is `false`, the value was not explicitly set and came
+from a preset or default. See `config-mistakes.md` § `runInCI` variants for the
+full table of values and their local/CI behavior.
 
 **Check 3: Is the `os` option filtering this platform out?**
 
@@ -104,7 +103,7 @@ moon task <project>:<task> --json
 
 **Check 4: Is the task a no-op?**
 
-Tasks with command `noop`, `nop`, or `no-op` intentionally do nothing. Moon
+Tasks with command `noop`, `nop`, or `no-op` intentionally do nothing. moon
 recognizes these as special no-operation commands.
 
 ```bash
@@ -156,30 +155,19 @@ moon run <project>:<task> --log debug --force 2>&1 | grep -i "toolchain\|version
 
 **Check 5: Are environment variables correct?**
 
-```bash
-MOON_DEBUG_PROCESS_ENV=true moon run <project>:<task> --log trace --force
-```
+Use `MOON_DEBUG_PROCESS_ENV=true` to reveal all env vars passed to the process.
+See `environment-debug.md` for all debug env vars and log levels.
 
-This reveals all env vars passed to the process. Look for missing or incorrect values.
+**Check 6: Is `timeout` or `allowFailure` involved?**
 
-**Check 6: Is the task timing out?**
-
-If `options.timeout` is set, the task is killed after that many seconds. The
-error message should mention a timeout, but if `allowFailure` is also set,
-it may be silently swallowed.
-
-**Check 7: Is `allowFailure` masking the real error?**
-
-If `options.allowFailure: true`, the task reports success even on failure. The
-error is logged but the pipeline continues. Check stderr:
-
-```bash
-cat .moon/cache/states/<project>/<task>/stderr.log
-```
+Check `options.timeout` and `options.allowFailure` in the JSON output. If
+`allowFailure: true`, the task reports success even on failure — check stderr
+at `.moon/cache/states/<project>/<task>/stderr.log`. See `config-mistakes.md`
+for details on both options.
 
 **Fix:** Switch `command` to `script` for shell syntax. Fix the binary path or
-toolchain. Correct the working directory setting. Increase `timeout` if needed.
-Check `allowFailure` and stderr for hidden errors.
+toolchain. Correct the working directory. See `config-mistakes.md` for the full
+`command` vs `script` guide.
 
 ---
 
@@ -205,7 +193,7 @@ moon run <project>:<task> --force
 
 **The output is missing files:**
 
-The task's `outputs` don't cover all files the build produces. Moon only archives
+The task's `outputs` don't cover all files the build produces. moon only archives
 and restores what's declared in `outputs`.
 
 ```bash
@@ -250,44 +238,23 @@ Visualize the graph and look for:
 - A persistent task in the dependency chain (it never "finishes," blocking
   everything downstream)
 
-### Check 2: No cache utilization
-
-If the task re-runs from scratch every time, it's either:
-- Not caching at all (`options.cache: false` or `preset: 'utility'`)
-- Always getting a cache miss (inputs too broad or outputs volatile)
+### Check 2: Cache, inputs, mutex, or retries
 
 ```bash
-moon task <project>:<task> --json | grep -i cache
-```
-
-### Check 3: Large inputs/outputs
-
-Hashing thousands of files is slow. Consider narrowing `inputs` to specific
-directories rather than using `**/*`. Check `state.default_inputs` — if `true`,
-the task is using the default `**/*` glob which captures everything in the
-project directory.
-
-### Check 4: Mutex serialization
-
-If multiple tasks share the same `mutex` value, they run sequentially instead
-of in parallel. This is intentional (to protect shared resources), but can
-cause unexpected slowness.
-
-```bash
-# Check if multiple tasks share the same mutex
 moon task <project>:<task> --json
-# Look at options.mutex
 ```
 
-### Check 5: Retries adding time
-
-If `options.retryCount` is set and the task is flaky, failed attempts add up.
-A task with `retryCount: 3` that fails twice before passing takes 3x the time
-of a single run.
+- **No cache?** Check `options.cache` — may be `false` or set by preset. See
+  `cache-issues.md` for cache miss diagnosis.
+- **Broad inputs?** Check `state.defaultInputs` — if `true`, the default `**/*`
+  glob is hashing the entire project directory.
+- **Mutex?** Check `options.mutex` — shared mutex serializes tasks. See
+  `config-mistakes.md` § `mutex` contention.
+- **Retries?** Check `options.retryCount` — flaky tasks with retries multiply
+  execution time.
 
 **Fix:** Remove unnecessary `deps`, narrow `inputs`, ensure caching is enabled,
-check for persistent tasks blocking the pipeline, review mutex usage, and
-investigate flaky tasks that rely on retries.
+review mutex usage, and investigate flaky tasks.
 
 ---
 

--- a/skills/debug-task/references/environment-debug.md
+++ b/skills/debug-task/references/environment-debug.md
@@ -18,7 +18,7 @@ inspection tools available for deep debugging of moon tasks.
 
 ## Debug environment variables
 
-Moon provides several environment variables that reveal internal state during
+moon provides several environment variables that reveal internal state during
 task execution. Set them before running `moon run`:
 
 | Variable | What it reveals |
@@ -125,6 +125,9 @@ Shows the fully resolved task configuration after inheritance, merging, and
 token resolution. This is the single most useful debugging command — always
 start here.
 
+**Tip:** Running `moon task <project>:<task>` without `--json` also displays
+all available `PATH`s for the resolved toolchain.
+
 ### `moon project` — inspect project metadata
 
 ```bash
@@ -137,6 +140,19 @@ moon project <project> --json
 
 Shows project metadata: language, toolchain, stack, layer, tags, dependencies,
 file groups, and all configured tasks.
+
+### `moon task-graph` / `moon project-graph` — visualize graphs
+
+```bash
+# Visualize the task dependency graph
+moon task-graph <project>:<task>
+
+# Visualize the project dependency graph
+moon project-graph <project>
+```
+
+These show task-level and project-level dependency relationships respectively,
+complementing the lower-level action graph below.
 
 ### `moon action-graph` — visualize the dependency graph
 
@@ -172,6 +188,8 @@ moon hash <hash1> <hash2>
 # JSON output
 moon hash <hash> --json
 ```
+
+> For interpreting hash diffs in cache investigations, see `cache-issues.md`.
 
 ### `moon query` — query project and task information
 


### PR DESCRIPTION
## Summary

Adds the first official Moon agent skill: `moon-debug-task`, a workflow-oriented skill that guides AI coding assistants through diagnosing failing, misconfigured, or incorrectly cached moon tasks.

This is the initial spike discussed in #2433 with @milesj. The skill follows the [Agent Skills specification](https://agentskills.io/specification) and is designed to complement (not duplicate) the existing documentation, `llms.txt`, and `moon mcp` server.

## Skills Checklist

### `moon-debug-task` — Diagnose broken, misconfigured, or incorrectly cached tasks
- [x] `SKILL.md` — 5-step diagnostic flow, symptom table, 9 anti-patterns (366 lines, under 500)
- [x] `references/decision-tree.md` — Full if/then/else troubleshooting tree
- [x] `references/cache-issues.md` — Cache hit/miss diagnosis with `moon hash` inspection
- [x] `references/config-mistakes.md` — command vs script, inheritance, presets, persistent tasks, runInCI variants, allowFailure, mutex, timeout, task builder validation errors
- [x] `references/environment-debug.md` — Debug env vars, log levels, trace profiling, inspection tools
- [x] Agent Skills spec compliant (name, description, license, compatibility, metadata, allowed-tools)
- [x] All commands validated against Moon v2.1 crate source code
- [x] Eval-tested: 6 test cases, 36 assertions, **100% pass rate** vs 78% baseline
- [x] Description optimized for triggering accuracy (938/1024 chars)

### Future skills (not in this PR)
- [ ] `moon-learn` — Reads `llms.txt` to orient agents on Moon concepts *(blocked by [#2434](https://github.com/moonrepo/moon/issues/2434) — current `llms.txt` contains raw MDX imports instead of clean rendered content)*
- [ ] `debug-project` — Diagnose project detection, dependencies, graph issues
- [ ] `create-toolchain` — Step-by-step WASM toolchain plugin scaffolding
- [ ] `migrate-v2` — Interactive v1 to v2 migration guidance

## Design decisions

- **`moon-debug-task/` not `moon/`:** @milesj's feedback steered toward focused, workflow-specific skills. Each skill gets its own directory matching its `name` frontmatter field per the Agent Skills spec. Future skills will be separate directories.
- **Workflow-first, not docs-first:** The skill guides agents through a diagnostic flow, not through Moon's API surface. Docs links are referenced, not reproduced.
- **Progressive disclosure:** SKILL.md covers 80% of cases. References load only when the agent needs to go deeper into cache, config, or environment issues.
- **v2-native:** All content targets Moon v2.x. Validated against crate source (`crates/task/`, `crates/task-runner/`, `crates/mcp/`, `crates/config/`, etc.) and official docs.
- **No MCP in this skill:** MCP integration (`get_task`, `get_project`, `get_changed_files`) belongs in a future `moon-learn` skill that provides general Moon knowledge grounding. This skill is purely a debugging workflow using CLI commands.

## Eval results

| Test case | With Skill | Without Skill | Delta |
|-----------|-----------|--------------|-------|
| Stale cache (inputs missing shared/) | 100% | 67% | +33pp |
| CI "nothing to do" (inheritance + affected) | 100% | 67% | +33pp |
| Pipeline hangs (auto server preset) | 100% | 67% | +33pp |
| command vs script (`&&` in command) | 100% | 67% | +33pp |
| allowFailure masking test failures | 100% | 100% | +0pp |
| Task inheritance not applying | 100% | 100% | +0pp |
| **Overall** | **100%** | **78%** | **+22pp** |

Strongest value on moon-specific knowledge the baseline model lacks: `moon hash` diffing, auto `server` preset for `dev`/`start`/`serve` tasks, `command` vs `script` distinction with merge strategy tradeoffs.

## How to test

```bash
# Symlink into Claude Code skills directory (local testing only)
mkdir -p .claude/skills
ln -s ../../skills/moon-debug-task .claude/skills/moon-debug-task

# Then ask Claude Code:
# "my moon task is cached but shouldn't be"
# "moon run fails with no output"
# "my task hangs and never finishes"
# "my task uses && in command and errors"
# "moon ci says nothing to do"
```

Closes #2433 (partially — this is the first skill of the proposed set)