### PR TITLE
fix: avoid dispatcher stalls on sync-heavy action graphs

### DIFF
--- a/crates/action-pipeline/src/job_dispatcher.rs
+++ b/crates/action-pipeline/src/job_dispatcher.rs
@@ -38,8 +38,9 @@ impl<'graph> JobDispatcher<'graph> {
         group: u8,
         index: NodeIndex,
         completed: &FxHashSet<NodeIndex>,
+        traversed: &mut FxHashSet<NodeIndex>,
     ) -> Option<NodeIndex> {
-        if self.visited.contains(&index) || completed.contains(&index) {
+        if !traversed.insert(index) || self.visited.contains(&index) || completed.contains(&index) {
             return None;
         }
 
@@ -62,7 +63,9 @@ impl<'graph> JobDispatcher<'graph> {
                 .graph()
                 .neighbors_directed(index, Direction::Outgoing)
             {
-                if let Some(index) = self.find_applicable_index(group, dep_index, completed) {
+                if let Some(index) =
+                    self.find_applicable_index(group, dep_index, completed, traversed)
+                {
                     return Some(index);
                 }
             }
@@ -76,7 +79,10 @@ impl<'graph> JobDispatcher<'graph> {
 // This is based on the `Topo` struct from petgraph!
 impl JobDispatcher<'_> {
     pub async fn next(&mut self) -> Option<NodeIndex> {
-        let completed = self.context.completed_jobs.read().await;
+        let completed = self.context.completed_jobs.read().await.clone();
+        // Avoid repeatedly traversing the same blocked dependency subgraph
+        // while a prerequisite action is still running.
+        let mut traversed = FxHashSet::default();
 
         // Loop based on priority groups, from critical to low
         {
@@ -84,8 +90,12 @@ impl JobDispatcher<'_> {
                 // Then loop through the indices within the group,
                 // which are topologically sorted
                 for maybe_index in indices {
-                    let Some(index) = self.find_applicable_index(*group, *maybe_index, &completed)
-                    else {
+                    let Some(index) = self.find_applicable_index(
+                        *group,
+                        *maybe_index,
+                        &completed,
+                        &mut traversed,
+                    ) else {
                         continue;
                     };
 
@@ -138,5 +148,141 @@ impl JobDispatcher<'_> {
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event_emitter::EventEmitter;
+    use moon_action::{Action, ActionNode, RunTaskNode, SyncProjectNode};
+    use moon_action_graph::{ActionGraph, ActionGraphType};
+    use moon_common::Id;
+    use moon_config::TaskDependencyType;
+    use moon_task::Target;
+    use moon_workspace_graph::WorkspaceGraph;
+    use rustc_hash::FxHashMap;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+    use tokio::sync::{RwLock, Semaphore, mpsc};
+    use tokio_util::sync::CancellationToken;
+
+    async fn create_job_context() -> JobContext {
+        let (sender, _receiver) = mpsc::channel::<Action>(8);
+
+        JobContext {
+            abort_token: CancellationToken::new(),
+            cancel_token: CancellationToken::new(),
+            completed_jobs: Arc::new(RwLock::new(FxHashSet::default())),
+            emitter: Arc::new(EventEmitter::default()),
+            result_sender: sender,
+            running_jobs: Arc::new(RwLock::new(FxHashMap::default())),
+            semaphore: Arc::new(Semaphore::new(1)),
+            workspace_graph: Arc::new(WorkspaceGraph::default()),
+        }
+    }
+
+    fn create_dense_sync_graph(depth: usize, width: usize) -> ActionGraph {
+        let mut graph = ActionGraphType::new();
+        let mut nodes = FxHashMap::default();
+
+        let root = graph.add_node(NodeIndex::new(0));
+        nodes.insert(root, ActionNode::sync_workspace());
+
+        let mut layers = vec![];
+
+        for layer in 0..depth {
+            let mut indices = vec![];
+
+            for node in 0..width {
+                let index = graph.add_node(NodeIndex::new(graph.node_count()));
+                nodes.insert(
+                    index,
+                    ActionNode::sync_project(SyncProjectNode {
+                        project_id: Id::raw(format!("p{layer}-{node}")),
+                    }),
+                );
+                indices.push(index);
+            }
+
+            layers.push(indices);
+        }
+
+        for (layer_index, layer) in layers.iter().enumerate() {
+            if layer_index == depth - 1 {
+                for index in layer {
+                    graph
+                        .add_edge(*index, root, TaskDependencyType::Required)
+                        .unwrap();
+                }
+            }
+
+            if let Some(next_layer) = layers.get(layer_index + 1) {
+                for index in layer {
+                    for next_index in next_layer {
+                        graph
+                            .add_edge(*index, *next_index, TaskDependencyType::Required)
+                            .unwrap();
+                    }
+                }
+            }
+        }
+
+        let run_task = graph.add_node(NodeIndex::new(graph.node_count()));
+        nodes.insert(
+            run_task,
+            ActionNode::run_task(RunTaskNode::new(Target::parse("root:noop").unwrap())),
+        );
+
+        for index in &layers[0] {
+            graph
+                .add_edge(run_task, *index, TaskDependencyType::Required)
+                .unwrap();
+        }
+
+        ActionGraph::new(graph, nodes)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dispatches_dense_sync_graph() {
+        for depth in [8, 12, 16, 20, 24] {
+            let action_graph = create_dense_sync_graph(depth, 2);
+            let groups = action_graph.group_priorities(action_graph.sort_topological().unwrap());
+            let context = create_job_context().await;
+            let mut dispatcher = JobDispatcher::new(&action_graph, context.clone(), groups);
+            let mut dispatched = vec![];
+
+            while dispatcher.has_queued_jobs() {
+                let Some(index) = dispatcher.next().await else {
+                    break;
+                };
+
+                dispatched.push(index.index());
+                context.mark_completed(index).await;
+            }
+
+            assert_eq!(dispatched.len(), action_graph.get_node_count());
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn avoids_rewalking_blocked_sync_subgraphs() {
+        let action_graph = create_dense_sync_graph(12, 4);
+        let groups = action_graph.group_priorities(action_graph.sort_topological().unwrap());
+        let context = create_job_context().await;
+        let mut dispatcher = JobDispatcher::new(&action_graph, context, groups);
+
+        assert_eq!(dispatcher.next().await, Some(NodeIndex::new(0)));
+
+        let start = Instant::now();
+        let next = dispatcher.next().await;
+        let elapsed = start.elapsed();
+
+        assert!(next.is_none());
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "dispatcher search took {:?} on a blocked sync-heavy graph",
+            elapsed
+        );
     }
 }

--- a/crates/cli/tests/exec_test.rs
+++ b/crates/cli/tests/exec_test.rs
@@ -5,7 +5,7 @@ use moon_task_runner::TaskRunCacheState;
 use moon_test_utils2::predicates::prelude::*;
 use starbase_utils::{fs, json};
 use std::path::MAIN_SEPARATOR_STR;
-use utils::{change_files, create_pipeline_sandbox};
+use utils::{change_files, create_pipeline_sandbox, create_sync_heavy_pipeline_sandbox};
 
 const PROJECT_DIR: &str = if cfg!(windows) { "windows" } else { "unix" };
 
@@ -15,6 +15,37 @@ fn target(task: &str) -> String {
 
 mod exec {
     use super::*;
+
+    mod dispatcher_regression {
+        use super::*;
+
+        #[test]
+        fn runs_sync_heavy_noop_graph_without_stalling() {
+            let depth = 12;
+            let width = 4;
+            let expected_sync_projects = (depth * width) + 1;
+            let mut sandbox = create_sync_heavy_pipeline_sandbox(depth, width);
+            sandbox.sandbox.settings.timeout = 20;
+
+            let assert = sandbox.run_bin(|cmd| {
+                cmd.arg("action-graph").arg("--dot").arg("app:noop");
+            });
+            let dot = assert.output();
+            assert.success();
+
+            assert_eq!(dot.matches("SyncProject(").count(), expected_sync_projects);
+            assert_eq!(dot.matches("RunTask(app:noop)").count(), 1);
+            assert!(dot.contains("SyncWorkspace"));
+
+            sandbox.sandbox.settings.timeout = 5;
+            sandbox
+                .run_bin(|cmd| {
+                    cmd.arg("exec").arg("app:noop");
+                })
+                .success()
+                .stdout(predicate::str::contains("Tasks: 1 completed"));
+        }
+    }
 
     mod general {
         use super::*;

--- a/crates/cli/tests/utils.rs
+++ b/crates/cli/tests/utils.rs
@@ -2,7 +2,7 @@
 
 use moon_common::{Id, is_ci};
 use moon_config::PartialToolchainPluginConfig;
-use moon_test_utils2::{MoonSandbox, create_moon_sandbox};
+use moon_test_utils2::{MoonSandbox, create_empty_moon_sandbox, create_moon_sandbox};
 use proto_core::UnresolvedVersionSpec;
 
 pub fn create_projects_sandbox() -> MoonSandbox {
@@ -38,10 +38,67 @@ pub fn create_pipeline_sandbox() -> MoonSandbox {
     sandbox
 }
 
+pub fn create_sync_heavy_pipeline_sandbox(depth: usize, width: usize) -> MoonSandbox {
+    let sandbox = create_empty_moon_sandbox();
+    sandbox.with_default_projects();
+
+    let first_layer = (0..width)
+        .map(|node| format!("layer0-node{node}"))
+        .collect::<Vec<_>>();
+
+    sandbox.create_file(
+        "app/moon.yml",
+        format!(
+            "{}\n{}",
+            format_depends_on(&first_layer),
+            r#"tasks:
+  noop:
+    command: 'exit 0'
+    options:
+      cache: true
+"#
+        ),
+    );
+
+    for layer in 0..depth {
+        let next_layer = if layer + 1 < depth {
+            Some(
+                (0..width)
+                    .map(|node| format!("layer{}-node{node}", layer + 1))
+                    .collect::<Vec<_>>(),
+            )
+        } else {
+            None
+        };
+
+        for node in 0..width {
+            let project_id = format!("layer{layer}-node{node}");
+            let contents = next_layer
+                .as_ref()
+                .map(|deps| format_depends_on(deps))
+                .unwrap_or_else(|| "tasks: {}\n".into());
+
+            sandbox.create_file(format!("{project_id}/moon.yml"), contents);
+        }
+    }
+
+    sandbox
+}
+
 pub fn create_query_sandbox() -> MoonSandbox {
     let sandbox = create_projects_sandbox();
     sandbox.enable_git();
     sandbox
+}
+
+fn format_depends_on(deps: &[String]) -> String {
+    let mut contents = String::from("dependsOn:\n");
+
+    for dep in deps {
+        contents.push_str(&format!("  - {dep}\n"));
+    }
+
+    contents
 }
 
 pub fn change_branch<T: AsRef<str>>(sandbox: &MoonSandbox, branch: T) {


### PR DESCRIPTION
## Summary
After upgrading to `2.2.2` in another project that uses moon, CI started stalling immediately after `SyncWorkspace` on a sync-heavy target with a single trailing noop task. I traced that back to dispatcher traversal in `JobDispatcher` and fixed it here.

This PR:
- memoizes nodes traversed during a dispatch pass so blocked sync-heavy subgraphs are not re-walked repeatedly
- adds dispatcher regression coverage for dense sync-heavy graphs
- adds a higher-level CLI regression that builds a dense sync-heavy workspace and verifies `moon exec app:noop` completes

## Root cause
`JobDispatcher::next()` recursively walks dependency chains to find the next runnable action.

On sync-heavy graphs with many shared `SyncProject` dependencies, that recursive search could repeatedly revisit the same blocked subgraphs while an early prerequisite was still the only runnable action. That left the dispatcher burning CPU after `SyncWorkspace` completed, and the pipeline appeared stalled even though the action graph itself was valid.

## What changed
- add per-pass traversal memoization in `JobDispatcher::find_applicable_index()`
- add dispatcher tests that exercise dense sync-heavy graphs directly
- add a CLI regression that builds a dense sync-heavy workspace dynamically and verifies both the graph shape and successful execution of `app:noop`

## Verification
- `cargo fmt --check`
- `cargo test -p moon_action_pipeline job_dispatcher::tests -- --nocapture`
- `cargo test -p moon_action_pipeline action_pipeline::priority::runs_priority_in_order -- --nocapture`
- `cargo test -p moon_cli exec::dispatcher_regression::runs_sync_heavy_noop_graph_without_stalling -- --nocapture`
