### PR TITLE
Add OpenTelemetry instrumentation for moon runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,6 +1166,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4937,6 +4949,7 @@ dependencies = [
  "moon_toolchain_plugin",
  "moon_workspace_graph",
  "num_cpus",
+ "opentelemetry",
  "petgraph 0.8.3",
  "rustc-hash",
  "serde",
@@ -5107,7 +5120,7 @@ dependencies = [
  "starbase_archive",
  "starbase_sandbox",
  "starbase_shell",
- "starbase_styles",
+ "starbase_styles 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "starbase_utils",
  "tera",
  "thiserror 2.0.18",
@@ -5208,6 +5221,7 @@ dependencies = [
  "moon_test_utils",
  "moon_test_utils2",
  "moon_vcs",
+ "opentelemetry-proto",
  "proto_core",
  "proto_shim",
  "rustc-hash",
@@ -5216,9 +5230,11 @@ dependencies = [
  "starbase",
  "starbase_archive",
  "starbase_sandbox",
- "starbase_styles",
+ "starbase_styles 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "starbase_utils",
  "tokio",
+ "tokio-stream",
+ "tonic",
  "tracing",
  "wasi-common",
  "wasmtime",
@@ -5276,7 +5292,7 @@ dependencies = [
  "schematic",
  "serde",
  "starbase_id",
- "starbase_styles",
+ "starbase_styles 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.18",
 ]
 
@@ -5343,7 +5359,7 @@ dependencies = [
  "moon_target",
  "moon_time",
  "starbase_console",
- "starbase_styles",
+ "starbase_styles 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
@@ -5659,7 +5675,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starbase_sandbox",
- "starbase_styles",
+ "starbase_styles 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "starbase_utils",
  "thiserror 2.0.18",
  "tokio",
@@ -5987,14 +6003,19 @@ dependencies = [
  "moon_task_hasher",
  "moon_test_utils2",
  "moon_time",
+ "opentelemetry",
+ "opentelemetry-proto",
  "rustc-hash",
  "serde",
+ "starbase",
  "starbase_archive",
  "starbase_sandbox",
  "starbase_utils",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tonic",
  "tracing",
 ]
 
@@ -6645,6 +6666,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "base64 0.22.1",
+ "const-hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "serde_json",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7169,6 +7266,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7251,7 +7363,7 @@ dependencies = [
  "starbase_archive",
  "starbase_console",
  "starbase_shell",
- "starbase_styles",
+ "starbase_styles 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "starbase_utils",
  "system_env",
  "thiserror 2.0.18",
@@ -7493,6 +7605,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -8109,7 +8230,7 @@ dependencies = [
  "serde_json",
  "serde_norway",
  "serde_path_to_error",
- "starbase_styles",
+ "starbase_styles 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
@@ -8614,16 +8735,19 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "starbase"
 version = "0.10.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd26ce3c899ad844fccd5bc6ecf06f899bea6c5a6f83fe3d35b579ba540f76d"
 dependencies = [
  "async-trait",
  "chrono",
  "miette 7.6.0",
- "starbase_styles",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "starbase_styles 0.6.7",
  "tokio",
  "tracing",
  "tracing-chrome",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -8639,7 +8763,7 @@ dependencies = [
  "liblzma",
  "miette 7.6.0",
  "rustc-hash",
- "starbase_styles",
+ "starbase_styles 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "starbase_utils",
  "thiserror 2.0.18",
  "tracing",
@@ -8667,7 +8791,7 @@ dependencies = [
  "iocraft",
  "miette 7.6.0",
  "parking_lot",
- "starbase_styles",
+ "starbase_styles 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8719,11 +8843,20 @@ dependencies = [
 [[package]]
 name = "starbase_styles"
 version = "0.6.7"
+dependencies = [
+ "dirs",
+ "miette 7.6.0",
+ "owo-colors",
+ "supports-color",
+]
+
+[[package]]
+name = "starbase_styles"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67078591b8bea68aa42e19c61b4a40978e8e3787155012c2aa26331efe07f5e0"
 dependencies = [
  "dirs",
- "miette 7.6.0",
  "owo-colors",
  "relative-path",
  "supports-color",
@@ -8747,7 +8880,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_norway",
- "starbase_styles",
+ "starbase_styles 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
@@ -9483,6 +9616,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9534,6 +9683,12 @@ dependencies = [
  "tempfile",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -9809,7 +9964,7 @@ dependencies = [
  "sha2",
  "starbase_archive",
  "starbase_shell",
- "starbase_styles",
+ "starbase_styles 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "starbase_utils",
  "system_env",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ iocraft = "0.8.0"
 md5 = "0.8.0"
 miette = "7.6.0"
 num_cpus = "1.17.0"
+opentelemetry = { version = "0.31.0", features = ["metrics"] }
 pathdiff = "0.2.3"
 petgraph = { version = "0.8.3", default-features = false, features = [
     "serde-1",
@@ -57,7 +58,7 @@ semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.10.9"
-starbase = { version = "0.10.10" }
+starbase = "0.10.10"
 starbase_archive = { version = "0.13.0", default-features = false, features = [
     "miette",
     "tar-all",
@@ -122,3 +123,6 @@ assigning_clones = "allow"
 
 [workspace.metadata.cargo-shear]
 ignored = ["serde"]
+
+[patch.crates-io]
+starbase = { path = "../starbase/crates/app" }

--- a/crates/action-graph/src/action_graph_builder.rs
+++ b/crates/action-graph/src/action_graph_builder.rs
@@ -299,7 +299,13 @@ impl<'query> ActionGraphBuilder<'query> {
         Ok(())
     }
 
-    #[instrument(skip(self))]
+    #[instrument(
+        skip_all,
+        fields(
+            toolchain_id = %spec.id,
+            project_id = %project.id,
+        )
+    )]
     pub async fn install_dependencies(
         &mut self,
         spec: &ToolchainSpec,
@@ -393,7 +399,7 @@ impl<'query> ActionGraphBuilder<'query> {
         Ok(setup_toolchain_index)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(project_id = %project.id))]
     pub async fn install_dependencies_by_project(
         &mut self,
         project: &Project,
@@ -402,7 +408,13 @@ impl<'query> ActionGraphBuilder<'query> {
             .await
     }
 
-    #[instrument(skip(self))]
+    #[instrument(
+        skip_all,
+        fields(
+            project_id = %project.id,
+            toolchain_count = toolchains.len(),
+        )
+    )]
     pub async fn install_dependencies_by_toolchains(
         &mut self,
         project: &Project,
@@ -419,7 +431,7 @@ impl<'query> ActionGraphBuilder<'query> {
         Ok(indexes)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(task_target = %task.target))]
     pub async fn run_task(
         &mut self,
         task: &Task,
@@ -631,7 +643,7 @@ impl<'query> ActionGraphBuilder<'query> {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(task_target = %task.target))]
     pub async fn run_task_dependencies(
         &mut self,
         task: &Task,
@@ -676,7 +688,7 @@ impl<'query> ActionGraphBuilder<'query> {
         Ok(indexes)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(task_target = %task.target))]
     pub async fn run_task_dependents(
         &mut self,
         task: &Task,
@@ -996,13 +1008,25 @@ impl<'query> ActionGraphBuilder<'query> {
         Ok(Some(index))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(
+        skip_all,
+        fields(
+            toolchain_id = %spec.id,
+            project_id = tracing::field::Empty,
+        )
+    )]
     pub async fn setup_environment(
         &mut self,
         spec: &ToolchainSpec,
         root: &WorkspaceRelativePathBuf,
         project: Option<&Project>,
     ) -> miette::Result<Option<NodeIndex>> {
+        let span = tracing::Span::current();
+
+        if let Some(project) = project {
+            span.record("project_id", project.id.as_str());
+        }
+
         // Explicitly disabled
         if !self.options.setup_environment.is_enabled(&spec.id) || spec.is_system() {
             return Ok(None);
@@ -1042,12 +1066,24 @@ impl<'query> ActionGraphBuilder<'query> {
         Ok(Some(index))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(
+        skip_all,
+        fields(
+            toolchain_id = %spec.id,
+            project_id = tracing::field::Empty,
+        )
+    )]
     pub async fn setup_toolchain(
         &mut self,
         spec: &ToolchainSpec,
         project: Option<&Project>,
     ) -> miette::Result<Option<NodeIndex>> {
+        let span = tracing::Span::current();
+
+        if let Some(project) = project {
+            span.record("project_id", project.id.as_str());
+        }
+
         Box::pin(self.internal_setup_toolchain(spec, project, FxHashSet::default())).await
     }
 
@@ -1134,7 +1170,7 @@ impl<'query> ActionGraphBuilder<'query> {
         Ok(Some(index))
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(project_id = %project.id))]
     pub async fn sync_project(
         &mut self,
         project: &Project,

--- a/crates/action-pipeline/Cargo.toml
+++ b/crates/action-pipeline/Cargo.toml
@@ -5,11 +5,15 @@ edition = "2024"
 license = "MIT"
 publish = false
 
+[features]
+default = ["otel"]
+otel = ["dep:opentelemetry", "moon_actions/otel"]
+
 [dependencies]
 moon_action = { path = "../action" }
 moon_action_context = { path = "../action-context" }
 moon_action_graph = { path = "../action-graph" }
-moon_actions = { path = "../actions" }
+moon_actions = { path = "../actions", default-features = false }
 moon_api = { path = "../api" }
 moon_app_context = { path = "../app-context" }
 moon_cache = { path = "../cache" }
@@ -28,6 +32,7 @@ moon_workspace_graph = { path = "../workspace-graph" }
 async-trait = { workspace = true }
 miette = { workspace = true }
 num_cpus = { workspace = true }
+opentelemetry = { workspace = true, optional = true }
 petgraph = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }

--- a/crates/action-pipeline/src/action_pipeline.rs
+++ b/crates/action-pipeline/src/action_pipeline.rs
@@ -2,6 +2,8 @@ use crate::event_emitter::{Event, EventEmitter};
 use crate::job::Job;
 use crate::job_context::JobContext;
 use crate::job_dispatcher::JobDispatcher;
+#[cfg(feature = "otel")]
+use crate::metrics::action_pipeline_metrics;
 use crate::subscribers::cleanup_subscriber::CleanupSubscriber;
 use crate::subscribers::console_subscriber::ConsoleSubscriber;
 use crate::subscribers::notifications_subscriber::NotificationsSubscriber;
@@ -25,7 +27,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::{RwLock, Semaphore, mpsc};
 use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, instrument, trace, warn};
+use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 
 pub struct ActionPipeline {
     pub bail: bool,
@@ -476,7 +478,14 @@ impl ActionPipeline {
     }
 }
 
-#[instrument(skip(job_context, app_context, action_context))]
+#[instrument(
+    name = "dispatch_action",
+    skip_all,
+    fields(
+        action_label = %node.label(),
+        task_target = tracing::field::Empty,
+    )
+)]
 async fn dispatch_job(
     node: ActionNode,
     node_index: usize,
@@ -484,6 +493,12 @@ async fn dispatch_job(
     app_context: Arc<AppContext>,
     action_context: Arc<ActionContext>,
 ) {
+    let span = tracing::Span::current();
+
+    if let ActionNode::RunTask(run_task) = &node {
+        span.record("task_target", run_task.target.as_str());
+    }
+
     let job = Job {
         node,
         node_index,
@@ -502,12 +517,38 @@ async fn dispatch_job_with_permit(
     app_context: Arc<AppContext>,
     action_context: Arc<ActionContext>,
 ) {
-    let permit = job_context
-        .semaphore
-        .clone()
-        .acquire_owned()
-        .await
-        .expect("Failed to dispatch job!");
+    let permit = if let ActionNode::RunTask(run_task) = &node {
+        let span = info_span!(
+            "task_concurrency_wait",
+            task_target = %run_task.target,
+            concurrency_wait_ms = tracing::field::Empty,
+        );
+
+        let wait_started = Instant::now();
+        let permit = job_context
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .instrument(span.clone())
+            .await
+            .expect("Failed to dispatch job!");
+
+        span.record(
+            "concurrency_wait_ms",
+            wait_started.elapsed().as_millis() as u64,
+        );
+        #[cfg(feature = "otel")]
+        action_pipeline_metrics()
+            .record_task_concurrency_wait(run_task.target.as_str(), wait_started.elapsed());
+        permit
+    } else {
+        job_context
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("Failed to dispatch job!")
+    };
 
     dispatch_job(node, node_index, job_context, app_context, action_context).await;
 

--- a/crates/action-pipeline/src/lib.rs
+++ b/crates/action-pipeline/src/lib.rs
@@ -4,6 +4,8 @@ mod event_emitter;
 mod job;
 mod job_context;
 mod job_dispatcher;
+#[cfg(feature = "otel")]
+mod metrics;
 pub mod reports;
 mod subscribers;
 

--- a/crates/action-pipeline/src/metrics.rs
+++ b/crates/action-pipeline/src/metrics.rs
@@ -1,0 +1,37 @@
+use opentelemetry::KeyValue;
+use opentelemetry::global;
+use opentelemetry::metrics::Histogram;
+use std::time::Duration;
+
+pub(crate) struct ActionPipelineMetrics {
+    task_concurrency_wait_duration: Histogram<u64>,
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    duration.as_millis().min(u64::MAX as u128) as u64
+}
+
+impl ActionPipelineMetrics {
+    fn new() -> Self {
+        let meter = global::meter("moon_action_pipeline");
+
+        Self {
+            task_concurrency_wait_duration: meter
+                .u64_histogram("moon.task.concurrency_wait.duration")
+                .with_description("Moon task concurrency wait duration.")
+                .with_unit("ms")
+                .build(),
+        }
+    }
+
+    pub fn record_task_concurrency_wait(&self, task_target: &str, duration: Duration) {
+        let attrs = [KeyValue::new("task_target", task_target.to_owned())];
+
+        self.task_concurrency_wait_duration
+            .record(duration_ms(duration), &attrs);
+    }
+}
+
+pub(crate) fn action_pipeline_metrics() -> ActionPipelineMetrics {
+    ActionPipelineMetrics::new()
+}

--- a/crates/actions/Cargo.toml
+++ b/crates/actions/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.1"
 edition = "2024"
 publish = false
 
+[features]
+default = ["otel"]
+otel = ["moon_task_runner/otel"]
+
 [dependencies]
 moon_action = { path = "../action" }
 moon_action_context = { path = "../action-context" }
@@ -24,7 +28,7 @@ moon_process = { path = "../process" }
 moon_process_augment = { path = "../process-augment" }
 moon_project = { path = "../project" }
 moon_remote = { path = "../remote" }
-moon_task_runner = { path = "../task-runner" }
+moon_task_runner = { path = "../task-runner", default-features = false }
 moon_time = { path = "../time" }
 moon_toolchain = { path = "../toolchain" }
 moon_toolchain_plugin = { path = "../toolchain-plugin" }

--- a/crates/actions/src/actions/install_dependencies.rs
+++ b/crates/actions/src/actions/install_dependencies.rs
@@ -35,7 +35,13 @@ hash_fingerprint!(
     }
 );
 
-#[instrument(skip(action, action_context, app_context, workspace_graph))]
+#[instrument(
+    skip_all,
+    fields(
+        toolchain_id = %node.toolchain_id,
+        project_id = tracing::field::Empty,
+    )
+)]
 pub async fn install_dependencies(
     action: &mut Action,
     action_context: Arc<ActionContext>,
@@ -43,6 +49,12 @@ pub async fn install_dependencies(
     workspace_graph: Arc<WorkspaceGraph>,
     node: &InstallDependenciesNode,
 ) -> miette::Result<ActionStatus> {
+    let span = tracing::Span::current();
+
+    if let Some(project_id) = &node.project_id {
+        span.record("project_id", project_id.as_str());
+    }
+
     let deps_root = node.root.to_logical_path(&app_context.workspace_root);
 
     // Skip this action if requested by the user

--- a/crates/actions/src/actions/run_task.rs
+++ b/crates/actions/src/actions/run_task.rs
@@ -7,7 +7,14 @@ use moon_workspace_graph::WorkspaceGraph;
 use std::sync::Arc;
 use tracing::{instrument, warn};
 
-#[instrument(skip(action, action_context, app_context, workspace_graph))]
+#[instrument(
+    skip_all,
+    fields(
+        task_target = %node.target,
+        interactive = node.interactive,
+        persistent = node.persistent,
+    )
+)]
 pub async fn run_task(
     action: &mut Action,
     action_context: Arc<ActionContext>,

--- a/crates/actions/src/actions/setup_environment.rs
+++ b/crates/actions/src/actions/setup_environment.rs
@@ -24,7 +24,13 @@ hash_fingerprint!(
     }
 );
 
-#[instrument(skip(action, _action_context, app_context, workspace_graph))]
+#[instrument(
+    skip_all,
+    fields(
+        toolchain_id = %node.toolchain_id,
+        project_id = tracing::field::Empty,
+    )
+)]
 pub async fn setup_environment(
     action: &mut Action,
     _action_context: Arc<ActionContext>,
@@ -32,6 +38,12 @@ pub async fn setup_environment(
     workspace_graph: Arc<WorkspaceGraph>,
     node: &SetupEnvironmentNode,
 ) -> miette::Result<ActionStatus> {
+    let span = tracing::Span::current();
+
+    if let Some(project_id) = &node.project_id {
+        span.record("project_id", project_id.as_str());
+    }
+
     // Skip this action if requested by the user
     if let Some(value) =
         should_skip_action_matching("MOON_SKIP_SETUP_ENVIRONMENT", &node.toolchain_id)

--- a/crates/actions/src/actions/setup_toolchain.rs
+++ b/crates/actions/src/actions/setup_toolchain.rs
@@ -19,13 +19,25 @@ hash_fingerprint!(
     }
 );
 
-#[instrument(skip(action, _action_context, app_context))]
+#[instrument(
+    skip_all,
+    fields(
+        toolchain_id = %node.toolchain.id,
+        version = tracing::field::Empty,
+    )
+)]
 pub async fn setup_toolchain(
     action: &mut Action,
     _action_context: Arc<ActionContext>,
     app_context: Arc<AppContext>,
     node: &SetupToolchainNode,
 ) -> miette::Result<ActionStatus> {
+    let span = tracing::Span::current();
+
+    if let Some(version) = &node.toolchain.req {
+        span.record("version", version.to_string());
+    }
+
     // No version configured, use globals on PATH
     if node.toolchain.is_global()
         || is_using_global_toolchain(GlobalEnvBag::instance(), &node.toolchain.id)

--- a/crates/actions/src/actions/sync_project.rs
+++ b/crates/actions/src/actions/sync_project.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashMap;
 use std::sync::Arc;
 use tracing::{debug, instrument, warn};
 
-#[instrument(skip(action, _action_context, app_context, workspace_graph))]
+#[instrument(skip_all, fields(project_id = %node.project_id))]
 pub async fn sync_project(
     action: &mut Action,
     _action_context: Arc<ActionContext>,

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -4,12 +4,22 @@ version = "0.0.1"
 edition = "2024"
 publish = false
 
+[features]
+default = ["otel"]
+otel = [
+    "moon_action_pipeline/otel",
+    "moon_actions/otel",
+    "moon_daemon/otel",
+    "moon_mcp/otel",
+    "moon_task_runner/otel",
+]
+
 [dependencies]
 moon_action = { path = "../action" }
 moon_action_context = { path = "../action-context" }
 moon_action_graph = { path = "../action-graph" }
-moon_action_pipeline = { path = "../action-pipeline" }
-moon_actions = { path = "../actions" }
+moon_action_pipeline = { path = "../action-pipeline", default-features = false }
+moon_actions = { path = "../actions", default-features = false }
 moon_affected = { path = "../affected" }
 moon_api = { path = "../api" }
 moon_app_context = { path = "../app-context" }
@@ -20,7 +30,7 @@ moon_common = { path = "../common" }
 moon_config = { path = "../config" }
 moon_config_loader = { path = "../config-loader" }
 moon_console = { path = "../console" }
-moon_daemon = { path = "../daemon" }
+moon_daemon = { path = "../daemon", default-features = false }
 moon_docker = { path = "../docker" }
 moon_env = { path = "../env" }
 moon_env_var = { path = "../env-var" }
@@ -28,7 +38,7 @@ moon_exec_plan = { path = "../exec-plan" }
 moon_extension_plugin = { path = "../extension-plugin" }
 moon_feature_flags = { path = "../feature-flags" }
 moon_file_watcher = { path = "../file-watcher" }
-moon_mcp = { path = "../mcp" }
+moon_mcp = { path = "../mcp", default-features = false }
 moon_pdk_api = { path = "../pdk-api" }
 moon_plugin = { path = "../plugin" }
 moon_process = { path = "../process" }
@@ -39,7 +49,7 @@ moon_query = { path = "../query" }
 moon_remote = { path = "../remote" }
 moon_task = { path = "../task" }
 moon_task_graph = { path = "../task-graph" }
-moon_task_runner = { path = "../task-runner" }
+moon_task_runner = { path = "../task-runner", default-features = false }
 moon_time = { path = "../time" }
 moon_toolchain = { path = "../toolchain" }
 moon_toolchain_plugin = { path = "../toolchain-plugin" }

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -334,6 +334,33 @@ pub struct Cli {
 
     #[arg(
         long,
+        global = true,
+        env = "MOON_OTEL",
+        help = "Export traces and metrics over OTLP using OTEL_EXPORTER_OTLP_* settings",
+        help_heading = "Global options"
+    )]
+    pub otel: bool,
+
+    #[arg(
+        long,
+        global = true,
+        env = "MOON_OTEL_LOGS",
+        help = "Export tracing events as OTLP logs using OTEL_EXPORTER_OTLP_* settings",
+        help_heading = "Global options"
+    )]
+    pub otel_logs: bool,
+
+    #[arg(
+        long,
+        global = true,
+        env = "MOON_OTEL_SERVICE_NAME",
+        help = "Service name to report when OTLP tracing is enabled",
+        help_heading = "Global options"
+    )]
+    pub otel_service_name: Option<String>,
+
+    #[arg(
+        long,
         short = 'q',
         global = true,
         env = "MOON_QUIET",

--- a/crates/app/src/commands/exec.rs
+++ b/crates/app/src/commands/exec.rs
@@ -86,8 +86,17 @@ pub struct ExecArgs {
     pub query: Option<String>,
 }
 
-#[instrument(skip(session))]
+#[instrument(
+    skip_all,
+    fields(
+        target_count = args.targets.len(),
+        has_query = args.query.is_some(),
+        on_failure = %args.on_failure,
+        ci = tracing::field::Empty,
+    )
+)]
 pub async fn exec(session: MoonSession, args: ExecArgs) -> AppResult {
+    tracing::Span::current().record("ci", args.ci.unwrap_or(false));
     let mut plan = ExecutionPlan::default();
 
     // Load the execution plan if provided

--- a/crates/app/src/commands/run.rs
+++ b/crates/app/src/commands/run.rs
@@ -22,7 +22,13 @@ pub struct RunArgs {
     query: Option<String>,
 }
 
-#[instrument(skip(session))]
+#[instrument(
+    skip_all,
+    fields(
+        target_count = args.targets.len(),
+        has_query = args.query.is_some(),
+    )
+)]
 pub async fn run(session: MoonSession, args: RunArgs) -> AppResult {
     exec(session, {
         let mut exec = args.to_exec_args();

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -7,6 +7,10 @@ repository = "https://github.com/moonrepo/moon"
 publish = false
 default-run = "moon"
 
+[features]
+default = ["otel"]
+otel = ["moon_app/otel", "starbase/otel"]
+
 [package.metadata.dist]
 dist = true
 
@@ -26,7 +30,7 @@ name = "moonx"
 path = "src/main_exec.rs"
 
 [dependencies]
-moon_app = { path = "../app" }
+moon_app = { path = "../app", default-features = false }
 moon_common = { path = "../common" }
 moon_env_var = { path = "../env-var" }
 clap = { workspace = true }
@@ -62,11 +66,14 @@ moon_test_utils = { path = "../../legacy/core/test-utils" }
 moon_test_utils2 = { path = "../test-utils" }
 moon_vcs = { path = "../vcs" }
 httpmock = "0.8.3"
+opentelemetry-proto = "0.31.0"
 proto_core = { workspace = true }
 rustc-hash = { workspace = true }
 serial_test = { workspace = true }
 starbase_archive = { workspace = true }
 starbase_sandbox = { workspace = true }
+tokio-stream = { version = "0.1.18", features = ["net"] }
+tonic = "0.14.5"
 
 [lints]
 workspace = true

--- a/crates/cli/src/shared.rs
+++ b/crates/cli/src/shared.rs
@@ -12,6 +12,8 @@ use moon_app::commands::toolchain::ToolchainCommands;
 use moon_app::{Cli, Commands, MoonSession, commands};
 use moon_env_var::GlobalEnvBag;
 use starbase::diagnostics::IntoDiagnostic;
+#[cfg(feature = "otel")]
+use starbase::tracing::OtelOptions;
 use starbase::tracing::TracingOptions;
 use starbase::{App, MainResult};
 use starbase_styles::color;
@@ -35,7 +37,15 @@ fn get_version() -> String {
 fn get_tracing_modules() -> Vec<String> {
     let bag = GlobalEnvBag::instance();
     let mut modules = string_vec![
-        "moon", "proto", // "schematic",
+        "moon",
+        "moon_action_pipeline",
+        "moon_actions",
+        "moon_app",
+        "moon_cli",
+        "moon_daemon",
+        "moon_process",
+        "moon_task_runner",
+        "proto", // "schematic",
         "starbase",
         "warpgate",
         // Remote testing
@@ -95,14 +105,37 @@ pub async fn run_cli(args: Vec<OsString>) -> MainResult {
     let app = App::default();
     app.setup_diagnostics();
 
-    let _guard = app.setup_tracing(TracingOptions {
-        dump_trace: cli.dump,
-        filter_modules: get_tracing_modules(),
-        log_env: "STARBASE_LOG".into(), // Don't conflict with proto
-        log_file: cli.log_file.clone(),
-        show_spans: cli.log.is_verbose(),
-        ..TracingOptions::default()
-    });
+    // Handoff to a locally installed binary before tracing is initialized, so
+    // Unix exec does not bypass OpenTelemetry guard shutdown.
+    if let (Some(home_dir), Ok(current_dir)) = (dirs::home_dir(), env::current_dir())
+        && is_globally_installed(&home_dir)
+        && let Some(local_bin) = has_locally_installed(&home_dir, &current_dir)
+    {
+        let mut command = Command::new(local_bin);
+        command.args(&args[1..]);
+        command.current_dir(current_dir);
+
+        let exit_code = exec_local_bin(command).into_diagnostic()?;
+
+        return Ok(ExitCode::from(exit_code));
+    }
+
+    let _guard = app
+        .setup_tracing(TracingOptions {
+            dump_trace: cli.dump,
+            filter_modules: get_tracing_modules(),
+            log_env: "STARBASE_LOG".into(), // Don't conflict with proto
+            log_file: cli.log_file.clone(),
+            #[cfg(feature = "otel")]
+            otel: OtelOptions {
+                enabled: cli.otel,
+                logs_enabled: cli.otel_logs,
+                service_name: cli.otel_service_name.clone(),
+            },
+            show_spans: cli.log.is_verbose(),
+            ..TracingOptions::default()
+        })
+        .into_diagnostic()?;
 
     let pid = std::process::id();
 
@@ -116,23 +149,6 @@ pub async fn run_cli(args: Vec<OsString>) -> MainResult {
         );
     } else {
         debug!(args = ?args, pid, "Running moon v{}", version);
-    }
-
-    // Detect if we've been installed globally
-    if let (Some(home_dir), Ok(current_dir)) = (dirs::home_dir(), env::current_dir())
-        && is_globally_installed(&home_dir)
-        && let Some(local_bin) = has_locally_installed(&home_dir, &current_dir)
-    {
-        debug!(local = ?local_bin, "Binary is running from a global path, but we found a local binary to use instead");
-        debug!("Will now execute the local binary and replace this running process");
-
-        let mut command = Command::new(local_bin);
-        command.args(&args[1..]);
-        command.current_dir(current_dir);
-
-        let exit_code = exec_local_bin(command).into_diagnostic()?;
-
-        return Ok(ExitCode::from(exit_code));
     }
 
     // Otherwise just run the CLI

--- a/crates/cli/tests/otel_test.rs
+++ b/crates/cli/tests/otel_test.rs
@@ -1,0 +1,699 @@
+use moon_test_utils2::{create_empty_moon_sandbox, predicates::prelude::*};
+use opentelemetry_proto::tonic::collector::logs::v1::{
+    ExportLogsServiceRequest, ExportLogsServiceResponse,
+    logs_service_server::{LogsService, LogsServiceServer},
+};
+use opentelemetry_proto::tonic::collector::metrics::v1::{
+    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
+    metrics_service_server::{MetricsService, MetricsServiceServer},
+};
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    ExportTraceServiceRequest, ExportTraceServiceResponse,
+    trace_service_server::{TraceService, TraceServiceServer},
+};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{Mutex, oneshot};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status, transport::Server};
+
+fn string_attr<'a>(
+    span: &'a opentelemetry_proto::tonic::trace::v1::Span,
+    key: &str,
+) -> Option<&'a str> {
+    span.attributes
+        .iter()
+        .find(|attribute| attribute.key == key)
+        .and_then(|attribute| attribute.value.as_ref())
+        .and_then(|value| value.value.as_ref())
+        .and_then(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+}
+
+fn any_value_string(value: &opentelemetry_proto::tonic::common::v1::AnyValue) -> Option<&str> {
+    value.value.as_ref().and_then(|value| match value {
+        opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+            Some(value.as_str())
+        }
+        _ => None,
+    })
+}
+
+fn any_value_bool(value: &opentelemetry_proto::tonic::common::v1::AnyValue) -> Option<bool> {
+    value.value.as_ref().and_then(|value| match value {
+        opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(value) => Some(*value),
+        _ => None,
+    })
+}
+
+fn key_value_matches(
+    attributes: &[opentelemetry_proto::tonic::common::v1::KeyValue],
+    key: &str,
+    expected: &str,
+) -> bool {
+    attributes.iter().any(|attribute| {
+        attribute.key == key
+            && attribute
+                .value
+                .as_ref()
+                .and_then(any_value_string)
+                .is_some_and(|value| value == expected)
+    })
+}
+
+fn key_value_bool_matches(
+    attributes: &[opentelemetry_proto::tonic::common::v1::KeyValue],
+    key: &str,
+    expected: bool,
+) -> bool {
+    attributes.iter().any(|attribute| {
+        attribute.key == key
+            && attribute
+                .value
+                .as_ref()
+                .and_then(any_value_bool)
+                .is_some_and(|value| value == expected)
+    })
+}
+
+fn metric_has_string_attr(
+    metric: &opentelemetry_proto::tonic::metrics::v1::Metric,
+    key: &str,
+    expected: &str,
+) -> bool {
+    match metric.data.as_ref() {
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(sum)) => sum
+            .data_points
+            .iter()
+            .any(|point| key_value_matches(&point.attributes, key, expected)),
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Histogram(histogram)) => {
+            histogram
+                .data_points
+                .iter()
+                .any(|point| key_value_matches(&point.attributes, key, expected))
+        }
+        _ => false,
+    }
+}
+
+fn metric_has_string_and_bool_attrs(
+    metric: &opentelemetry_proto::tonic::metrics::v1::Metric,
+    string_key: &str,
+    string_expected: &str,
+    bool_key: &str,
+    bool_expected: bool,
+) -> bool {
+    let point_matches = |attributes: &[opentelemetry_proto::tonic::common::v1::KeyValue]| {
+        key_value_matches(attributes, string_key, string_expected)
+            && key_value_bool_matches(attributes, bool_key, bool_expected)
+    };
+
+    match metric.data.as_ref() {
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(sum)) => sum
+            .data_points
+            .iter()
+            .any(|point| point_matches(&point.attributes)),
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Histogram(histogram)) => {
+            histogram
+                .data_points
+                .iter()
+                .any(|point| point_matches(&point.attributes))
+        }
+        _ => false,
+    }
+}
+
+#[derive(Clone, Default)]
+struct Collector {
+    log_requests: Arc<Mutex<Vec<ExportLogsServiceRequest>>>,
+    metric_requests: Arc<Mutex<Vec<ExportMetricsServiceRequest>>>,
+    trace_requests: Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
+}
+
+#[tonic::async_trait]
+impl LogsService for Collector {
+    async fn export(
+        &self,
+        request: Request<ExportLogsServiceRequest>,
+    ) -> Result<Response<ExportLogsServiceResponse>, Status> {
+        self.log_requests.lock().await.push(request.into_inner());
+
+        Ok(Response::new(ExportLogsServiceResponse {
+            partial_success: None,
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl MetricsService for Collector {
+    async fn export(
+        &self,
+        request: Request<ExportMetricsServiceRequest>,
+    ) -> Result<Response<ExportMetricsServiceResponse>, Status> {
+        self.metric_requests.lock().await.push(request.into_inner());
+
+        Ok(Response::new(ExportMetricsServiceResponse {
+            partial_success: None,
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl TraceService for Collector {
+    async fn export(
+        &self,
+        request: Request<ExportTraceServiceRequest>,
+    ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        self.trace_requests.lock().await.push(request.into_inner());
+
+        Ok(Response::new(ExportTraceServiceResponse {
+            partial_success: None,
+        }))
+    }
+}
+
+async fn wait_for_cli_exports(
+    trace_requests: &Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
+    metric_requests: &Arc<Mutex<Vec<ExportMetricsServiceRequest>>>,
+    log_requests: &Arc<Mutex<Vec<ExportLogsServiceRequest>>>,
+    command_output: &impl std::fmt::Display,
+) {
+    let wait_result = tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            if !trace_requests.lock().await.is_empty()
+                && !metric_requests.lock().await.is_empty()
+                && !log_requests.lock().await.is_empty()
+            {
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+
+    if wait_result.is_err() {
+        let trace_count = trace_requests.lock().await.len();
+        let metric_count = metric_requests.lock().await.len();
+        let log_count = log_requests.lock().await.len();
+
+        panic!(
+            "timed out waiting for OTLP export from moon (traces={trace_count}, metrics={metric_count}, logs={log_count})\n{command_output}"
+        );
+    }
+}
+
+#[test]
+fn shows_otel_flags_in_help() {
+    let sandbox = create_empty_moon_sandbox();
+
+    let assert = sandbox.run_bin(|cmd| {
+        cmd.arg("--help");
+    });
+
+    assert.success().stdout(
+        predicate::str::contains("--otel")
+            .and(predicate::str::contains("--otel-logs"))
+            .and(predicate::str::contains("--otel-service-name")),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exports_task_spans_over_otlp() {
+    let sandbox = create_empty_moon_sandbox();
+    sandbox.with_default_projects();
+    sandbox.enable_git();
+    sandbox.create_file(
+        "app/moon.yml",
+        r#"tasks:
+  otel:
+    command: bash
+    args:
+      - -c
+      - echo "otel tracing"
+"#,
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let log_requests = Arc::new(Mutex::new(Vec::new()));
+    let metric_requests = Arc::new(Mutex::new(Vec::new()));
+    let trace_requests = Arc::new(Mutex::new(Vec::new()));
+    let collector = Collector {
+        log_requests: Arc::clone(&log_requests),
+        metric_requests: Arc::clone(&metric_requests),
+        trace_requests: Arc::clone(&trace_requests),
+    };
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(
+                LogsServiceServer::new(collector.clone())
+                    .max_decoding_message_size(32 * 1024 * 1024),
+            )
+            .add_service(
+                MetricsServiceServer::new(collector.clone())
+                    .max_decoding_message_size(32 * 1024 * 1024),
+            )
+            .add_service(
+                TraceServiceServer::new(collector).max_decoding_message_size(32 * 1024 * 1024),
+            )
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+
+    let assert = sandbox.run_bin(|cmd| {
+        cmd.arg("--otel")
+            .arg("--otel-logs")
+            .arg("--otel-service-name")
+            .arg("moon-cli-flag-test")
+            .arg("run")
+            .arg("app:otel");
+        cmd.env("MOON_LOG", "debug");
+        cmd.env("OTEL_EXPORTER_OTLP_ENDPOINT", format!("http://{addr}"));
+        cmd.env(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            format!("http://{addr}"),
+        );
+        cmd.env("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc");
+        cmd.env("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc");
+        cmd.env(
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+            format!("http://{addr}"),
+        );
+        cmd.env("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "grpc");
+        cmd.env("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", format!("http://{addr}"));
+        cmd.env("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "grpc");
+    });
+    let command_output = assert.output();
+
+    assert.success();
+
+    wait_for_cli_exports(
+        &trace_requests,
+        &metric_requests,
+        &log_requests,
+        &command_output,
+    )
+    .await;
+
+    let log_requests = log_requests.lock().await.clone();
+    let trace_requests = trace_requests.lock().await.clone();
+    let metric_requests = metric_requests.lock().await.clone();
+    let spans = trace_requests
+        .iter()
+        .flat_map(|request| request.resource_spans.iter())
+        .flat_map(|resource| resource.scope_spans.iter())
+        .flat_map(|scope| scope.spans.iter())
+        .collect::<Vec<_>>();
+    let trace_service_names = trace_requests
+        .iter()
+        .flat_map(|request| request.resource_spans.iter())
+        .flat_map(|resource| resource.resource.as_ref())
+        .flat_map(|resource| resource.attributes.iter())
+        .filter(|attribute| attribute.key == "service.name")
+        .filter_map(|attribute| attribute.value.as_ref())
+        .filter_map(|value| value.value.as_ref())
+        .filter_map(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let metrics = metric_requests
+        .iter()
+        .flat_map(|request| request.resource_metrics.iter())
+        .flat_map(|resource| resource.scope_metrics.iter())
+        .flat_map(|scope| scope.metrics.iter())
+        .collect::<Vec<_>>();
+    let metric_service_names = metric_requests
+        .iter()
+        .flat_map(|request| request.resource_metrics.iter())
+        .flat_map(|resource| resource.resource.as_ref())
+        .flat_map(|resource| resource.attributes.iter())
+        .filter(|attribute| attribute.key == "service.name")
+        .filter_map(|attribute| attribute.value.as_ref())
+        .filter_map(|value| value.value.as_ref())
+        .filter_map(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let log_bodies = log_requests
+        .iter()
+        .flat_map(|request| request.resource_logs.iter())
+        .flat_map(|resource| resource.scope_logs.iter())
+        .flat_map(|scope| scope.log_records.iter())
+        .filter_map(|record| record.body.as_ref())
+        .filter_map(|body| body.value.as_ref())
+        .filter_map(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let log_service_names = log_requests
+        .iter()
+        .flat_map(|request| request.resource_logs.iter())
+        .flat_map(|resource| resource.resource.as_ref())
+        .flat_map(|resource| resource.attributes.iter())
+        .filter(|attribute| attribute.key == "service.name")
+        .filter_map(|attribute| attribute.value.as_ref())
+        .filter_map(|value| value.value.as_ref())
+        .filter_map(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    let has_span = |name: &str| spans.iter().any(|span| span.name == name);
+    let has_metric = |name: &str| metrics.iter().any(|metric| metric.name == name);
+    let span_count = |name: &str| spans.iter().filter(|span| span.name == name).count();
+    let observed_span_names = spans
+        .iter()
+        .map(|span| span.name.as_str())
+        .collect::<Vec<_>>();
+    let observed_metric_names = metrics
+        .iter()
+        .map(|metric| metric.name.as_str())
+        .collect::<Vec<_>>();
+    let task_run = spans.iter().find(|span| span.name == "task_run").unwrap();
+    let disallowed_attrs = [
+        "args",
+        "command_line",
+        "hash",
+        "node",
+        "project",
+        "root",
+        "task_command",
+    ];
+    let reviewed_span_names = [
+        "install_dependencies",
+        "process_spawn",
+        "setup_environment",
+        "task_cache_lookup",
+        "task_execution",
+        "task_hash_generation",
+        "task_output_hydration",
+        "task_run",
+    ];
+
+    assert!(
+        has_span("task_run"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("task_concurrency_wait"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("task_hash_generation"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("task_cache_lookup"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("task_output_hydration"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("task_execution"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("task_execution_attempts"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("process_spawn"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.run.total"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.run.duration"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.concurrency_wait.duration"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.cache.lookup.total"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.execution.duration"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.execution.attempts"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        log_bodies
+            .iter()
+            .any(|body| body.contains("Running moon") || body.contains("Run target")),
+        "expected OTLP logs exported from moon CLI tracing events"
+    );
+    assert!(!has_span("task_queue_wait"));
+    assert_eq!(span_count("task_concurrency_wait"), 1);
+    assert_eq!(string_attr(task_run, "task_target"), Some("app:otel"));
+    assert_eq!(string_attr(task_run, "cache_source"), Some("miss"));
+    assert!(
+        trace_service_names.contains(&"moon-cli-flag-test"),
+        "expected CLI --otel-service-name to set trace service.name; observed: {trace_service_names:?}"
+    );
+    assert!(
+        metric_service_names.contains(&"moon-cli-flag-test"),
+        "expected CLI --otel-service-name to set metric service.name; observed: {metric_service_names:?}"
+    );
+    assert!(
+        log_service_names.contains(&"moon-cli-flag-test"),
+        "expected CLI --otel-service-name to set log service.name; observed: {log_service_names:?}"
+    );
+    assert!(
+        metrics.iter().any(|metric| {
+            metric.name == "moon.task.run.total"
+                && metric_has_string_attr(metric, "task_target", "app:otel")
+        }),
+        "expected moon.task.run.total to include task_target=app:otel; observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        metrics.iter().any(|metric| {
+            metric.name == "moon.task.cache.lookup.total"
+                && metric_has_string_and_bool_attrs(
+                    metric,
+                    "cache_source",
+                    "miss",
+                    "cache_hit",
+                    false,
+                )
+        }),
+        "expected moon.task.cache.lookup.total to include cache_source=miss and cache_hit=false; observed metrics: {observed_metric_names:?}"
+    );
+    let offending_attrs = spans
+        .iter()
+        .filter(|span| reviewed_span_names.contains(&span.name.as_str()))
+        .flat_map(|span| {
+            span.attributes.iter().filter_map(|attribute| {
+                disallowed_attrs
+                    .contains(&attribute.key.as_str())
+                    .then(|| format!("{}:{}", span.name, attribute.key))
+            })
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        offending_attrs.is_empty(),
+        "exported spans unexpectedly included high-cardinality attrs: {offending_attrs:?}"
+    );
+
+    let _ = shutdown_tx.send(());
+    server.await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exports_task_spans_with_otel_env_vars() {
+    let sandbox = create_empty_moon_sandbox();
+    sandbox.with_default_projects();
+    sandbox.enable_git();
+    sandbox.create_file(
+        "app/moon.yml",
+        r#"tasks:
+  otel:
+    command: bash
+    args:
+      - -c
+      - echo "otel env tracing"
+"#,
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let log_requests = Arc::new(Mutex::new(Vec::new()));
+    let metric_requests = Arc::new(Mutex::new(Vec::new()));
+    let trace_requests = Arc::new(Mutex::new(Vec::new()));
+    let collector = Collector {
+        log_requests: Arc::clone(&log_requests),
+        metric_requests: Arc::clone(&metric_requests),
+        trace_requests: Arc::clone(&trace_requests),
+    };
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(
+                LogsServiceServer::new(collector.clone())
+                    .max_decoding_message_size(32 * 1024 * 1024),
+            )
+            .add_service(
+                MetricsServiceServer::new(collector.clone())
+                    .max_decoding_message_size(32 * 1024 * 1024),
+            )
+            .add_service(
+                TraceServiceServer::new(collector).max_decoding_message_size(32 * 1024 * 1024),
+            )
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+
+    let assert = sandbox.run_bin(|cmd| {
+        cmd.arg("run").arg("app:otel");
+        cmd.env("MOON_LOG", "debug");
+        cmd.env("MOON_OTEL", "true");
+        cmd.env("MOON_OTEL_LOGS", "true");
+        cmd.env("MOON_OTEL_SERVICE_NAME", "moon-cli-env-test");
+        cmd.env("OTEL_EXPORTER_OTLP_ENDPOINT", format!("http://{addr}"));
+        cmd.env(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            format!("http://{addr}"),
+        );
+        cmd.env("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc");
+        cmd.env("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc");
+        cmd.env(
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+            format!("http://{addr}"),
+        );
+        cmd.env("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "grpc");
+        cmd.env("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", format!("http://{addr}"));
+        cmd.env("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "grpc");
+    });
+    let command_output = assert.output();
+
+    assert.success();
+
+    wait_for_cli_exports(
+        &trace_requests,
+        &metric_requests,
+        &log_requests,
+        &command_output,
+    )
+    .await;
+
+    let log_requests = log_requests.lock().await.clone();
+    let trace_requests = trace_requests.lock().await.clone();
+    let metric_requests = metric_requests.lock().await.clone();
+    let trace_service_names = trace_requests
+        .iter()
+        .flat_map(|request| request.resource_spans.iter())
+        .flat_map(|resource| resource.resource.as_ref())
+        .flat_map(|resource| resource.attributes.iter())
+        .filter(|attribute| attribute.key == "service.name")
+        .filter_map(|attribute| attribute.value.as_ref())
+        .filter_map(|value| value.value.as_ref())
+        .filter_map(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let metric_service_names = metric_requests
+        .iter()
+        .flat_map(|request| request.resource_metrics.iter())
+        .flat_map(|resource| resource.resource.as_ref())
+        .flat_map(|resource| resource.attributes.iter())
+        .filter(|attribute| attribute.key == "service.name")
+        .filter_map(|attribute| attribute.value.as_ref())
+        .filter_map(|value| value.value.as_ref())
+        .filter_map(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let log_service_names = log_requests
+        .iter()
+        .flat_map(|request| request.resource_logs.iter())
+        .flat_map(|resource| resource.resource.as_ref())
+        .flat_map(|resource| resource.attributes.iter())
+        .filter(|attribute| attribute.key == "service.name")
+        .filter_map(|attribute| attribute.value.as_ref())
+        .filter_map(|value| value.value.as_ref())
+        .filter_map(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let log_bodies = log_requests
+        .iter()
+        .flat_map(|request| request.resource_logs.iter())
+        .flat_map(|resource| resource.scope_logs.iter())
+        .flat_map(|scope| scope.log_records.iter())
+        .filter_map(|record| record.body.as_ref())
+        .filter_map(|body| body.value.as_ref())
+        .filter_map(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        trace_service_names.contains(&"moon-cli-env-test"),
+        "expected MOON_OTEL_SERVICE_NAME to set trace service.name; observed: {trace_service_names:?}"
+    );
+    assert!(
+        metric_service_names.contains(&"moon-cli-env-test"),
+        "expected MOON_OTEL_SERVICE_NAME to set metric service.name; observed: {metric_service_names:?}"
+    );
+    assert!(
+        log_service_names.contains(&"moon-cli-env-test"),
+        "expected MOON_OTEL_SERVICE_NAME to set log service.name; observed: {log_service_names:?}"
+    );
+    assert!(
+        log_bodies
+            .iter()
+            .any(|body| body.contains("Running moon") || body.contains("Run target")),
+        "expected MOON_OTEL_LOGS to enable OTLP log export"
+    );
+
+    let _ = shutdown_tx.send(());
+    server.await.unwrap();
+}

--- a/crates/daemon-server/Cargo.toml
+++ b/crates/daemon-server/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.1"
 edition = "2024"
 publish = false
 
+[features]
+default = ["otel"]
+otel = ["moon_task_runner/otel"]
+
 [dependencies]
 moon_app_context = { path = "../app-context" }
 moon_common = { path = "../common" }
@@ -12,7 +16,7 @@ moon_daemon_utils = { path = "../daemon-utils" }
 moon_file_watcher = { path = "../file-watcher" }
 moon_process = { path = "../process" }
 moon_target = { path = "../target" }
-moon_task_runner = { path = "../task-runner" }
+moon_task_runner = { path = "../task-runner", default-features = false }
 moon_workspace_graph = { path = "../workspace-graph" }
 miette = { workspace = true }
 notify-debouncer-full = { version = "0.7.0", features = ["flume"] }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -4,10 +4,14 @@ version = "0.0.1"
 edition = "2024"
 publish = false
 
+[features]
+default = ["otel"]
+otel = ["moon_daemon_server/otel"]
+
 [dependencies]
 moon_daemon_client = { path = "../daemon-client" }
 moon_daemon_proto = { path = "../daemon-proto" }
-moon_daemon_server = { path = "../daemon-server" }
+moon_daemon_server = { path = "../daemon-server", default-features = false }
 moon_daemon_utils = { path = "../daemon-utils" }
 miette = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -8,10 +8,14 @@ homepage = "https://moonrepo.dev/moon"
 repository = "https://github.com/moonrepo/moon"
 publish = false
 
+[features]
+default = ["otel"]
+otel = ["moon_action_pipeline/otel"]
+
 [dependencies]
 moon_action = { path = "../action" }
 moon_action_graph = { path = "../action-graph" }
-moon_action_pipeline = { path = "../action-pipeline" }
+moon_action_pipeline = { path = "../action-pipeline", default-features = false }
 moon_app_context = { path = "../app-context" }
 moon_common = { version = "2.0.5", path = "../common" }
 moon_process = { path = "../process" }

--- a/crates/process/src/exec_command.rs
+++ b/crates/process/src/exec_command.rs
@@ -19,7 +19,7 @@ use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command as TokioCommand};
 use tokio::task::{self, JoinHandle};
-use tracing::{debug, enabled, trace};
+use tracing::{debug, enabled, info_span, trace};
 
 impl Command {
     pub async fn exec_capture_output(&mut self) -> miette::Result<Output> {
@@ -37,10 +37,16 @@ impl Command {
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
 
-            let mut child = command.spawn().map_err(|error| ProcessError::Capture {
-                bin: self.get_bin_name(),
-                error: Box::new(error),
-            })?;
+            let spawn_span = self.create_spawn_span();
+            let mut child = {
+                let _guard = spawn_span.enter();
+
+                command.spawn().map_err(|error| ProcessError::Capture {
+                    bin: self.get_bin_name(),
+                    error: Box::new(error),
+                })?
+            };
+            self.record_spawn_pid(&spawn_span, &child);
 
             self.write_input_to_child(&mut child).await?;
 
@@ -48,10 +54,18 @@ impl Command {
         } else {
             command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-            command.spawn().map_err(|error| ProcessError::Capture {
-                bin: self.get_bin_name(),
-                error: Box::new(error),
-            })?
+            let spawn_span = self.create_spawn_span();
+            let child = {
+                let _guard = spawn_span.enter();
+
+                command.spawn().map_err(|error| ProcessError::Capture {
+                    bin: self.get_bin_name(),
+                    error: Box::new(error),
+                })?
+            };
+            self.record_spawn_pid(&spawn_span, &child);
+
+            child
         };
 
         let shared_child = registry.add_running(child).await;
@@ -87,10 +101,16 @@ impl Command {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        let child = command.spawn().map_err(|error| ProcessError::Capture {
-            bin: self.get_bin_name(),
-            error: Box::new(error),
-        })?;
+        let spawn_span = self.create_spawn_span();
+        let child = {
+            let _guard = spawn_span.enter();
+
+            command.spawn().map_err(|error| ProcessError::Capture {
+                bin: self.get_bin_name(),
+                error: Box::new(error),
+            })?
+        };
+        self.record_spawn_pid(&spawn_span, &child);
 
         let shared_child = registry.add_running(child).await;
         let stdin = shared_child.take_stdin().await;
@@ -200,19 +220,33 @@ impl Command {
         let child = if self.should_pass_stdin() {
             command.stdin(Stdio::piped());
 
-            let mut child = command.spawn().map_err(|error| ProcessError::Stream {
-                bin: self.get_bin_name(),
-                error: Box::new(error),
-            })?;
+            let spawn_span = self.create_spawn_span();
+            let mut child = {
+                let _guard = spawn_span.enter();
+
+                command.spawn().map_err(|error| ProcessError::Stream {
+                    bin: self.get_bin_name(),
+                    error: Box::new(error),
+                })?
+            };
+            self.record_spawn_pid(&spawn_span, &child);
 
             self.write_input_to_child(&mut child).await?;
 
             child
         } else {
-            command.spawn().map_err(|error| ProcessError::Stream {
-                bin: self.get_bin_name(),
-                error: Box::new(error),
-            })?
+            let spawn_span = self.create_spawn_span();
+            let child = {
+                let _guard = spawn_span.enter();
+
+                command.spawn().map_err(|error| ProcessError::Stream {
+                    bin: self.get_bin_name(),
+                    error: Box::new(error),
+                })?
+            };
+            self.record_spawn_pid(&spawn_span, &child);
+
+            child
         };
 
         let shared_child = registry.add_running(child).await;
@@ -257,12 +291,18 @@ impl Command {
             .stderr(Stdio::piped())
             .stdout(Stdio::piped());
 
-        let mut child = command
-            .spawn()
-            .map_err(|error| ProcessError::StreamCapture {
-                bin: self.get_bin_name(),
-                error: Box::new(error),
-            })?;
+        let spawn_span = self.create_spawn_span();
+        let mut child = {
+            let _guard = spawn_span.enter();
+
+            command
+                .spawn()
+                .map_err(|error| ProcessError::StreamCapture {
+                    bin: self.get_bin_name(),
+                    error: Box::new(error),
+                })?
+        };
+        self.record_spawn_pid(&spawn_span, &child);
 
         if self.should_pass_stdin() {
             self.write_input_to_child(&mut child).await?;
@@ -581,6 +621,20 @@ impl Command {
 
     fn create_async_command(&self) -> miette::Result<TokioCommand> {
         Ok(TokioCommand::from(self.create_sync_command()?))
+    }
+
+    fn create_spawn_span(&self) -> tracing::Span {
+        info_span!(
+            "process_spawn",
+            command = %self.get_bin_name(),
+            pid = tracing::field::Empty,
+        )
+    }
+
+    fn record_spawn_pid(&self, span: &tracing::Span, child: &Child) {
+        if let Some(pid) = child.id() {
+            span.record("pid", pid as u64);
+        }
     }
 
     fn handle_nonzero_status(&mut self, output: &Output, with_message: bool) -> miette::Result<()> {

--- a/crates/task-runner/Cargo.toml
+++ b/crates/task-runner/Cargo.toml
@@ -8,6 +8,10 @@ homepage = "https://moonrepo.dev/moon"
 repository = "https://github.com/moonrepo/moon"
 publish = false
 
+[features]
+default = ["otel"]
+otel = ["dep:opentelemetry"]
+
 [dependencies]
 moon_api = { path = "../api" }
 moon_app_context = { path = "../app-context" }
@@ -28,6 +32,7 @@ moon_task = { path = "../task" }
 moon_task_hasher = { path = "../task-hasher" }
 moon_time = { path = "../time" }
 miette = { workspace = true }
+opentelemetry = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 starbase_archive = { workspace = true }
@@ -40,7 +45,11 @@ tracing = { workspace = true }
 [dev-dependencies]
 moon_affected = { path = "../affected" }
 moon_test_utils2 = { path = "../test-utils" }
+opentelemetry-proto = "0.31.0"
+starbase = { workspace = true, features = ["otel"] }
 starbase_sandbox = { workspace = true }
+tokio-stream = { version = "0.1.18", features = ["net"] }
+tonic = "0.14.5"
 
 [lints]
 workspace = true

--- a/crates/task-runner/src/command_executor.rs
+++ b/crates/task-runner/src/command_executor.rs
@@ -1,3 +1,6 @@
+use crate::labels::action_status_label;
+#[cfg(feature = "otel")]
+use crate::metrics::task_runner_metrics;
 use moon_action::{ActionNode, ActionStatus, Operation, OperationList};
 use moon_action_context::{ActionContext, TargetState};
 use moon_app_context::AppContext;
@@ -11,7 +14,7 @@ use std::time::Duration;
 use tokio::task::{self, JoinHandle};
 use tokio::time::{sleep, timeout};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, instrument};
+use tracing::{Span, debug, instrument};
 
 #[derive(Debug)]
 pub struct CommandExecuteResult {
@@ -65,12 +68,27 @@ impl<'task> CommandExecutor<'task> {
         }
     }
 
-    #[instrument(skip(self, context))]
+    #[instrument(
+        name = "task_execution_attempts",
+        skip(self, context),
+        fields(
+            project_id = %self.project.id,
+            task_target = %self.task.target,
+            task_id = %self.task.id,
+            command = %self.command.get_bin_name(),
+            interactive = self.interactive,
+            persistent = self.persistent,
+            retry_total = self.attempt_total,
+            status = tracing::field::Empty,
+            exit_code = tracing::field::Empty,
+        )
+    )]
     pub async fn execute(
         mut self,
         context: &ActionContext,
         report_item: &mut TaskReportItem,
     ) -> miette::Result<CommandExecuteResult> {
+        let span = Span::current();
         // Prepare state for the executor, and each attempt
         let mut run_state = TargetState::Failed;
 
@@ -149,9 +167,11 @@ impl<'task> CommandExecutor<'task> {
                 // Zero and non-zero exit codes
                 Ok(maybe_output) => {
                     let mut is_success = false;
+                    let mut exit_code = -1;
 
                     if let Some(output) = maybe_output {
                         is_success = output.success();
+                        exit_code = output.code().unwrap_or(-1);
 
                         debug!(
                             task_target = self.task.target.as_str(),
@@ -178,6 +198,7 @@ impl<'task> CommandExecutor<'task> {
                         None,
                     )?;
 
+                    let status = attempt.status;
                     self.attempts.push(attempt);
 
                     // Successful execution, so break the loop
@@ -187,6 +208,8 @@ impl<'task> CommandExecutor<'task> {
                             "Task was successful, proceeding to next step",
                         );
 
+                        span.record("status", "passed");
+                        span.record("exit_code", exit_code);
                         run_state = TargetState::from_hash(report_item.hash.as_deref());
                         break None;
                     }
@@ -207,6 +230,8 @@ impl<'task> CommandExecutor<'task> {
                             "Task was unsuccessful, failing as we hit our max attempts",
                         );
 
+                        span.record("status", action_status_label(status));
+                        span.record("exit_code", exit_code);
                         break None;
                     }
                 }
@@ -229,6 +254,8 @@ impl<'task> CommandExecutor<'task> {
                     )?;
 
                     self.attempts.push(attempt);
+                    span.record("status", "failed");
+                    span.record("exit_code", -1);
 
                     break Some(error);
                 }
@@ -236,6 +263,14 @@ impl<'task> CommandExecutor<'task> {
         };
 
         self.stop_monitoring();
+        #[cfg(feature = "otel")]
+        task_runner_metrics().record_execution_attempts(
+            self.task,
+            self.attempts.get_final_status(),
+            self.interactive,
+            self.persistent,
+            self.attempts.len() as u64,
+        );
 
         Ok(CommandExecuteResult {
             attempts: self.attempts.take(),

--- a/crates/task-runner/src/labels.rs
+++ b/crates/task-runner/src/labels.rs
@@ -1,0 +1,15 @@
+use moon_action::ActionStatus;
+
+pub(crate) fn action_status_label(status: ActionStatus) -> &'static str {
+    match status {
+        ActionStatus::Aborted => "aborted",
+        ActionStatus::Cached => "cached",
+        ActionStatus::CachedFromRemote => "cached-from-remote",
+        ActionStatus::Failed => "failed",
+        ActionStatus::Invalid => "invalid",
+        ActionStatus::Passed => "passed",
+        ActionStatus::Running => "running",
+        ActionStatus::Skipped => "skipped",
+        ActionStatus::TimedOut => "timed-out",
+    }
+}

--- a/crates/task-runner/src/lib.rs
+++ b/crates/task-runner/src/lib.rs
@@ -1,6 +1,9 @@
 // Public for tests
 pub mod command_builder;
 pub mod command_executor;
+mod labels;
+#[cfg(feature = "otel")]
+mod metrics;
 pub mod output_archiver;
 pub mod output_hydrater;
 mod run_state;

--- a/crates/task-runner/src/metrics.rs
+++ b/crates/task-runner/src/metrics.rs
@@ -1,0 +1,235 @@
+use moon_action::ActionStatus;
+use moon_common::is_ci_env;
+use moon_task::Task;
+use opentelemetry::KeyValue;
+use opentelemetry::global;
+use opentelemetry::metrics::{Counter, Histogram};
+use std::time::Duration;
+
+use crate::labels::action_status_label;
+
+pub(crate) struct TaskRunnerMetrics {
+    task_run_total: Counter<u64>,
+    task_run_failure_total: Counter<u64>,
+    task_retry_total: Counter<u64>,
+    task_run_duration: Histogram<u64>,
+    task_hash_generation_duration: Histogram<u64>,
+    task_cache_lookup_total: Counter<u64>,
+    task_cache_hit_total: Counter<u64>,
+    task_cache_lookup_duration: Histogram<u64>,
+    task_hydration_duration: Histogram<u64>,
+    task_archive_duration: Histogram<u64>,
+    task_execution_duration: Histogram<u64>,
+    task_execution_attempts: Histogram<u64>,
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    duration.as_millis().min(u64::MAX as u128) as u64
+}
+
+fn build_base_attrs(task: &Task) -> Vec<KeyValue> {
+    vec![
+        KeyValue::new("task_target", task.target.to_string()),
+        KeyValue::new("task_id", task.id.to_string()),
+        KeyValue::new("task_type", task.type_of.to_string()),
+        KeyValue::new("cache_enabled", task.options.cache.is_enabled()),
+        KeyValue::new("ci", is_ci_env()),
+    ]
+}
+
+impl TaskRunnerMetrics {
+    fn new() -> Self {
+        let meter = global::meter("moon_task_runner");
+
+        Self {
+            task_run_total: meter
+                .u64_counter("moon.task.run.total")
+                .with_description("Total number of moon task runs.")
+                .build(),
+            task_run_failure_total: meter
+                .u64_counter("moon.task.run.failure.total")
+                .with_description("Total number of failed moon task runs.")
+                .build(),
+            task_retry_total: meter
+                .u64_counter("moon.task.retry.total")
+                .with_description("Total number of moon task execution retries.")
+                .build(),
+            task_run_duration: meter
+                .u64_histogram("moon.task.run.duration")
+                .with_description("Overall moon task run duration.")
+                .with_unit("ms")
+                .build(),
+            task_hash_generation_duration: meter
+                .u64_histogram("moon.task.hash_generation.duration")
+                .with_description("Moon task hash generation duration.")
+                .with_unit("ms")
+                .build(),
+            task_cache_lookup_total: meter
+                .u64_counter("moon.task.cache.lookup.total")
+                .with_description("Total number of moon task cache lookups.")
+                .build(),
+            task_cache_hit_total: meter
+                .u64_counter("moon.task.cache.hit.total")
+                .with_description("Total number of moon task cache hits.")
+                .build(),
+            task_cache_lookup_duration: meter
+                .u64_histogram("moon.task.cache.lookup.duration")
+                .with_description("Moon task cache lookup duration.")
+                .with_unit("ms")
+                .build(),
+            task_hydration_duration: meter
+                .u64_histogram("moon.task.output.hydration.duration")
+                .with_description("Moon task output hydration duration.")
+                .with_unit("ms")
+                .build(),
+            task_archive_duration: meter
+                .u64_histogram("moon.task.output.archive.duration")
+                .with_description("Moon task output archive duration.")
+                .with_unit("ms")
+                .build(),
+            task_execution_duration: meter
+                .u64_histogram("moon.task.execution.duration")
+                .with_description("Moon task command execution duration.")
+                .with_unit("ms")
+                .build(),
+            task_execution_attempts: meter
+                .u64_histogram("moon.task.execution.attempts")
+                .with_description("Moon task execution attempt count.")
+                .build(),
+        }
+    }
+
+    pub fn record_task_run(
+        &self,
+        task: &Task,
+        status: ActionStatus,
+        cache_source: &str,
+        interactive: bool,
+        persistent: bool,
+        duration: Duration,
+    ) {
+        let mut attrs = build_base_attrs(task);
+        attrs.extend([
+            KeyValue::new("status", action_status_label(status)),
+            KeyValue::new("cache_source", cache_source.to_owned()),
+            KeyValue::new("interactive", interactive),
+            KeyValue::new("persistent", persistent),
+        ]);
+
+        self.task_run_total.add(1, &attrs);
+        self.task_run_duration.record(duration_ms(duration), &attrs);
+
+        if matches!(
+            status,
+            ActionStatus::Aborted
+                | ActionStatus::Failed
+                | ActionStatus::Invalid
+                | ActionStatus::TimedOut
+        ) {
+            self.task_run_failure_total.add(1, &attrs);
+        }
+    }
+
+    pub fn record_hash_generation(&self, task: &Task, duration: Duration) {
+        let attrs = build_base_attrs(task);
+        self.task_hash_generation_duration
+            .record(duration_ms(duration), &attrs);
+    }
+
+    pub fn record_cache_lookup(&self, task: &Task, source: &str, hit: bool, duration: Duration) {
+        let mut attrs = build_base_attrs(task);
+        attrs.extend([
+            KeyValue::new("cache_source", source.to_owned()),
+            KeyValue::new("cache_hit", hit),
+        ]);
+
+        self.task_cache_lookup_total.add(1, &attrs);
+        self.task_cache_lookup_duration
+            .record(duration_ms(duration), &attrs);
+
+        if hit {
+            self.task_cache_hit_total.add(1, &attrs);
+        }
+    }
+
+    pub fn record_hydration(
+        &self,
+        task: &Task,
+        hydrate_from: &str,
+        status: ActionStatus,
+        hydrated: bool,
+        duration: Duration,
+    ) {
+        let mut attrs = build_base_attrs(task);
+        attrs.extend([
+            KeyValue::new("hydrate_from", hydrate_from.to_owned()),
+            KeyValue::new("hydrated", hydrated),
+            KeyValue::new("status", action_status_label(status)),
+        ]);
+
+        self.task_hydration_duration
+            .record(duration_ms(duration), &attrs);
+    }
+
+    pub fn record_archive(
+        &self,
+        task: &Task,
+        archived: bool,
+        status: ActionStatus,
+        duration: Duration,
+    ) {
+        let mut attrs = build_base_attrs(task);
+        attrs.extend([
+            KeyValue::new("archived", archived),
+            KeyValue::new("status", action_status_label(status)),
+        ]);
+
+        self.task_archive_duration
+            .record(duration_ms(duration), &attrs);
+    }
+
+    pub fn record_execution(
+        &self,
+        task: &Task,
+        status: ActionStatus,
+        interactive: bool,
+        persistent: bool,
+        duration: Duration,
+    ) {
+        let mut attrs = build_base_attrs(task);
+        attrs.extend([
+            KeyValue::new("status", action_status_label(status)),
+            KeyValue::new("interactive", interactive),
+            KeyValue::new("persistent", persistent),
+        ]);
+
+        self.task_execution_duration
+            .record(duration_ms(duration), &attrs);
+    }
+
+    pub fn record_execution_attempts(
+        &self,
+        task: &Task,
+        status: ActionStatus,
+        interactive: bool,
+        persistent: bool,
+        attempts: u64,
+    ) {
+        let mut attrs = build_base_attrs(task);
+        attrs.extend([
+            KeyValue::new("status", action_status_label(status)),
+            KeyValue::new("interactive", interactive),
+            KeyValue::new("persistent", persistent),
+        ]);
+
+        self.task_execution_attempts.record(attempts, &attrs);
+
+        if attempts > 1 {
+            self.task_retry_total.add(attempts - 1, &attrs);
+        }
+    }
+}
+
+pub(crate) fn task_runner_metrics() -> TaskRunnerMetrics {
+    TaskRunnerMetrics::new()
+}

--- a/crates/task-runner/src/task_runner.rs
+++ b/crates/task-runner/src/task_runner.rs
@@ -1,5 +1,8 @@
 use crate::command_builder::CommandBuilder;
 use crate::command_executor::CommandExecutor;
+use crate::labels::action_status_label;
+#[cfg(feature = "otel")]
+use crate::metrics::task_runner_metrics;
 use crate::output_archiver::OutputArchiver;
 use crate::output_hydrater::{HydrateFrom, OutputHydrater};
 use crate::run_state::*;
@@ -8,6 +11,7 @@ use moon_action::{ActionNode, ActionStatus, Operation, OperationList, OperationM
 use moon_action_context::{ActionContext, TargetState};
 use moon_app_context::AppContext;
 use moon_cache::CacheItem;
+use moon_common::is_ci_env;
 use moon_console::TaskReportItem;
 use moon_process::ProcessError;
 use moon_project::Project;
@@ -17,7 +21,9 @@ use moon_task_hasher::*;
 use moon_time::{is_stale, now_millis};
 use starbase_utils::fs;
 use std::sync::Arc;
-use tracing::{debug, instrument, trace};
+#[cfg(feature = "otel")]
+use std::time::Instant;
+use tracing::{Span, debug, instrument, trace};
 
 #[derive(Debug)]
 pub struct TaskRunResult {
@@ -39,6 +45,7 @@ pub struct TaskRunner<'task> {
     pub operations: OperationList,
     pub remote_state: Option<ActionState<'task>>,
     pub report_item: TaskReportItem,
+    pub trace_cache_source: Option<&'static str>,
     pub target_state: Option<TargetState>,
 }
 
@@ -72,6 +79,7 @@ impl<'task> TaskRunner<'task> {
                 output_style: task.options.output_style,
                 ..Default::default()
             },
+            trace_cache_source: None,
             target_state: None,
             task,
             app_context,
@@ -123,12 +131,54 @@ impl<'task> TaskRunner<'task> {
         Ok(Some(hash))
     }
 
-    #[instrument(skip(self, context))]
+    fn record_cache_lookup(&mut self, span: &Span, hit: bool, source: &'static str) {
+        self.trace_cache_source = Some(source);
+        span.record("cache_hit", hit);
+        span.record("cache_source", source);
+    }
+
+    fn record_status(span: &Span, status: ActionStatus) {
+        span.record("status", action_status_label(status));
+    }
+
+    fn get_trace_cache_source(&self) -> &'static str {
+        self.trace_cache_source.unwrap_or_else(|| {
+            if self.is_cache_enabled() {
+                "miss"
+            } else {
+                "disabled"
+            }
+        })
+    }
+
+    #[instrument(
+        name = "task_run",
+        skip(self, context, node),
+        fields(
+            project_id = %self.project.id,
+            task_target = %self.task.target,
+            task_id = %self.task.id,
+            task_type = %self.task.type_of,
+            interactive = node.is_interactive() || self.task.is_interactive(),
+            persistent = node.is_persistent() || self.task.is_persistent(),
+            retry_total = self.task.options.retry_count + 1,
+            cache_enabled = self.is_cache_enabled(),
+            ci = is_ci_env(),
+            status = tracing::field::Empty,
+            cache_hit = tracing::field::Empty,
+            cache_source = tracing::field::Empty,
+            exit_code = tracing::field::Empty,
+            flaky = tracing::field::Empty,
+        )
+    )]
     pub async fn run(
         &mut self,
         context: &ActionContext,
         node: &ActionNode,
     ) -> miette::Result<TaskRunResult> {
+        #[cfg(feature = "otel")]
+        let run_started = Instant::now();
+        let span = Span::current();
         self.report_item.output_prefix = Some(context.get_target_prefix(&self.task.target));
 
         let result = self.internal_run(context, node).await;
@@ -152,6 +202,31 @@ impl<'task> TaskRunner<'task> {
                     None,
                 )?;
 
+                let status = self.operations.get_final_status();
+                Self::record_status(&span, status);
+                span.record("cache_hit", self.operations.iter().any(|op| op.is_cached()));
+                let cache_source = self.get_trace_cache_source();
+                span.record("cache_source", cache_source);
+                span.record("flaky", self.operations.is_flaky());
+                #[cfg(feature = "otel")]
+                task_runner_metrics().record_task_run(
+                    self.task,
+                    status,
+                    cache_source,
+                    node.is_interactive() || self.task.is_interactive(),
+                    node.is_persistent() || self.task.is_persistent(),
+                    run_started.elapsed(),
+                );
+
+                if let Some(exit_code) = self
+                    .operations
+                    .get_last_process()
+                    .and_then(|operation| operation.get_exec_output())
+                    .and_then(|output| output.exit_code)
+                {
+                    span.record("exit_code", exit_code);
+                }
+
                 Ok(TaskRunResult {
                     error: None,
                     hash: maybe_hash,
@@ -172,6 +247,31 @@ impl<'task> TaskRunner<'task> {
                     &self.report_item,
                     Some(&error),
                 )?;
+
+                let status = self.operations.get_final_status();
+                Self::record_status(&span, status);
+                span.record("cache_hit", self.operations.iter().any(|op| op.is_cached()));
+                let cache_source = self.get_trace_cache_source();
+                span.record("cache_source", cache_source);
+                span.record("flaky", self.operations.is_flaky());
+                #[cfg(feature = "otel")]
+                task_runner_metrics().record_task_run(
+                    self.task,
+                    status,
+                    cache_source,
+                    node.is_interactive() || self.task.is_interactive(),
+                    node.is_persistent() || self.task.is_persistent(),
+                    run_started.elapsed(),
+                );
+
+                if let Some(exit_code) = self
+                    .operations
+                    .get_last_process()
+                    .and_then(|operation| operation.get_exec_output())
+                    .and_then(|output| output.exit_code)
+                {
+                    span.record("exit_code", exit_code);
+                }
 
                 Ok(TaskRunResult {
                     error: Some(error),
@@ -197,8 +297,21 @@ impl<'task> TaskRunner<'task> {
         Ok(result)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(
+        name = "task_cache_lookup",
+        skip(self, hash),
+        fields(
+            project_id = %self.project.id,
+            task_target = %self.task.target,
+            task_id = %self.task.id,
+            cache_hit = tracing::field::Empty,
+            cache_source = tracing::field::Empty,
+        )
+    )]
     pub async fn is_cached(&mut self, hash: &str) -> miette::Result<Option<HydrateFrom>> {
+        #[cfg(feature = "otel")]
+        let lookup_started = Instant::now();
+        let span = Span::current();
         let cache_engine = &self.app_context.cache_engine;
 
         debug!(
@@ -245,6 +358,14 @@ impl<'task> TaskRunner<'task> {
                 hash, "Hash matches previous run, reusing existing outputs"
             );
 
+            self.record_cache_lookup(&span, true, "previous-output");
+            #[cfg(feature = "otel")]
+            task_runner_metrics().record_cache_lookup(
+                self.task,
+                "previous-output",
+                true,
+                lookup_started.elapsed(),
+            );
             return Ok(Some(HydrateFrom::PreviousOutput));
         }
 
@@ -254,6 +375,14 @@ impl<'task> TaskRunner<'task> {
                 hash, "Cache is not readable, continuing run"
             );
 
+            self.record_cache_lookup(&span, false, "unreadable");
+            #[cfg(feature = "otel")]
+            task_runner_metrics().record_cache_lookup(
+                self.task,
+                "unreadable",
+                false,
+                lookup_started.elapsed(),
+            );
             return Ok(None);
         }
 
@@ -267,6 +396,14 @@ impl<'task> TaskRunner<'task> {
                 hash, "Previous run failed, avoiding hydration"
             );
 
+            self.record_cache_lookup(&span, false, "previous-failure");
+            #[cfg(feature = "otel")]
+            task_runner_metrics().record_cache_lookup(
+                self.task,
+                "previous-failure",
+                false,
+                lookup_started.elapsed(),
+            );
             return Ok(None);
         }
 
@@ -301,6 +438,14 @@ impl<'task> TaskRunner<'task> {
                 "Cache hit in local cache, will reuse existing archive"
             );
 
+            self.record_cache_lookup(&span, true, "local-cache");
+            #[cfg(feature = "otel")]
+            task_runner_metrics().record_cache_lookup(
+                self.task,
+                "local-cache",
+                true,
+                lookup_started.elapsed(),
+            );
             return Ok(Some(HydrateFrom::LocalCache));
         }
 
@@ -317,6 +462,14 @@ impl<'task> TaskRunner<'task> {
 
             state.set_action_result(result);
 
+            self.record_cache_lookup(&span, true, "remote-cache");
+            #[cfg(feature = "otel")]
+            task_runner_metrics().record_cache_lookup(
+                self.task,
+                "remote-cache",
+                true,
+                lookup_started.elapsed(),
+            );
             return Ok(Some(HydrateFrom::RemoteCache));
         }
 
@@ -325,6 +478,14 @@ impl<'task> TaskRunner<'task> {
             hash, "Cache miss, continuing run"
         );
 
+        self.record_cache_lookup(&span, false, "miss");
+        #[cfg(feature = "otel")]
+        task_runner_metrics().record_cache_lookup(
+            self.task,
+            "miss",
+            false,
+            lookup_started.elapsed(),
+        );
         Ok(None)
     }
 
@@ -365,12 +526,22 @@ impl<'task> TaskRunner<'task> {
         Ok(true)
     }
 
-    #[instrument(skip_all)]
+    #[instrument(
+        name = "task_hash_generation",
+        skip_all,
+        fields(
+            project_id = %self.project.id,
+            task_target = %self.task.target,
+            task_id = %self.task.id,
+        )
+    )]
     pub async fn generate_hash(
         &mut self,
         context: &ActionContext,
         node: &ActionNode,
     ) -> miette::Result<String> {
+        #[cfg(feature = "otel")]
+        let hash_started = Instant::now();
         debug!(
             task_target = self.task.target.as_str(),
             "Generating a unique hash for this task"
@@ -425,18 +596,45 @@ impl<'task> TaskRunner<'task> {
             "Generated a unique hash"
         );
 
+        #[cfg(feature = "otel")]
+        task_runner_metrics().record_hash_generation(self.task, hash_started.elapsed());
+
         Ok(hash)
     }
 
-    #[instrument(skip(self, context, node))]
+    #[instrument(
+        name = "task_execution",
+        skip(self, context, node),
+        fields(
+            project_id = %self.project.id,
+            task_target = %self.task.target,
+            task_id = %self.task.id,
+            interactive = node.is_interactive() || self.task.is_interactive(),
+            persistent = node.is_persistent() || self.task.is_persistent(),
+            retry_total = self.task.options.retry_count + 1,
+            status = tracing::field::Empty,
+            exit_code = tracing::field::Empty,
+        )
+    )]
     pub async fn execute(
         &mut self,
         context: &ActionContext,
         node: &ActionNode,
     ) -> miette::Result<()> {
-        // If the task is a no-operation, we should exit early
+        #[cfg(feature = "otel")]
+        let execution_started = Instant::now();
+        let span = Span::current();
         if self.task.is_no_op() {
             self.skip_no_op()?;
+            Self::record_status(&span, ActionStatus::Passed);
+            #[cfg(feature = "otel")]
+            task_runner_metrics().record_execution(
+                self.task,
+                ActionStatus::Passed,
+                node.is_interactive() || self.task.is_interactive(),
+                node.is_persistent() || self.task.is_persistent(),
+                execution_started.elapsed(),
+            );
 
             return Ok(());
         }
@@ -491,6 +689,15 @@ impl<'task> TaskRunner<'task> {
         if let Some(last_attempt) = result.attempts.get_last_execution() {
             self.persist_state(last_attempt)?;
 
+            Self::record_status(&span, last_attempt.status);
+
+            if let Some(exit_code) = last_attempt
+                .get_exec_output()
+                .and_then(|output| output.exit_code)
+            {
+                span.record("exit_code", exit_code);
+            }
+
             if let Some(state) = &mut self.remote_state {
                 state.create_action_result_from_operation(last_attempt)?;
             }
@@ -506,6 +713,17 @@ impl<'task> TaskRunner<'task> {
         // We do this here instead of in `execute` so that we can
         // capture the attempts and report them.
         if let Some(result_error) = result.error {
+            #[cfg(feature = "otel")]
+            task_runner_metrics().record_execution(
+                self.task,
+                self.operations
+                    .get_last_execution()
+                    .map(|attempt| attempt.status)
+                    .unwrap_or(ActionStatus::Failed),
+                node.is_interactive() || self.task.is_interactive(),
+                node.is_persistent() || self.task.is_persistent(),
+                execution_started.elapsed(),
+            );
             return Err(result_error);
         }
 
@@ -513,6 +731,14 @@ impl<'task> TaskRunner<'task> {
         if let Some(last_attempt) = self.operations.get_last_execution()
             && last_attempt.has_failed()
         {
+            #[cfg(feature = "otel")]
+            task_runner_metrics().record_execution(
+                self.task,
+                last_attempt.status,
+                node.is_interactive() || self.task.is_interactive(),
+                node.is_persistent() || self.task.is_persistent(),
+                execution_started.elapsed(),
+            );
             return Err(TaskRunnerError::RunFailed {
                 target: self.task.target.clone(),
                 error: Box::new(ProcessError::ExitNonZero {
@@ -521,6 +747,23 @@ impl<'task> TaskRunner<'task> {
                 }),
             }
             .into());
+        }
+
+        #[cfg(feature = "otel")]
+        {
+            let execution_status = self
+                .operations
+                .get_last_execution()
+                .map(|attempt| attempt.status)
+                .unwrap_or(ActionStatus::Passed);
+
+            task_runner_metrics().record_execution(
+                self.task,
+                execution_status,
+                node.is_interactive() || self.task.is_interactive(),
+                node.is_persistent() || self.task.is_persistent(),
+                execution_started.elapsed(),
+            );
         }
 
         Ok(())
@@ -557,8 +800,19 @@ impl<'task> TaskRunner<'task> {
         Ok(())
     }
 
-    #[instrument(skip(self))]
+    #[instrument(
+        name = "task_output_archive",
+        skip(self, hash),
+        fields(
+            project_id = %self.project.id,
+            task_target = %self.task.target,
+            task_id = %self.task.id,
+            archived = tracing::field::Empty,
+        )
+    )]
     pub async fn archive(&mut self, hash: &str) -> miette::Result<bool> {
+        #[cfg(feature = "otel")]
+        let archive_started = Instant::now();
         let mut operation = Operation::archive_creation();
 
         debug!(
@@ -589,12 +843,38 @@ impl<'task> TaskRunner<'task> {
         }
 
         self.operations.push(operation);
+        Span::current().record("archived", archived);
+        #[cfg(feature = "otel")]
+        task_runner_metrics().record_archive(
+            self.task,
+            archived,
+            self.operations
+                .iter()
+                .last()
+                .map(|operation| operation.status)
+                .unwrap_or(ActionStatus::Skipped),
+            archive_started.elapsed(),
+        );
 
         Ok(archived)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(
+        name = "task_output_hydration",
+        skip(self, hash),
+        fields(
+            project_id = %self.project.id,
+            task_target = %self.task.target,
+            task_id = %self.task.id,
+            hydrate_from = tracing::field::Empty,
+            hydrated = tracing::field::Empty,
+            status = tracing::field::Empty,
+        )
+    )]
     pub async fn hydrate(&mut self, hash: &str) -> miette::Result<bool> {
+        #[cfg(feature = "otel")]
+        let hydration_started = Instant::now();
+        let span = Span::current();
         let mut operation = Operation::output_hydration();
 
         // Not cached
@@ -607,6 +887,17 @@ impl<'task> TaskRunner<'task> {
             operation.finish(ActionStatus::Skipped);
 
             self.operations.push(operation);
+            Self::record_status(&span, ActionStatus::Skipped);
+            span.record("hydrated", false);
+            span.record("hydrate_from", "miss");
+            #[cfg(feature = "otel")]
+            task_runner_metrics().record_hydration(
+                self.task,
+                "miss",
+                ActionStatus::Skipped,
+                false,
+                hydration_started.elapsed(),
+            );
 
             return Ok(false);
         };
@@ -628,6 +919,22 @@ impl<'task> TaskRunner<'task> {
             operation.finish(ActionStatus::Invalid);
 
             self.operations.push(operation);
+            Self::record_status(&span, ActionStatus::Invalid);
+            span.record("hydrated", false);
+            let hydrate_from = match from {
+                HydrateFrom::LocalCache => "local-cache",
+                HydrateFrom::PreviousOutput => "previous-output",
+                HydrateFrom::RemoteCache => "remote-cache",
+            };
+            span.record("hydrate_from", hydrate_from);
+            #[cfg(feature = "otel")]
+            task_runner_metrics().record_hydration(
+                self.task,
+                hydrate_from,
+                ActionStatus::Invalid,
+                false,
+                hydration_started.elapsed(),
+            );
 
             return Ok(false);
         }
@@ -690,8 +997,26 @@ impl<'task> TaskRunner<'task> {
 
         self.persist_state(&operation)?;
 
+        let status = operation.status;
+
         self.operations.push(operation);
         self.target_state = Some(TargetState::Passed(hash.to_owned()));
+        span.record("hydrated", true);
+        Self::record_status(&span, status);
+        let hydrate_from = match from {
+            HydrateFrom::LocalCache => "local-cache",
+            HydrateFrom::PreviousOutput => "previous-output",
+            HydrateFrom::RemoteCache => "remote-cache",
+        };
+        span.record("hydrate_from", hydrate_from);
+        #[cfg(feature = "otel")]
+        task_runner_metrics().record_hydration(
+            self.task,
+            hydrate_from,
+            status,
+            true,
+            hydration_started.elapsed(),
+        );
 
         Ok(true)
     }

--- a/crates/task-runner/tests/otel_test.rs
+++ b/crates/task-runner/tests/otel_test.rs
@@ -1,0 +1,472 @@
+mod utils;
+
+use moon_action_context::ActionContext;
+use opentelemetry_proto::tonic::collector::metrics::v1::{
+    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
+    metrics_service_server::{MetricsService, MetricsServiceServer},
+};
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    ExportTraceServiceRequest, ExportTraceServiceResponse,
+    trace_service_server::{TraceService, TraceServiceServer},
+};
+use starbase::tracing::{OtelOptions, TracingOptions, setup_tracing};
+use std::env;
+use std::fs;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{Mutex, oneshot};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status, transport::Server};
+use utils::TaskRunnerContainer;
+
+fn string_attr<'a>(
+    span: &'a opentelemetry_proto::tonic::trace::v1::Span,
+    key: &str,
+) -> Option<&'a str> {
+    span.attributes
+        .iter()
+        .find(|attribute| attribute.key == key)
+        .and_then(|attribute| attribute.value.as_ref())
+        .and_then(|value| value.value.as_ref())
+        .and_then(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+}
+
+fn bool_attr(span: &opentelemetry_proto::tonic::trace::v1::Span, key: &str) -> Option<bool> {
+    span.attributes
+        .iter()
+        .find(|attribute| attribute.key == key)
+        .and_then(|attribute| attribute.value.as_ref())
+        .and_then(|value| value.value.as_ref())
+        .and_then(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(value) => {
+                Some(*value)
+            }
+            _ => None,
+        })
+}
+
+fn any_value_string(value: &opentelemetry_proto::tonic::common::v1::AnyValue) -> Option<&str> {
+    value.value.as_ref().and_then(|value| match value {
+        opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+            Some(value.as_str())
+        }
+        _ => None,
+    })
+}
+
+fn any_value_bool(value: &opentelemetry_proto::tonic::common::v1::AnyValue) -> Option<bool> {
+    value.value.as_ref().and_then(|value| match value {
+        opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(value) => Some(*value),
+        _ => None,
+    })
+}
+
+fn key_value_matches(
+    attributes: &[opentelemetry_proto::tonic::common::v1::KeyValue],
+    key: &str,
+    expected: &str,
+) -> bool {
+    attributes.iter().any(|attribute| {
+        attribute.key == key
+            && attribute
+                .value
+                .as_ref()
+                .and_then(any_value_string)
+                .is_some_and(|value| value == expected)
+    })
+}
+
+fn key_value_bool_matches(
+    attributes: &[opentelemetry_proto::tonic::common::v1::KeyValue],
+    key: &str,
+    expected: bool,
+) -> bool {
+    attributes.iter().any(|attribute| {
+        attribute.key == key
+            && attribute
+                .value
+                .as_ref()
+                .and_then(any_value_bool)
+                .is_some_and(|value| value == expected)
+    })
+}
+
+fn metric_has_string_attr(
+    metric: &opentelemetry_proto::tonic::metrics::v1::Metric,
+    key: &str,
+    expected: &str,
+) -> bool {
+    match metric.data.as_ref() {
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(sum)) => sum
+            .data_points
+            .iter()
+            .any(|point| key_value_matches(&point.attributes, key, expected)),
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Histogram(histogram)) => {
+            histogram
+                .data_points
+                .iter()
+                .any(|point| key_value_matches(&point.attributes, key, expected))
+        }
+        _ => false,
+    }
+}
+
+fn metric_has_string_and_bool_attrs(
+    metric: &opentelemetry_proto::tonic::metrics::v1::Metric,
+    string_key: &str,
+    string_expected: &str,
+    bool_key: &str,
+    bool_expected: bool,
+) -> bool {
+    let point_matches = |attributes: &[opentelemetry_proto::tonic::common::v1::KeyValue]| {
+        key_value_matches(attributes, string_key, string_expected)
+            && key_value_bool_matches(attributes, bool_key, bool_expected)
+    };
+
+    match metric.data.as_ref() {
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(sum)) => sum
+            .data_points
+            .iter()
+            .any(|point| point_matches(&point.attributes)),
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Histogram(histogram)) => {
+            histogram
+                .data_points
+                .iter()
+                .any(|point| point_matches(&point.attributes))
+        }
+        _ => false,
+    }
+}
+
+#[derive(Clone, Default)]
+struct Collector {
+    metric_requests: Arc<Mutex<Vec<ExportMetricsServiceRequest>>>,
+    trace_requests: Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
+}
+
+#[tonic::async_trait]
+impl MetricsService for Collector {
+    async fn export(
+        &self,
+        request: Request<ExportMetricsServiceRequest>,
+    ) -> Result<Response<ExportMetricsServiceResponse>, Status> {
+        self.metric_requests.lock().await.push(request.into_inner());
+
+        Ok(Response::new(ExportMetricsServiceResponse {
+            partial_success: None,
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl TraceService for Collector {
+    async fn export(
+        &self,
+        request: Request<ExportTraceServiceRequest>,
+    ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        self.trace_requests.lock().await.push(request.into_inner());
+
+        Ok(Response::new(ExportTraceServiceResponse {
+            partial_success: None,
+        }))
+    }
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    old_value: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: String) -> Self {
+        let old_value = env::var(key).ok();
+
+        unsafe {
+            env::set_var(key, value);
+        }
+
+        Self { key, old_value }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(value) = &self.old_value {
+            unsafe {
+                env::set_var(self.key, value);
+            }
+        } else {
+            unsafe {
+                env::remove_var(self.key);
+            }
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exports_task_runner_spans_over_otlp() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let metric_requests = Arc::new(Mutex::new(Vec::new()));
+    let trace_requests = Arc::new(Mutex::new(Vec::new()));
+    let collector = Collector {
+        metric_requests: Arc::clone(&metric_requests),
+        trace_requests: Arc::clone(&trace_requests),
+    };
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(
+                MetricsServiceServer::new(collector.clone())
+                    .max_decoding_message_size(32 * 1024 * 1024),
+            )
+            .add_service(
+                TraceServiceServer::new(collector).max_decoding_message_size(32 * 1024 * 1024),
+            )
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+
+    let _endpoint = EnvVarGuard::set(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        format!("http://{addr}"),
+    );
+    let _protocol = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc".into());
+    let _metrics_endpoint = EnvVarGuard::set(
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        format!("http://{addr}"),
+    );
+    let _metrics_protocol = EnvVarGuard::set("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "grpc".into());
+
+    let guard = setup_tracing(TracingOptions {
+        otel: OtelOptions {
+            enabled: true,
+            logs_enabled: false,
+            service_name: Some("moon-task-runner-test".into()),
+        },
+        ..TracingOptions::default()
+    });
+
+    let container = TaskRunnerContainer::new_os("runner", "create-file").await;
+    container.sandbox.enable_git();
+
+    let mut runner = container.create_runner();
+    let node = container.create_action_node();
+    let context = ActionContext::default();
+
+    runner.run_with_panic(&context, &node).await.unwrap();
+    fs::remove_file(container.project.root.join("file.txt")).unwrap();
+
+    let mut cached_runner = container.create_runner();
+    cached_runner.run_with_panic(&context, &node).await.unwrap();
+    drop(guard);
+
+    let wait_result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if !trace_requests.lock().await.is_empty() && !metric_requests.lock().await.is_empty() {
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+
+    if wait_result.is_err() {
+        let trace_count = trace_requests.lock().await.len();
+        let metric_count = metric_requests.lock().await.len();
+
+        panic!(
+            "timed out waiting for task runner OTLP export (traces={trace_count}, metrics={metric_count})"
+        );
+    }
+
+    let trace_requests = trace_requests.lock().await.clone();
+    let metric_requests = metric_requests.lock().await.clone();
+    let spans = trace_requests
+        .iter()
+        .flat_map(|request| request.resource_spans.iter())
+        .flat_map(|resource| resource.scope_spans.iter())
+        .flat_map(|scope| scope.spans.iter())
+        .collect::<Vec<_>>();
+    let metrics = metric_requests
+        .iter()
+        .flat_map(|request| request.resource_metrics.iter())
+        .flat_map(|resource| resource.scope_metrics.iter())
+        .flat_map(|scope| scope.metrics.iter())
+        .collect::<Vec<_>>();
+
+    let has_span = |name: &str| spans.iter().any(|span| span.name == name);
+    let has_metric = |name: &str| metrics.iter().any(|metric| metric.name == name);
+    let observed_span_names = spans
+        .iter()
+        .map(|span| span.name.as_str())
+        .collect::<Vec<_>>();
+    let observed_metric_names = metrics
+        .iter()
+        .map(|metric| metric.name.as_str())
+        .collect::<Vec<_>>();
+    let disallowed_attrs = [
+        "args",
+        "command_line",
+        "hash",
+        "node",
+        "project",
+        "root",
+        "task_command",
+    ];
+    let reviewed_span_names = [
+        "process_spawn",
+        "task_cache_lookup",
+        "task_execution",
+        "task_hash_generation",
+        "task_output_hydration",
+        "task_run",
+    ];
+    let task_run_miss = spans
+        .iter()
+        .find(|span| span.name == "task_run" && string_attr(span, "cache_source") == Some("miss"));
+    let task_run_local_cache = spans.iter().find(|span| {
+        span.name == "task_run" && string_attr(span, "cache_source") == Some("local-cache")
+    });
+
+    assert!(
+        has_span("task_run"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("task_hash_generation"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("task_cache_lookup"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("task_output_hydration"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("task_execution"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("task_execution_attempts"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("process_spawn"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_span("task_output_archive"),
+        "observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.run.total"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.run.duration"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.hash_generation.duration"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.cache.lookup.total"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.cache.lookup.duration"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.output.hydration.duration"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.execution.duration"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.execution.attempts"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        has_metric("moon.task.output.archive.duration"),
+        "observed metrics: {observed_metric_names:?}"
+    );
+    assert_eq!(
+        task_run_miss.and_then(|span| string_attr(span, "task_target")),
+        Some(container.task.target.as_str())
+    );
+    assert!(
+        task_run_local_cache.is_some(),
+        "expected task_run span with cache_source=local-cache; observed spans: {observed_span_names:?}"
+    );
+    let cache_lookup_local_cache = spans.iter().find(|span| {
+        span.name == "task_cache_lookup" && string_attr(span, "cache_source") == Some("local-cache")
+    });
+    assert_eq!(
+        cache_lookup_local_cache.and_then(|span| bool_attr(span, "cache_hit")),
+        Some(true),
+        "expected task_cache_lookup span to include cache_source=local-cache and cache_hit=true; observed spans: {observed_span_names:?}"
+    );
+    let offending_attrs = spans
+        .iter()
+        .filter(|span| reviewed_span_names.contains(&span.name.as_str()))
+        .flat_map(|span| {
+            span.attributes.iter().filter_map(|attribute| {
+                disallowed_attrs
+                    .contains(&attribute.key.as_str())
+                    .then(|| format!("{}:{}", span.name, attribute.key))
+            })
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        offending_attrs.is_empty(),
+        "exported spans unexpectedly included high-cardinality attrs: {offending_attrs:?}; observed spans: {observed_span_names:?}"
+    );
+    assert!(
+        metrics.iter().any(|metric| {
+            metric.name == "moon.task.cache.hit.total"
+                && metric_has_string_attr(metric, "cache_source", "local-cache")
+        }),
+        "expected moon.task.cache.hit.total to include cache_source=local-cache; observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        metrics.iter().any(|metric| {
+            metric.name == "moon.task.cache.lookup.total"
+                && metric_has_string_and_bool_attrs(
+                    metric,
+                    "cache_source",
+                    "local-cache",
+                    "cache_hit",
+                    true,
+                )
+        }),
+        "expected moon.task.cache.lookup.total to include cache_source=local-cache and cache_hit=true; observed metrics: {observed_metric_names:?}"
+    );
+    assert!(
+        metrics.iter().any(|metric| {
+            metric.name == "moon.task.output.hydration.duration"
+                && metric_has_string_attr(metric, "hydrate_from", "local-cache")
+        }),
+        "expected moon.task.output.hydration.duration to include hydrate_from=local-cache; observed metrics: {observed_metric_names:?}"
+    );
+
+    let _ = shutdown_tx.send(());
+    server.await.unwrap();
+}

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -1,0 +1,68 @@
+# OpenTelemetry
+
+`moon` can now export 3 OTLP signals:
+
+- traces: `MOON_OTEL=true`
+- metrics: `MOON_OTEL=true`
+- logs: `MOON_OTEL_LOGS=true`
+
+All exporters use the standard `OTEL_EXPORTER_OTLP_*` environment variables. The common service
+name override is `MOON_OTEL_SERVICE_NAME`.
+
+Example:
+
+```bash
+MOON_LOG=debug \
+MOON_OTEL=true \
+MOON_OTEL_LOGS=true \
+MOON_OTEL_SERVICE_NAME=moon-dev \
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4317 \
+moon run app:build
+```
+
+## Exported data
+
+Traces currently include task lifecycle spans such as:
+
+- `task_run`
+- `task_hash_generation`
+- `task_cache_lookup`
+- `task_output_hydration`
+- `task_execution`
+- `task_output_archive`
+- `task_concurrency_wait`
+
+Metrics currently include:
+
+- `moon.task.run.total`
+- `moon.task.run.failure.total`
+- `moon.task.run.duration`
+- `moon.task.hash_generation.duration`
+- `moon.task.cache.lookup.total`
+- `moon.task.cache.hit.total`
+- `moon.task.cache.lookup.duration`
+- `moon.task.output.hydration.duration`
+- `moon.task.output.archive.duration`
+- `moon.task.execution.duration`
+- `moon.task.execution.attempts`
+- `moon.task.retry.total`
+- `moon.task.concurrency_wait.duration`
+
+Logs are exported by bridging `tracing` events into OTLP log records. This is separate from the
+existing stderr/file log output, so local logs still work even when OTLP logs are disabled.
+
+## Real collector smoke tests
+
+These scripts are opt-in and Docker-based. They are meant for local verification, not normal CI.
+
+- OTel Collector smoke:
+  - [scripts/otel/smoke-collector.sh](../scripts/otel/smoke-collector.sh)
+  - Proves OTLP traces, metrics, and logs are accepted by a real OpenTelemetry Collector and show
+    up in the collector debug exporter output.
+- Alloy + Loki smoke:
+  - [scripts/otel/smoke-alloy-loki.sh](../scripts/otel/smoke-alloy-loki.sh)
+  - Proves Alloy accepts OTLP traces, metrics, and logs, and that OTLP logs land in Loki and are
+    queryable through the Loki HTTP API.
+
+Both scripts accept image overrides through env vars so versions can be pinned when needed.

--- a/scripts/otel/smoke-alloy-loki.sh
+++ b/scripts/otel/smoke-alloy-loki.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MOON_BIN_OVERRIDE="${MOON_BIN:-}"
+MOON_BIN="${MOON_BIN_OVERRIDE:-$ROOT_DIR/target/debug/moon}"
+ALLOY_IMAGE="${ALLOY_IMAGE:-grafana/alloy:latest}"
+LOKI_IMAGE="${LOKI_IMAGE:-grafana/loki:latest}"
+NETWORK_NAME="${NETWORK_NAME:-moon-otel-smoke}"
+ALLOY_CONTAINER_NAME="${ALLOY_CONTAINER_NAME:-moon-alloy-smoke}"
+LOKI_CONTAINER_NAME="${LOKI_CONTAINER_NAME:-moon-loki-smoke}"
+HOST_OTLP_GRPC_PORT="${HOST_OTLP_GRPC_PORT:-14318}"
+HOST_LOKI_PORT="${HOST_LOKI_PORT:-13100}"
+
+TMP_DIR="$(mktemp -d)"
+WORKSPACE_DIR="$TMP_DIR/workspace"
+ALLOY_CONFIG_PATH="$TMP_DIR/config.alloy"
+MOON_STDOUT="$TMP_DIR/moon.stdout"
+MOON_STDERR="$TMP_DIR/moon.stderr"
+LOKI_RESPONSE_PATH="$TMP_DIR/loki.response.json"
+
+cleanup() {
+	docker rm -f "$ALLOY_CONTAINER_NAME" "$LOKI_CONTAINER_NAME" >/dev/null 2>&1 || true
+	docker network rm "$NETWORK_NAME" >/dev/null 2>&1 || true
+	rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
+
+print_debug_context() {
+	printf '\n--- moon stdout ---\n' >&2
+	if [[ -f "$MOON_STDOUT" ]]; then
+		sed -n '1,200p' "$MOON_STDOUT" >&2
+	fi
+
+	printf '\n--- moon stderr ---\n' >&2
+	if [[ -f "$MOON_STDERR" ]]; then
+		sed -n '1,200p' "$MOON_STDERR" >&2
+	fi
+
+	printf '\n--- alloy logs ---\n' >&2
+	docker logs "$ALLOY_CONTAINER_NAME" 2>&1 | tail -n 200 >&2 || true
+
+	printf '\n--- loki logs ---\n' >&2
+	docker logs "$LOKI_CONTAINER_NAME" 2>&1 | tail -n 200 >&2 || true
+
+	printf '\n--- loki response ---\n' >&2
+	if [[ -f "$LOKI_RESPONSE_PATH" ]]; then
+		sed -n '1,200p' "$LOKI_RESPONSE_PATH" >&2
+	fi
+}
+
+fail() {
+	printf 'alloy+loki smoke failed: %s\n' "$*" >&2
+	print_debug_context
+	exit 1
+}
+
+wait_for_tcp_port() {
+	local host="$1"
+	local port="$2"
+	local description="$3"
+
+	for _ in $(seq 1 30); do
+		if (echo >"/dev/tcp/$host/$port") >/dev/null 2>&1; then
+			return
+		fi
+
+		sleep 1
+	done
+
+	fail "timed out waiting for $description on $host:$port"
+}
+
+wait_for_container_log() {
+	local container="$1"
+	local pattern="$2"
+	local description="$3"
+	local log_path="$TMP_DIR/$container.log"
+
+	for _ in $(seq 1 45); do
+		if docker logs "$container" >"$log_path" 2>&1 && grep -Fq "$pattern" "$log_path"; then
+			return
+		fi
+
+		sleep 1
+	done
+
+	fail "timed out waiting for $description ($pattern)"
+}
+
+wait_for_loki_ready() {
+	for _ in $(seq 1 45); do
+		if curl -fsS "http://127.0.0.1:$HOST_LOKI_PORT/ready" >/dev/null 2>&1; then
+			return
+		fi
+
+		sleep 1
+	done
+
+	fail "timed out waiting for Loki readiness"
+}
+
+wait_for_loki_log() {
+	for _ in $(seq 1 45); do
+		if curl -fsS -G "http://127.0.0.1:$HOST_LOKI_PORT/loki/api/v1/query_range" \
+			--data-urlencode 'query={service_name="moon-alloy-loki-smoke"} |= "Running moon"' \
+			--data-urlencode 'limit=20' >"$LOKI_RESPONSE_PATH" 2>/dev/null &&
+			grep -Fq 'Running moon' "$LOKI_RESPONSE_PATH"; then
+			return
+		fi
+
+		sleep 1
+	done
+
+	fail "timed out waiting for exported moon logs in Loki"
+}
+
+mkdir -p "$WORKSPACE_DIR/.moon" "$WORKSPACE_DIR/app"
+
+cat >"$ALLOY_CONFIG_PATH" <<EOF
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+    max_recv_msg_size = "32MiB"
+  }
+
+  output {
+    traces  = [otelcol.processor.batch.default.input]
+    metrics = [otelcol.processor.batch.default.input]
+    logs = [otelcol.processor.batch.default.input]
+  }
+}
+
+otelcol.processor.batch "default" {
+  output {
+    traces  = [otelcol.exporter.debug.default.input]
+    metrics = [otelcol.exporter.debug.default.input]
+    logs    = [otelcol.exporter.debug.default.input, otelcol.exporter.otlphttp.loki.input]
+  }
+}
+
+otelcol.exporter.debug "default" {
+  verbosity = "detailed"
+}
+
+otelcol.exporter.otlphttp "loki" {
+  client {
+    // Loki accepts OTLP logs on /otlp/v1/logs when the exporter endpoint is /otlp.
+    endpoint = "http://$LOKI_CONTAINER_NAME:3100/otlp"
+  }
+}
+EOF
+
+cat >"$WORKSPACE_DIR/.moon/workspace.yml" <<EOF
+projects:
+  app: app
+EOF
+
+cat >"$WORKSPACE_DIR/app/moon.yml" <<EOF
+tasks:
+  otel:
+    command: bash
+    args:
+      - -c
+      - echo "alloy loki smoke"
+EOF
+
+git -C "$WORKSPACE_DIR" init -q
+git -C "$WORKSPACE_DIR" config user.email "smoke@example.com"
+git -C "$WORKSPACE_DIR" config user.name "moon smoke"
+git -C "$WORKSPACE_DIR" add .
+git -C "$WORKSPACE_DIR" commit -qm "init smoke workspace"
+
+if [[ -z "$MOON_BIN_OVERRIDE" || ! -x "$MOON_BIN" ]]; then
+	cargo build -p moon_cli --bin moon --manifest-path "$ROOT_DIR/Cargo.toml"
+fi
+
+docker network create "$NETWORK_NAME" >/dev/null
+
+docker run -d \
+	--name "$LOKI_CONTAINER_NAME" \
+	--network "$NETWORK_NAME" \
+	-p "$HOST_LOKI_PORT:3100" \
+	"$LOKI_IMAGE" \
+	-config.file=/etc/loki/local-config.yaml >/dev/null
+
+wait_for_loki_ready
+
+docker run -d \
+	--name "$ALLOY_CONTAINER_NAME" \
+	--network "$NETWORK_NAME" \
+	-p "$HOST_OTLP_GRPC_PORT:4317" \
+	-v "$ALLOY_CONFIG_PATH:/etc/alloy/config.alloy:ro" \
+	"$ALLOY_IMAGE" \
+	run --stability.level=experimental /etc/alloy/config.alloy >/dev/null
+
+wait_for_tcp_port "127.0.0.1" "$HOST_OTLP_GRPC_PORT" "Alloy OTLP gRPC receiver"
+
+if ! (
+	cd "$WORKSPACE_DIR"
+	MOON_LOG=debug \
+	OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
+	OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc \
+	OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=grpc \
+	OTEL_EXPORTER_OTLP_LOGS_PROTOCOL=grpc \
+	OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:$HOST_OTLP_GRPC_PORT" \
+	OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://127.0.0.1:$HOST_OTLP_GRPC_PORT" \
+	OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="http://127.0.0.1:$HOST_OTLP_GRPC_PORT" \
+	OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="http://127.0.0.1:$HOST_OTLP_GRPC_PORT" \
+	"$MOON_BIN" --otel --otel-logs --otel-service-name moon-alloy-loki-smoke run app:otel >"$MOON_STDOUT" 2>"$MOON_STDERR"
+); then
+	fail "moon command failed"
+fi
+
+wait_for_container_log "$ALLOY_CONTAINER_NAME" "Span #" "trace export"
+wait_for_container_log "$ALLOY_CONTAINER_NAME" "moon.task.run.total" "task metric export"
+wait_for_container_log "$ALLOY_CONTAINER_NAME" "Running moon" "log export"
+wait_for_loki_log
+
+printf 'alloy+loki smoke passed\n'

--- a/scripts/otel/smoke-collector.sh
+++ b/scripts/otel/smoke-collector.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MOON_BIN_OVERRIDE="${MOON_BIN:-}"
+MOON_BIN="${MOON_BIN_OVERRIDE:-$ROOT_DIR/target/debug/moon}"
+OTELCOL_IMAGE="${OTELCOL_IMAGE:-otel/opentelemetry-collector-contrib:latest}"
+CONTAINER_NAME="${CONTAINER_NAME:-moon-otelcol-smoke}"
+HOST_OTLP_GRPC_PORT="${HOST_OTLP_GRPC_PORT:-14317}"
+
+TMP_DIR="$(mktemp -d)"
+WORKSPACE_DIR="$TMP_DIR/workspace"
+CONFIG_PATH="$TMP_DIR/otelcol.yaml"
+MOON_STDOUT="$TMP_DIR/moon.stdout"
+MOON_STDERR="$TMP_DIR/moon.stderr"
+
+cleanup() {
+	docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+	rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
+
+print_debug_context() {
+	printf '\n--- moon stdout ---\n' >&2
+	if [[ -f "$MOON_STDOUT" ]]; then
+		sed -n '1,200p' "$MOON_STDOUT" >&2
+	fi
+
+	printf '\n--- moon stderr ---\n' >&2
+	if [[ -f "$MOON_STDERR" ]]; then
+		sed -n '1,200p' "$MOON_STDERR" >&2
+	fi
+
+	printf '\n--- collector logs ---\n' >&2
+	docker logs "$CONTAINER_NAME" 2>&1 | tail -n 200 >&2 || true
+
+	for file in traces metrics logs; do
+		printf '\n--- %s export file ---\n' "$file" >&2
+		if [[ -f "$TMP_DIR/$file.json" ]]; then
+			tail -n 120 "$TMP_DIR/$file.json" >&2
+		fi
+	done
+}
+
+fail() {
+	printf 'collector smoke failed: %s\n' "$*" >&2
+	print_debug_context
+	exit 1
+}
+
+wait_for_container_log() {
+	local pattern="$1"
+	local description="$2"
+
+	for _ in $(seq 1 30); do
+		if docker logs "$CONTAINER_NAME" 2>&1 | grep -Fq "$pattern"; then
+			return
+		fi
+
+		sleep 1
+	done
+
+	fail "timed out waiting for $description ($pattern)"
+}
+
+wait_for_file_content() {
+	local path="$1"
+	local pattern="$2"
+	local description="$3"
+
+	for _ in $(seq 1 30); do
+		if [[ -f "$path" ]] && grep -Fq "$pattern" "$path"; then
+			return
+		fi
+
+		sleep 1
+	done
+
+	fail "timed out waiting for $description ($pattern) in $path"
+}
+
+mkdir -p "$WORKSPACE_DIR/app"
+mkdir -p "$WORKSPACE_DIR/.moon"
+chmod 0777 "$TMP_DIR"
+
+cat >"$CONFIG_PATH" <<EOF
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        max_recv_msg_size_mib: 32
+processors:
+  batch: {}
+exporters:
+  debug:
+    verbosity: detailed
+  file/traces:
+    path: /data/traces.json
+  file/metrics:
+    path: /data/metrics.json
+  file/logs:
+    path: /data/logs.json
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug, file/traces]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug, file/metrics]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug, file/logs]
+EOF
+
+cat >"$WORKSPACE_DIR/.moon/workspace.yml" <<EOF
+projects:
+  app: app
+EOF
+
+cat >"$WORKSPACE_DIR/app/moon.yml" <<EOF
+tasks:
+  otel:
+    command: bash
+    args:
+      - -c
+      - echo "collector smoke"
+EOF
+
+git -C "$WORKSPACE_DIR" init -q
+git -C "$WORKSPACE_DIR" config user.email "smoke@example.com"
+git -C "$WORKSPACE_DIR" config user.name "moon smoke"
+git -C "$WORKSPACE_DIR" add .
+git -C "$WORKSPACE_DIR" commit -qm "init smoke workspace"
+
+if [[ -z "$MOON_BIN_OVERRIDE" || ! -x "$MOON_BIN" ]]; then
+	cargo build -p moon_cli --bin moon --manifest-path "$ROOT_DIR/Cargo.toml"
+fi
+
+docker run -d \
+	--name "$CONTAINER_NAME" \
+	-p "$HOST_OTLP_GRPC_PORT:4317" \
+	-v "$CONFIG_PATH:/etc/otelcol/config.yaml:ro" \
+	-v "$TMP_DIR:/data" \
+	"$OTELCOL_IMAGE" \
+	--config=/etc/otelcol/config.yaml >/dev/null
+
+wait_for_container_log "Everything is ready" "collector readiness"
+
+if ! (
+	cd "$WORKSPACE_DIR"
+	MOON_LOG=debug \
+	OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
+	OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc \
+	OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=grpc \
+	OTEL_EXPORTER_OTLP_LOGS_PROTOCOL=grpc \
+	OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:$HOST_OTLP_GRPC_PORT" \
+	OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://127.0.0.1:$HOST_OTLP_GRPC_PORT" \
+	OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="http://127.0.0.1:$HOST_OTLP_GRPC_PORT" \
+	OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="http://127.0.0.1:$HOST_OTLP_GRPC_PORT" \
+	"$MOON_BIN" --otel --otel-logs --otel-service-name moon-collector-smoke run app:otel >"$MOON_STDOUT" 2>"$MOON_STDERR"
+); then
+	fail "moon command failed"
+fi
+
+if ! docker stop "$CONTAINER_NAME" >/dev/null; then
+	fail "collector did not stop cleanly"
+fi
+
+wait_for_file_content "$TMP_DIR/traces.json" "task_run" "task span export"
+wait_for_file_content "$TMP_DIR/metrics.json" "moon.task.run.total" "task metric export"
+wait_for_file_content "$TMP_DIR/logs.json" "Running moon" "log export"
+
+printf 'collector smoke passed\n'


### PR DESCRIPTION
## Summary

Adds OpenTelemetry support for `moon` CLI runs, including traces, metrics, and optional logs.

This builds on the `starbase` OTEL support and instruments task execution, cache behavior, action graph/pipeline work, and process spawning with low-cardinality attributes suitable for collectors and dashboards.

## Dependency

Depends on moonrepo/starbase#186.

## Changes

- Add `--otel`, `--otel-logs`, and `--otel-service-name` CLI support.
- Add env-backed configuration through `MOON_OTEL`, `MOON_OTEL_LOGS`, and `MOON_OTEL_SERVICE_NAME`.
- Instrument task runs, execution attempts, cache lookup/hydration/archive, hash generation, action graph construction, pipeline concurrency waits, and process spawning.
- Add OTEL metrics for task runs, failures, retries, durations, cache lookups/hits, hydration, archive, execution, and concurrency wait.
- Keep OTEL dependencies feature-gated so `--no-default-features` does not pull OpenTelemetry.
- Avoid high-cardinality span attributes such as hashes, command lines, root paths, and full task commands.
- Move local-bin handoff before tracing initialization so Unix `exec` does not bypass tracing shutdown.
- Add OTEL docs and smoke scripts for OpenTelemetry Collector and Grafana Alloy + Loki.
- Add CLI and task-runner OTLP tests, including env-var configuration and cache-hit coverage.

## Verification

- `cargo fmt --check`
- `cargo check -p moon_task_runner --no-default-features`
- `cargo check -p moon_action_pipeline --no-default-features`
- `cargo check -p moon_cli --no-default-features`
- `cargo test -p moon_task_runner --test otel_test`
- `cargo test -p moon_cli --test otel_test`
- `scripts/otel/smoke-collector.sh`
- `scripts/otel/smoke-alloy-loki.sh`