### PR TITLE
fix: reindex filtered workspace graphs

### DIFF
--- a/crates/project-graph/tests/project_graph_test.rs
+++ b/crates/project-graph/tests/project_graph_test.rs
@@ -1001,11 +1001,15 @@ mod project_graph {
                 let mock = create_workspace_mocker(sandbox.path());
 
                 let graph = mock.mock_workspace_graph_for(&["some-depends-on"]).await;
+                let project = graph.get_project("some-depends-on").unwrap();
+                let mut direct_deps = map_ids(graph.projects.dependencies_of(&project));
+                direct_deps.sort();
 
                 assert_eq!(
                     map_ids(graph.projects.get_node_keys()),
                     ["some-depends-on", "a", "c"]
                 );
+                assert_eq!(direct_deps, ["a", "c"]);
             }
 
             #[tokio::test(flavor = "multi_thread")]
@@ -1014,10 +1018,28 @@ mod project_graph {
                 let mock = create_workspace_mocker(sandbox.path());
 
                 let graph = mock.mock_workspace_graph_for(&["from-task-deps"]).await;
+                let project = graph.get_project("from-task-deps").unwrap();
+                let build = graph
+                    .get_task_from_project("from-task-deps", "build")
+                    .unwrap();
+                let check = graph
+                    .get_task_from_project("from-task-deps", "check")
+                    .unwrap();
+                let mut direct_deps = map_ids(graph.projects.dependencies_of(&project));
+                direct_deps.sort();
 
                 assert_eq!(
                     map_ids(graph.projects.get_node_keys()),
                     ["from-task-deps", "b", "c"]
+                );
+                assert_eq!(direct_deps, ["b", "c"]);
+                assert_eq!(
+                    graph.tasks.dependencies_of(&build),
+                    vec![Target::parse("b:build").unwrap()]
+                );
+                assert_eq!(
+                    graph.tasks.dependencies_of(&check),
+                    vec![Target::parse("c:check").unwrap()]
                 );
 
                 let deps = &graph.get_project("from-task-deps").unwrap().dependencies;
@@ -1034,10 +1056,17 @@ mod project_graph {
                 let graph = mock
                     .mock_workspace_graph_for(&["from-root-task-deps"])
                     .await;
+                let build = graph
+                    .get_task_from_project("from-root-task-deps", "build")
+                    .unwrap();
 
                 assert_eq!(
                     map_ids(graph.projects.get_node_keys()),
                     ["from-root-task-deps", "root"]
+                );
+                assert_eq!(
+                    graph.tasks.dependencies_of(&build),
+                    vec![Target::parse("root:noop").unwrap()]
                 );
 
                 let deps = &graph

--- a/crates/workspace/src/projects_builder.rs
+++ b/crates/workspace/src/projects_builder.rs
@@ -367,19 +367,14 @@ impl WorkspaceProjectsBuilder {
         let mut project_graph = ProjectGraph::new(context);
         project_graph.default_id = self.context().workspace_config.default_project.clone();
         project_graph.aliases.extend(self.aliases_to_ids);
+        let mut loaded_projects = FxHashMap::default();
 
         // TODO switch to filter_map_owned
         project_graph.graph = self.graph.filter_map(
             |ni, node| match node {
                 NodeState::Loading => None,
                 NodeState::Loaded(project) => {
-                    project_graph.nodes.insert(
-                        project.id.clone(),
-                        ProjectNode {
-                            index: ni,
-                            project: project.to_owned(),
-                        },
-                    );
+                    loaded_projects.insert(ni, project.to_owned());
 
                     Some(ni)
                 }
@@ -387,8 +382,15 @@ impl WorkspaceProjectsBuilder {
             |_, edge| Some(*edge),
         );
 
-        for (id, index) in self.ids_to_indexes {
-            project_graph.indexes.insert(index, id);
+        for index in project_graph.graph.graph().node_indices() {
+            let old_index = *project_graph.graph.node_weight(index).unwrap();
+            let project = loaded_projects.remove(&old_index).unwrap();
+            let id = project.id.clone();
+
+            project_graph.indexes.insert(index, id.clone());
+            project_graph
+                .nodes
+                .insert(id, ProjectNode { index, project });
         }
 
         project_graph

--- a/crates/workspace/src/tasks_builder.rs
+++ b/crates/workspace/src/tasks_builder.rs
@@ -118,19 +118,14 @@ impl WorkspaceTasksBuilder {
         project_graph: Arc<ProjectGraph>,
     ) -> TaskGraph {
         let mut task_graph = TaskGraph::new(context, project_graph);
+        let mut loaded_tasks = FxHashMap::default();
 
         // TODO switch to filter_map_owned
         task_graph.graph = self.graph.filter_map(
             |ni, node| match node {
                 NodeState::Loading => None,
                 NodeState::Loaded(task) => {
-                    task_graph.nodes.insert(
-                        task.target.clone(),
-                        TaskNode {
-                            index: ni,
-                            task: task.to_owned(),
-                        },
-                    );
+                    loaded_tasks.insert(ni, task.to_owned());
 
                     Some(ni)
                 }
@@ -138,8 +133,13 @@ impl WorkspaceTasksBuilder {
             |_, edge| Some(*edge),
         );
 
-        for (target, index) in self.targets_to_indexes {
-            task_graph.indexes.insert(index, target);
+        for index in task_graph.graph.graph().node_indices() {
+            let old_index = *task_graph.graph.node_weight(index).unwrap();
+            let task = loaded_tasks.remove(&old_index).unwrap();
+            let target = task.target.clone();
+
+            task_graph.indexes.insert(index, target.clone());
+            task_graph.nodes.insert(target, TaskNode { index, task });
         }
 
         task_graph

--- a/crates/workspace/src/workspace_builder.rs
+++ b/crates/workspace/src/workspace_builder.rs
@@ -246,25 +246,13 @@ impl WorkspaceBuilder {
         let mut project_graph = ProjectGraph::new(graph_context.clone());
         project_graph.default_id = context.workspace_config.default_project.clone();
         project_graph.aliases.extend(self.aliases);
-
-        for (id, build_data) in self.project_data {
-            if let Some(index) = build_data.node_index {
-                project_graph.indexes.insert(index, id.clone());
-                project_graph.nodes.insert(
-                    id,
-                    ProjectNode {
-                        index,
-                        project: Default::default(),
-                    },
-                );
-            }
-        }
+        let mut loaded_projects = FxHashMap::default();
 
         project_graph.graph = self.project_graph.filter_map(
             |ni, node| match node {
                 NodeState::Loading => None,
                 NodeState::Loaded(project) => {
-                    project_graph.nodes.get_mut(&project.id).unwrap().project = project.to_owned();
+                    loaded_projects.insert(ni, project.to_owned());
 
                     Some(ni)
                 }
@@ -272,34 +260,42 @@ impl WorkspaceBuilder {
             |_, edge| Some(*edge),
         );
 
+        for index in project_graph.graph.graph().node_indices() {
+            let old_index = *project_graph.graph.node_weight(index).unwrap();
+            let project = loaded_projects.remove(&old_index).unwrap();
+            let id = project.id.clone();
+
+            project_graph.indexes.insert(index, id.clone());
+            project_graph
+                .nodes
+                .insert(id, ProjectNode { index, project });
+        }
+
         let project_graph = Arc::new(project_graph);
 
         let mut task_graph = TaskGraph::new(graph_context, Arc::clone(&project_graph));
-
-        for (target, build_data) in self.task_data {
-            if let Some(index) = build_data.node_index {
-                task_graph.indexes.insert(index, target.clone());
-                task_graph.nodes.insert(
-                    target,
-                    TaskNode {
-                        index,
-                        task: Default::default(),
-                    },
-                );
-            }
-        }
+        let mut loaded_tasks = FxHashMap::default();
 
         task_graph.graph = self.task_graph.filter_map(
             |ni, node| match node {
                 NodeState::Loading => None,
                 NodeState::Loaded(task) => {
-                    task_graph.nodes.get_mut(&task.target).unwrap().task = task.to_owned();
+                    loaded_tasks.insert(ni, task.to_owned());
 
                     Some(ni)
                 }
             },
             |_, edge| Some(*edge),
         );
+
+        for index in task_graph.graph.graph().node_indices() {
+            let old_index = *task_graph.graph.node_weight(index).unwrap();
+            let task = loaded_tasks.remove(&old_index).unwrap();
+            let target = task.target.clone();
+
+            task_graph.indexes.insert(index, target.clone());
+            task_graph.nodes.insert(target, TaskNode { index, task });
+        }
 
         let task_graph = Arc::new(task_graph);
 
@@ -1044,5 +1040,138 @@ impl WorkspaceBuilder {
                 .as_ref()
                 .expect("Missing workspace builder context!"),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moon_extension_plugin::ExtensionRegistry;
+    use moon_graph_utils::GraphConnections;
+    use moon_test_utils2::create_empty_moon_sandbox;
+    use moon_toolchain_plugin::ToolchainRegistry;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reindexes_project_graph_after_filtering_loading_nodes() {
+        let sandbox = create_empty_moon_sandbox();
+        let context = WorkspaceBuilderContext {
+            config_loader: ConfigLoader::default(),
+            enabled_toolchains: vec![],
+            extensions_config: Arc::new(ExtensionsConfig::default()),
+            extension_registry: Arc::new(ExtensionRegistry::default()),
+            inherited_tasks: Arc::new(InheritedTasksManager::default()),
+            toolchains_config: Arc::new(ToolchainsConfig::default()),
+            toolchain_registry: Arc::new(ToolchainRegistry::default()),
+            vcs: None,
+            working_dir: sandbox.path().to_path_buf(),
+            workspace_config: Arc::new(WorkspaceConfig::default()),
+            workspace_root: sandbox.path().to_path_buf(),
+        };
+
+        let mut project_graph = Dag::new();
+        let _ghost = project_graph.add_node(NodeState::Loading);
+        let app_index = project_graph.add_node(NodeState::Loaded(Project {
+            id: Id::raw("app"),
+            ..Project::default()
+        }));
+        let dep_index = project_graph.add_node(NodeState::Loaded(Project {
+            id: Id::raw("dep"),
+            ..Project::default()
+        }));
+
+        project_graph
+            .add_edge(app_index, dep_index, DependencyScope::Build)
+            .unwrap();
+
+        let graph = WorkspaceBuilder {
+            context: Some(Arc::new(context)),
+            config_paths: vec![],
+            aliases: FxHashMap::default(),
+            projects_by_tag: FxHashMap::default(),
+            project_data: FxHashMap::default(),
+            project_graph,
+            renamed_project_ids: FxHashMap::default(),
+            repo_type: RepoType::Monorepo,
+            root_project_id: None,
+            task_data: FxHashMap::default(),
+            task_graph: Dag::new(),
+        }
+        .build()
+        .await
+        .unwrap();
+
+        let app = graph.get_project("app").unwrap();
+
+        assert_eq!(
+            graph.projects.dependencies_of(app.as_ref()),
+            vec![Id::raw("dep")]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reindexes_task_graph_after_filtering_loading_nodes() {
+        let sandbox = create_empty_moon_sandbox();
+        let context = WorkspaceBuilderContext {
+            config_loader: ConfigLoader::default(),
+            enabled_toolchains: vec![],
+            extensions_config: Arc::new(ExtensionsConfig::default()),
+            extension_registry: Arc::new(ExtensionRegistry::default()),
+            inherited_tasks: Arc::new(InheritedTasksManager::default()),
+            toolchains_config: Arc::new(ToolchainsConfig::default()),
+            toolchain_registry: Arc::new(ToolchainRegistry::default()),
+            vcs: None,
+            working_dir: sandbox.path().to_path_buf(),
+            workspace_config: Arc::new(WorkspaceConfig::default()),
+            workspace_root: sandbox.path().to_path_buf(),
+        };
+
+        let mut project_graph = Dag::new();
+        project_graph.add_node(NodeState::Loaded(Project {
+            id: Id::raw("app"),
+            ..Project::default()
+        }));
+
+        let mut task_graph = Dag::new();
+        let _ghost = task_graph.add_node(NodeState::Loading);
+        let build_target = Target::parse("app:build").unwrap();
+        let lint_target = Target::parse("app:lint").unwrap();
+        let build_index = task_graph.add_node(NodeState::Loaded(Task {
+            id: Id::raw("build"),
+            target: build_target.clone(),
+            ..Task::default()
+        }));
+        let lint_index = task_graph.add_node(NodeState::Loaded(Task {
+            id: Id::raw("lint"),
+            target: lint_target.clone(),
+            ..Task::default()
+        }));
+
+        task_graph
+            .add_edge(build_index, lint_index, TaskDependencyType::Required)
+            .unwrap();
+
+        let graph = WorkspaceBuilder {
+            context: Some(Arc::new(context)),
+            config_paths: vec![],
+            aliases: FxHashMap::default(),
+            projects_by_tag: FxHashMap::default(),
+            project_data: FxHashMap::default(),
+            project_graph,
+            renamed_project_ids: FxHashMap::default(),
+            repo_type: RepoType::Monorepo,
+            root_project_id: None,
+            task_data: FxHashMap::default(),
+            task_graph,
+        }
+        .build()
+        .await
+        .unwrap();
+
+        let build_task = graph.get_task(&build_target).unwrap();
+
+        assert_eq!(
+            graph.tasks.dependencies_of(build_task.as_ref()),
+            vec![lint_target]
+        );
     }
 }


### PR DESCRIPTION
## Summary
After upgrading to `2.2.0` in another project that uses moon, CI started timing out during graph build. I traced the regression back to filtered workspace graph reindexing in moon and fixed it here.

This PR:
- rebuilds project/task side maps from post-filter node indices so filtered workspace graphs keep correct direct dependencies
- adds regression coverage in the workspace builder for filtering `Loading` nodes
- adds higher-level partial-load regression tests for public project/task dependency queries

## Root cause
`#2469` reduced graph memory usage by changing project/task/workspace graphs to store `NodeIndex` weights plus side maps instead of full node payloads.

During workspace graph finalization, `filter_map` drops `Loading` nodes and may reindex the DAG. The side maps were still keyed by the pre-filter indices, so `ProjectGraph` and `TaskGraph` could resolve the wrong node for a given index. That broke direct dependency queries like `dependencies_of()`, which then corrupted action graph sync requirements.

## What changed
- rebuild `ProjectGraph.indexes` and `ProjectGraph.nodes` from the filtered graph's new indices
- rebuild `TaskGraph.indexes` and `TaskGraph.nodes` the same way
- apply the same fix in both the sync workspace builder and the shared async finalize paths

## Verification
- `cargo test -p moon_workspace reindexes_ -- --nocapture`
- `cargo test -p moon_project_graph --test project_graph_test isolation -- --nocapture`