### PR TITLE
fix(cli): clear inherited O_NONBLOCK on stdio at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5194,6 +5194,7 @@ dependencies = [
  "clap",
  "extism",
  "httpmock",
+ "libc",
  "liblzma",
  "mimalloc",
  "moon_affected",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -51,6 +51,9 @@ wiggle = "~41.0.4"
 # Overrides
 liblzma = { version = "0.4.6", features = ["static"] }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 moon_affected = { path = "../affected" }
 moon_cache = { path = "../cache" }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,6 @@
 mod lookup;
 mod shared;
+mod stdio;
 
 use starbase::MainResult;
 use std::env;

--- a/crates/cli/src/shared.rs
+++ b/crates/cli/src/shared.rs
@@ -82,6 +82,7 @@ fn exec_local_bin(mut command: Command) -> std::io::Result<u8> {
 }
 
 pub async fn run_cli(args: Vec<OsString>) -> MainResult {
+    crate::stdio::normalize_stdio_blocking();
     sigpipe::reset();
 
     // Detect info about the current process

--- a/crates/cli/src/stdio.rs
+++ b/crates/cli/src/stdio.rs
@@ -19,11 +19,7 @@
 pub fn normalize_stdio_blocking() {
     use std::os::raw::c_int;
 
-    for fd in [
-        libc::STDIN_FILENO,
-        libc::STDOUT_FILENO,
-        libc::STDERR_FILENO,
-    ] {
+    for fd in [libc::STDIN_FILENO, libc::STDOUT_FILENO, libc::STDERR_FILENO] {
         clear_nonblock_on_fd(fd as c_int);
     }
 }
@@ -124,11 +120,7 @@ mod tests {
         // either blocking or were not modifiable (e.g. not yet open).
         normalize_stdio_blocking();
 
-        for fd in [
-            libc::STDIN_FILENO,
-            libc::STDOUT_FILENO,
-            libc::STDERR_FILENO,
-        ] {
+        for fd in [libc::STDIN_FILENO, libc::STDOUT_FILENO, libc::STDERR_FILENO] {
             let flags = get_flags(fd);
             if flags >= 0 {
                 assert_eq!(

--- a/crates/cli/src/stdio.rs
+++ b/crates/cli/src/stdio.rs
@@ -1,0 +1,142 @@
+// Standard I/O hardening for moon's CLI.
+//
+// Some environments (notably the GitHub Actions log forwarder) hand
+// child processes stdio file descriptors with `O_NONBLOCK` set on the
+// underlying open file description. Rust's standard library — and any
+// crate that calls `write_all` on `io::stdout()` / `io::stderr()` —
+// assumes blocking semantics. Under sustained output, a non-blocking
+// stdout pipe returns `EAGAIN` (`io::ErrorKind::WouldBlock`) which
+// propagates as a fatal error, causing moon to exit 1 mid-task with
+// `Error: console::write_failed`.
+//
+// See: moonrepo/moon#2465 and the EAGAIN follow-up. starbase's console
+// writer was patched separately to retry on `WouldBlock`, but moon
+// prints from many writers (`println!`, panic hook, `tracing`,
+// `miette`, third-party crates) that we can't audit individually.
+// Clearing `O_NONBLOCK` once at startup immunizes them all.
+
+#[cfg(unix)]
+pub fn normalize_stdio_blocking() {
+    use std::os::raw::c_int;
+
+    for fd in [
+        libc::STDIN_FILENO,
+        libc::STDOUT_FILENO,
+        libc::STDERR_FILENO,
+    ] {
+        clear_nonblock_on_fd(fd as c_int);
+    }
+}
+
+#[cfg(not(unix))]
+pub fn normalize_stdio_blocking() {}
+
+#[cfg(unix)]
+fn clear_nonblock_on_fd(fd: std::os::raw::c_int) {
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL, 0);
+        if flags < 0 {
+            return;
+        }
+        if (flags & libc::O_NONBLOCK) != 0 {
+            let _ = libc::fcntl(fd, libc::F_SETFL, flags & !libc::O_NONBLOCK);
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::raw::c_int;
+
+    fn get_flags(fd: c_int) -> c_int {
+        unsafe { libc::fcntl(fd, libc::F_GETFL, 0) }
+    }
+
+    fn set_nonblock(fd: c_int) {
+        let flags = get_flags(fd);
+        assert!(flags >= 0);
+        let rc = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+        assert_eq!(rc, 0);
+    }
+
+    fn make_pipe() -> (c_int, c_int) {
+        let mut fds = [0_i32; 2];
+        let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert_eq!(rc, 0);
+        (fds[0], fds[1])
+    }
+
+    fn close(fd: c_int) {
+        unsafe { libc::close(fd) };
+    }
+
+    // Regression for moon #2465 EAGAIN variant: an fd that arrived with
+    // O_NONBLOCK set must come out blocking after normalization.
+    #[test]
+    fn clears_o_nonblock_when_set() {
+        let (r, w) = make_pipe();
+        set_nonblock(w);
+        assert_ne!(get_flags(w) & libc::O_NONBLOCK, 0, "precondition");
+
+        clear_nonblock_on_fd(w);
+
+        assert_eq!(
+            get_flags(w) & libc::O_NONBLOCK,
+            0,
+            "O_NONBLOCK should be cleared"
+        );
+
+        close(r);
+        close(w);
+    }
+
+    // Idempotent on already-blocking fds: must not flip them or error.
+    #[test]
+    fn leaves_blocking_fd_alone() {
+        let (r, w) = make_pipe();
+        let before = get_flags(w);
+        assert_eq!(before & libc::O_NONBLOCK, 0, "precondition");
+
+        clear_nonblock_on_fd(w);
+
+        let after = get_flags(w);
+        assert_eq!(before, after, "flags should be unchanged");
+
+        close(r);
+        close(w);
+    }
+
+    // Bad fd must not crash — fcntl returns -1, we ignore.
+    #[test]
+    fn bad_fd_is_silent() {
+        clear_nonblock_on_fd(-1);
+        clear_nonblock_on_fd(99999);
+    }
+
+    // Smoke test of the public entry point: must not panic regardless
+    // of inherited stdio state, and must leave fds 0/1/2 blocking.
+    #[test]
+    fn normalize_stdio_blocking_clears_inherited_nonblock() {
+        // We can't safely flip the real stdio fds in the test process
+        // (it would affect cargo's own output). Instead, validate the
+        // observable post-condition: after the call, fds 0/1/2 are
+        // either blocking or were not modifiable (e.g. not yet open).
+        normalize_stdio_blocking();
+
+        for fd in [
+            libc::STDIN_FILENO,
+            libc::STDOUT_FILENO,
+            libc::STDERR_FILENO,
+        ] {
+            let flags = get_flags(fd);
+            if flags >= 0 {
+                assert_eq!(
+                    flags & libc::O_NONBLOCK,
+                    0,
+                    "fd {fd} should be blocking after normalize_stdio_blocking"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the EAGAIN variant of #2465.

When moon is invoked from an environment that hands children file descriptors with `O_NONBLOCK` set on the underlying open file description — most notably the GitHub Actions log forwarder — Rust's `write_all` returns `WouldBlock` mid-task and the binary exits 1 with `Error: console::write_failed` / `Resource temporarily unavailable (os error 11)`. The original bug report observed this in ~13% of CI invocations across many unrelated branches.

This patch adds a tiny unix-only `normalize_stdio_blocking()` that runs once at the top of `run_cli` (before any output) and clears `O_NONBLOCK` from fds 0, 1, 2 if it's set. After that, every writer in the process — `println!`, the panic hook, `tracing`, `miette`, `clap_complete`, `starbase_console`, third-party crates — sees blocking stdio and can use `write_all` correctly. SIGPIPE handling at `crates/cli/src/shared.rs:85` (`sigpipe::reset()`) already covered the EPIPE side of #2465; no change needed there.

## Why a process-wide clear, not per-writer retry

The starbase console writer was the most visible failure site, but it isn't the only one. While validating this fix, removing `normalize_stdio_blocking()` and replaying the same workload (`moon completions --shell bash` piped to a slow reader) crashed inside `clap_complete::generate`'s writer instead — different crate, same EAGAIN, same fatal exit. Auditing every `write_all` in moon's transitive dep graph isn't tractable; clearing the OS-level flag once is.

Trade-off: `fcntl(F_SETFL)` modifies the open file description, which is shared with the parent's pipe. In practice `cargo`, `rustc`, and coreutils all rely on this being safe. The parent set `O_NONBLOCK` incorrectly for a child that doesn't expect it; restoring blocking semantics matches what stdlib assumes.

## Tests

`crates/cli/src/stdio.rs` adds 4 regression tests:

- `clears_o_nonblock_when_set` — opens a real pipe via `libc::pipe`, sets `O_NONBLOCK` on the write end, calls the helper, asserts the flag is cleared.
- `leaves_blocking_fd_alone` — idempotency on already-blocking fds.
- `bad_fd_is_silent` — graceful handling of invalid fds (no panic).
- `normalize_stdio_blocking_clears_inherited_nonblock` — public-API smoke test asserting fds 0/1/2 are blocking after the call.

`libc` is added under `[target.'cfg(unix)'.dependencies]` so Windows builds are unaffected.

## Validation against the original bug

End-to-end repro using a wrapper that flips stdout to `O_NONBLOCK` and execs moon — exact GHA-style condition with `moon completions --shell bash | (sleep 1; cat > /dev/null)`:

| Build | Exit | Stderr |
|---|---|---|
| **Without this patch** | 1 | `Error: ... os error 11, kind: WouldBlock` (panicked in `clap_complete`) |
| **With this patch** | 0 | (empty) |

A companion library-side fix is open at [moonrepo/starbase#187](https://github.com/moonrepo/starbase/pull/187). It is not required for this PR — clearing `O_NONBLOCK` here neutralizes EAGAIN for every writer in the process, including third-party crates.

## Test plan
- [x] `cargo test -p moon_cli --bin moon stdio::` — 4/4 pass
- [x] `cargo build -p moon_cli --bin moon` — clean (no new warnings)
- [x] `cargo clippy -p moon_cli --bin moon --no-deps` — clean
- [x] End-to-end repro: patched moon survives `O_NONBLOCK` stdout + slow reader; unpatched moon dies with `os error 11`