### PR TITLE
Expose task content hash to task processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where proto's `auto-clean` would remove tools installed by moon as they weren't
+  marked as used.
+
 ## 2.2.3
 
 #### 🐞 Fixes

--- a/crates/action-pipeline/src/action_runner.rs
+++ b/crates/action-pipeline/src/action_runner.rs
@@ -118,7 +118,7 @@ pub async fn run_action(
                 })
                 .await?;
 
-            let result = setup_toolchain_plugin(action, action_context, app_context, inner).await;
+            let result = setup_toolchain(action, action_context, app_context, inner).await;
 
             emitter
                 .emit(Event::ToolchainInstalled {

--- a/crates/actions/src/actions/setup_toolchain.rs
+++ b/crates/actions/src/actions/setup_toolchain.rs
@@ -20,7 +20,7 @@ hash_fingerprint!(
 );
 
 #[instrument(skip(action, _action_context, app_context))]
-pub async fn setup_toolchain_plugin(
+pub async fn setup_toolchain(
     action: &mut Action,
     _action_context: Arc<ActionContext>,
     app_context: Arc<AppContext>,

--- a/crates/task-hasher/src/task_fingerprint.rs
+++ b/crates/task-hasher/src/task_fingerprint.rs
@@ -7,6 +7,7 @@ use moon_task::{Target, Task};
 use std::collections::BTreeMap;
 
 hash_fingerprint!(
+    #[derive(Clone)]
     pub struct TaskFingerprint<'task> {
         // Task option `cacheKey`
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/task-hasher/src/task_hashing.rs
+++ b/crates/task-hasher/src/task_hashing.rs
@@ -1,3 +1,4 @@
+use crate::task_fingerprint::TaskFingerprint;
 use crate::task_hasher::TaskHasher;
 use miette::IntoDiagnostic;
 use moon_action::ActionNode;
@@ -18,14 +19,15 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::task::JoinSet;
 
-pub async fn hash_common_task_contents(
-    app_context: &AppContext,
-    action_context: &ActionContext,
-    project: &Project,
-    task: &Task,
-    node: &ActionNode,
-    hasher: &mut ContentHasher,
-) -> miette::Result<()> {
+const TASK_CONTENT_DEP_VALUE: &str = "dependency";
+
+pub async fn generate_common_task_fingerprint<'hash>(
+    app_context: &'hash AppContext,
+    action_context: &'hash ActionContext,
+    project: &'hash Project,
+    task: &'hash Task,
+    node: &'hash ActionNode,
+) -> miette::Result<TaskFingerprint<'hash>> {
     let mut task_hasher = TaskHasher::new(
         app_context,
         project,
@@ -64,13 +66,41 @@ pub async fn hash_common_task_contents(
         task_hasher.hash_env(&inner.env);
     }
 
-    hasher.hash_content(task_hasher.hash())?;
+    Ok(task_hasher.hash())
+}
+
+pub fn generate_task_content_fingerprint<'hash>(
+    common_fingerprint: &TaskFingerprint<'hash>,
+    task: &'hash Task,
+) -> TaskFingerprint<'hash> {
+    let mut fingerprint = common_fingerprint.clone();
+
+    fingerprint.deps = task
+        .deps
+        .iter()
+        .map(|dep| (&dep.target, TASK_CONTENT_DEP_VALUE.to_owned()))
+        .collect();
+
+    fingerprint
+}
+
+pub async fn hash_common_task_contents(
+    app_context: &AppContext,
+    action_context: &ActionContext,
+    project: &Project,
+    task: &Task,
+    node: &ActionNode,
+    hasher: &mut ContentHasher,
+) -> miette::Result<()> {
+    hasher.hash_content(
+        generate_common_task_fingerprint(app_context, action_context, project, task, node).await?,
+    )?;
 
     Ok(())
 }
 
 hash_fingerprint!(
-    struct TaskToolchainFingerprint {
+    pub struct TaskToolchainFingerprint {
         toolchain: String,
 
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -84,12 +114,11 @@ hash_fingerprint!(
     }
 );
 
-pub async fn hash_toolchain_task_contents(
+pub async fn generate_toolchain_task_fingerprints(
     app_context: &Arc<AppContext>,
     project: &Project,
     task: &Task,
-    hasher: &mut ContentHasher,
-) -> miette::Result<()> {
+) -> miette::Result<Vec<TaskToolchainFingerprint>> {
     // Load all toolchains
     let toolchains = app_context
         .toolchain_registry
@@ -128,11 +157,30 @@ pub async fn hash_toolchain_task_contents(
     // Sort the contents so the hash is deterministic
     contents.sort_by(|a, d| a.toolchain.cmp(&d.toolchain));
 
+    Ok(contents)
+}
+
+pub fn hash_toolchain_task_fingerprints(
+    contents: &[TaskToolchainFingerprint],
+    hasher: &mut ContentHasher,
+) -> miette::Result<()> {
     for content in contents {
         hasher.hash_content(content)?;
     }
 
     Ok(())
+}
+
+pub async fn hash_toolchain_task_contents(
+    app_context: &Arc<AppContext>,
+    project: &Project,
+    task: &Task,
+    hasher: &mut ContentHasher,
+) -> miette::Result<()> {
+    hash_toolchain_task_fingerprints(
+        &generate_toolchain_task_fingerprints(app_context, project, task).await?,
+        hasher,
+    )
 }
 
 async fn apply_toolchain(

--- a/crates/task-runner/src/command_builder.rs
+++ b/crates/task-runner/src/command_builder.rs
@@ -57,7 +57,12 @@ impl<'task> CommandBuilder<'task> {
     }
 
     #[instrument(name = "build_command", skip_all)]
-    pub async fn build(mut self, context: &ActionContext, hash: &str) -> miette::Result<Command> {
+    pub async fn build(
+        mut self,
+        context: &ActionContext,
+        hash: &str,
+        content_hash: &str,
+    ) -> miette::Result<Command> {
         debug!(
             task_target = self.task.target.as_str(),
             working_dir = ?self.working_dir,
@@ -75,7 +80,7 @@ impl<'task> CommandBuilder<'task> {
 
         // Order is important!
         self.inject_args(context);
-        self.inject_env(hash)?;
+        self.inject_env(hash, content_hash)?;
         self.inject_shell();
         self.inherit_affected(context)?;
         self.inherit_config();
@@ -116,7 +121,7 @@ impl<'task> CommandBuilder<'task> {
     }
 
     #[instrument(skip_all)]
-    fn inject_env(&mut self, hash: &str) -> miette::Result<()> {
+    fn inject_env(&mut self, hash: &str, content_hash: &str) -> miette::Result<()> {
         let task = self.task;
         let mut moon_env = FxHashMap::<String, Option<String>>::default();
 
@@ -158,6 +163,10 @@ impl<'task> CommandBuilder<'task> {
                 ),
             ),
             ("MOON_TASK_ID".into(), Some(task.id.to_string())),
+            (
+                "MOON_TASK_CONTENT_HASH".into(),
+                Some(content_hash.to_string()),
+            ),
             ("MOON_TASK_HASH".into(), Some(hash.to_string())),
             ("MOON_TARGET".into(), Some(task.target.to_string())),
             (

--- a/crates/task-runner/src/task_runner.rs
+++ b/crates/task-runner/src/task_runner.rs
@@ -26,6 +26,12 @@ pub struct TaskRunResult {
     pub operations: OperationList,
 }
 
+#[derive(Debug)]
+pub struct TaskHashes {
+    pub content_hash: String,
+    pub hash: String,
+}
+
 pub struct TaskRunner<'task> {
     app_context: &'task Arc<AppContext>,
     project: &'task Arc<Project>,
@@ -39,6 +45,7 @@ pub struct TaskRunner<'task> {
     pub operations: OperationList,
     pub remote_state: Option<ActionState<'task>>,
     pub report_item: TaskReportItem,
+    pub task_content_hash: Option<String>,
     pub target_state: Option<TargetState>,
 }
 
@@ -72,6 +79,7 @@ impl<'task> TaskRunner<'task> {
                 output_style: task.options.output_style,
                 ..Default::default()
             },
+            task_content_hash: None,
             target_state: None,
             task,
             app_context,
@@ -92,7 +100,7 @@ impl<'task> TaskRunner<'task> {
         }
 
         // Always generate a hash
-        let hash = self.generate_hash(context, node).await?;
+        let hashes = self.generate_hashes(context, node).await?;
 
         if self.is_cache_enabled() {
             debug!(
@@ -101,15 +109,15 @@ impl<'task> TaskRunner<'task> {
             );
 
             // Exit early if this build has already been cached/hashed
-            if self.hydrate(&hash).await? {
-                return Ok(Some(hash));
+            if self.hydrate(&hashes.hash).await? {
+                return Ok(Some(hashes.hash));
             }
 
             // Otherwise build and execute the command as a child process
             self.execute(context, node).await?;
 
             // If we created outputs, archive them into the cache
-            self.archive(&hash).await?;
+            self.archive(&hashes.hash).await?;
         } else {
             debug!(
                 task_target = self.task.target.as_str(),
@@ -120,7 +128,7 @@ impl<'task> TaskRunner<'task> {
             self.execute(context, node).await?;
         }
 
-        Ok(Some(hash))
+        Ok(Some(hashes.hash))
     }
 
     #[instrument(skip(self, context))]
@@ -371,6 +379,15 @@ impl<'task> TaskRunner<'task> {
         context: &ActionContext,
         node: &ActionNode,
     ) -> miette::Result<String> {
+        Ok(self.generate_hashes(context, node).await?.hash)
+    }
+
+    #[instrument(skip_all)]
+    pub async fn generate_hashes(
+        &mut self,
+        context: &ActionContext,
+        node: &ActionNode,
+    ) -> miette::Result<TaskHashes> {
         debug!(
             task_target = self.task.target.as_str(),
             "Generating a unique hash for this task"
@@ -378,31 +395,42 @@ impl<'task> TaskRunner<'task> {
 
         let hash_engine = &self.app_context.cache_engine.hash;
         let mut hasher = hash_engine.create_hasher(node.label());
+        let mut content_hasher = hash_engine.create_hasher(format!("{}-content", node.label()));
         let mut operation = Operation::hash_generation();
 
         // Hash common fields
-        hash_common_task_contents(
+        let common_fingerprint = generate_common_task_fingerprint(
             self.app_context,
             context,
             self.project,
             self.task,
             node,
-            &mut hasher,
         )
         .await?;
 
+        hasher.hash_content(&common_fingerprint)?;
+        content_hasher.hash_content(generate_task_content_fingerprint(
+            &common_fingerprint,
+            self.task,
+        ))?;
+
         // Hash toolchain fields
-        hash_toolchain_task_contents(self.app_context, self.project, self.task, &mut hasher)
-            .await?;
+        let toolchain_fingerprints =
+            generate_toolchain_task_fingerprints(self.app_context, self.project, self.task).await?;
+
+        hash_toolchain_task_fingerprints(&toolchain_fingerprints, &mut hasher)?;
+        hash_toolchain_task_fingerprints(&toolchain_fingerprints, &mut content_hasher)?;
 
         // Generate the hash and persist values
         let hash = hash_engine.save_manifest(&mut hasher)?;
+        let content_hash = content_hasher.generate_hash()?;
 
         operation.meta.set_hash(&hash);
         operation.finish(ActionStatus::Passed);
 
         self.operations.push(operation);
         self.report_item.hash = Some(hash.clone());
+        self.task_content_hash = Some(content_hash.clone());
 
         // Store the hash digest for remote caching
         if RemoteService::is_enabled() {
@@ -422,10 +450,11 @@ impl<'task> TaskRunner<'task> {
         debug!(
             task_target = self.task.target.as_str(),
             hash = &hash,
+            content_hash = &content_hash,
             "Generated a unique hash"
         );
 
-        Ok(hash)
+        Ok(TaskHashes { content_hash, hash })
     }
 
     #[instrument(skip(self, context, node))]
@@ -451,6 +480,7 @@ impl<'task> TaskRunner<'task> {
             .build(
                 context,
                 self.report_item.hash.as_deref().unwrap_or_default(),
+                self.task_content_hash.as_deref().unwrap_or_default(),
             )
             .await?;
 

--- a/crates/task-runner/tests/command_builder_test.rs
+++ b/crates/task-runner/tests/command_builder_test.rs
@@ -300,6 +300,18 @@ mod command_builder {
         }
 
         #[tokio::test(flavor = "multi_thread")]
+        async fn sets_task_hashes() {
+            let container = TaskRunnerContainer::new("builder", "base").await;
+            let command = container.create_command(ActionContext::default()).await;
+
+            assert_eq!(get_env(&command, "MOON_TASK_HASH").unwrap(), "abc123");
+            assert_eq!(
+                get_env(&command, "MOON_TASK_CONTENT_HASH").unwrap(),
+                "content123"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
         async fn inherits_when_a_task_dep() {
             let container = TaskRunnerContainer::new("builder", "base").await;
             let command = container

--- a/crates/task-runner/tests/task_runner_test.rs
+++ b/crates/task-runner/tests/task_runner_test.rs
@@ -655,6 +655,57 @@ mod task_runner {
         }
 
         #[tokio::test(flavor = "multi_thread")]
+        async fn generates_a_content_hash() {
+            let container = TaskRunnerContainer::new("runner", "base").await;
+            container.sandbox.enable_git();
+
+            let mut runner = container.create_runner();
+            let context = ActionContext::default();
+            let node = container.create_action_node();
+
+            let hashes = runner.generate_hashes(&context, &node).await.unwrap();
+
+            assert_eq!(hashes.hash.len(), 64);
+            assert_eq!(hashes.content_hash.len(), 64);
+            assert_eq!(
+                runner.task_content_hash.as_ref(),
+                Some(&hashes.content_hash)
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn excludes_dependency_hashes_from_content_hash() {
+            let container = TaskRunnerContainer::new("runner", "has-deps").await;
+            container.sandbox.enable_git();
+
+            let node = container.create_action_node();
+            let dep_target = container.task.deps[0].target.clone();
+            let before_context = ActionContext::default();
+            before_context
+                .target_states
+                .insert_sync(dep_target.clone(), TargetState::Passed("hash123".into()))
+                .unwrap();
+
+            let mut runner = container.create_runner();
+            let before_hashes = runner
+                .generate_hashes(&before_context, &node)
+                .await
+                .unwrap();
+
+            let after_context = ActionContext::default();
+            after_context
+                .target_states
+                .insert_sync(dep_target, TargetState::Passed("hash456".into()))
+                .unwrap();
+
+            let mut runner = container.create_runner();
+            let after_hashes = runner.generate_hashes(&after_context, &node).await.unwrap();
+
+            assert_ne!(before_hashes.hash, after_hashes.hash);
+            assert_eq!(before_hashes.content_hash, after_hashes.content_hash);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
         async fn generates_a_different_hash_via_passthrough_args() {
             let container = TaskRunnerContainer::new("runner", "base").await;
             container.sandbox.enable_git();

--- a/crates/task-runner/tests/utils.rs
+++ b/crates/task-runner/tests/utils.rs
@@ -176,6 +176,9 @@ impl TaskRunnerContainer {
     ) -> Command {
         let mut builder = CommandBuilder::new(&self.app_context, &self.project, task, node);
         builder.set_env_bag(&self.env_bag);
-        builder.build(context, "abc123").await.unwrap()
+        builder
+            .build(context, "abc123", "content123")
+            .await
+            .unwrap()
     }
 }

--- a/crates/toolchain-plugin/src/toolchain_plugin.rs
+++ b/crates/toolchain-plugin/src/toolchain_plugin.rs
@@ -535,6 +535,11 @@ impl ToolchainPlugin {
                     // proto, like Rust (via rustup)
                     manager.sync_manifest().await?;
                 }
+
+                // Track used at so that proto's auto-clean doesn't remove it
+                if let Some(version) = &spec.version {
+                    tool.inventory.create_product(version).track_used_at()?;
+                }
             }
 
             // Pre-load the tool plugin so that task executions

--- a/website/docs/concepts/cache.mdx
+++ b/website/docs/concepts/cache.mdx
@@ -32,6 +32,12 @@ Our smart hashing currently takes the following sources into account:
   - `package.json` dependencies (including development and peer).
   - `tsconfig.json` compiler options (when applicable).
 
+When running a task, moon exposes the full hash as `MOON_TASK_HASH`. It also exposes
+`MOON_TASK_CONTENT_HASH`, which hashes the same task-local content and toolchain information but
+excludes upstream dependency task result hashes. This value is intended for external command wrappers
+that want to namespace their own runtime-observed cache experiments without changing moon's built-in
+cache behavior.
+
 :::caution
 
 Be aware that greedy inputs (`**/*`, the default) will include _everything_ in the target directory


### PR DESCRIPTION
## Summary

Expose `MOON_TASK_CONTENT_HASH` to task child processes.

This hash uses Moon’s task-local and toolchain hash material, but excludes upstream dependency task result hashes. Moon’s existing cache behavior remains unchanged and continues to use `MOON_TASK_HASH` for hydrate/archive/remote cache behavior.

This gives external command wrappers a Moon-native static key for runtime-observed cache experiments without requiring them to reimplement Moon’s task hashing logic.

## Changes

- Generate both the full task hash and task content hash during task hash generation
- Preserve dependency edge identity in the content hash while excluding dependency result hash values
- Inject `MOON_TASK_CONTENT_HASH` alongside `MOON_TASK_HASH`
- Add tests for env injection and dep-hash exclusion behavior
- Document the new env var in cache docs