### PR TITLE
fix: Fix upstream-none dependency hashing

### DIFF
--- a/crates/action-context/src/lib.rs
+++ b/crates/action-context/src/lib.rs
@@ -43,6 +43,9 @@ pub struct ActionContext {
     #[serde(skip)]
     pub named_mutexes: scc::HashMap<String, Arc<Mutex<()>>>,
 
+    /// Dependency edges that were intentionally ignored by graph options.
+    pub ignored_dependencies: FxHashMap<Target, FxHashSet<Target>>,
+
     /// Additional arguments passed after `--` to passthrough.
     pub passthrough_args: Vec<String>,
 
@@ -89,6 +92,16 @@ impl ActionContext {
 
     pub fn is_primary_target<T: AsRef<Target>>(&self, target: T) -> bool {
         self.primary_targets.contains(target.as_ref())
+    }
+
+    pub fn is_dependency_ignored<T: AsRef<Target>, D: AsRef<Target>>(
+        &self,
+        target: T,
+        dependency: D,
+    ) -> bool {
+        self.ignored_dependencies
+            .get(target.as_ref())
+            .is_some_and(|dependencies| dependencies.contains(dependency.as_ref()))
     }
 
     pub fn set_target_state<T: AsRef<Target>>(&self, target: T, state: TargetState) {

--- a/crates/action-context/src/lib.rs
+++ b/crates/action-context/src/lib.rs
@@ -44,6 +44,7 @@ pub struct ActionContext {
     pub named_mutexes: scc::HashMap<String, Arc<Mutex<()>>>,
 
     /// Dependency edges that were intentionally ignored by graph options.
+    #[serde(default, skip_serializing_if = "FxHashMap::is_empty")]
     pub ignored_dependencies: FxHashMap<Target, FxHashSet<Target>>,
 
     /// Additional arguments passed after `--` to passthrough.

--- a/crates/action-graph/src/action_graph_builder.rs
+++ b/crates/action-graph/src/action_graph_builder.rs
@@ -132,7 +132,7 @@ pub struct ActionGraphBuilder<'query> {
     changed_files: Option<FxHashSet<WorkspaceRelativePathBuf>>,
 
     // Target tracking
-    ignored_dependency_targets: FxHashSet<Target>,
+    ignored_dependencies: FxHashMap<Target, FxHashSet<Target>>,
     passthrough_targets: FxHashSet<Target>,
     primary_targets: FxHashSet<Target>,
 }
@@ -152,7 +152,7 @@ impl<'query> ActionGraphBuilder<'query> {
             graph: Dag::new(),
             nodes: FxHashMap::default(),
             options,
-            ignored_dependency_targets: FxHashSet::default(),
+            ignored_dependencies: FxHashMap::default(),
             passthrough_targets: FxHashSet::default(),
             primary_targets: FxHashSet::default(),
             changed_files: None,
@@ -172,10 +172,8 @@ impl<'query> ActionGraphBuilder<'query> {
             }
         }
 
-        if !self.ignored_dependency_targets.is_empty() {
-            for target in mem::take(&mut self.ignored_dependency_targets) {
-                context.set_target_state(target, TargetState::Passthrough);
-            }
+        if !self.ignored_dependencies.is_empty() {
+            context.ignored_dependencies = mem::take(&mut self.ignored_dependencies);
         }
 
         if !self.primary_targets.is_empty() {
@@ -992,8 +990,10 @@ impl<'query> ActionGraphBuilder<'query> {
 
                 edges.extend(Box::pin(self.run_task_dependencies(task, &child_reqs, state)).await?);
             } else {
-                self.ignored_dependency_targets
-                    .extend(task.deps.iter().map(|dep| dep.target.clone()));
+                self.ignored_dependencies.insert(
+                    task.target.clone(),
+                    task.deps.iter().map(|dep| dep.target.clone()).collect(),
+                );
             }
         }
 

--- a/crates/action-graph/src/action_graph_builder.rs
+++ b/crates/action-graph/src/action_graph_builder.rs
@@ -963,8 +963,22 @@ impl<'query> ActionGraphBuilder<'query> {
             id: None,
         });
 
+        let had_ignored_dependencies = if should_run_dependencies {
+            self.ignored_dependencies.remove(&task.target).is_some()
+        } else {
+            false
+        };
+
         // Check if the node exists to avoid all the overhead below
         if let Some(index) = self.get_index_from_node(&node) {
+            if had_ignored_dependencies && !task.deps.is_empty() {
+                child_reqs.skip_affected = true;
+
+                let edges = Box::pin(self.run_task_dependencies(task, &child_reqs, state)).await?;
+
+                self.link_optional_requirements(index, edges)?;
+            }
+
             return Ok(Some(index));
         }
 

--- a/crates/action-graph/src/action_graph_builder.rs
+++ b/crates/action-graph/src/action_graph_builder.rs
@@ -132,6 +132,7 @@ pub struct ActionGraphBuilder<'query> {
     changed_files: Option<FxHashSet<WorkspaceRelativePathBuf>>,
 
     // Target tracking
+    ignored_dependency_targets: FxHashSet<Target>,
     passthrough_targets: FxHashSet<Target>,
     primary_targets: FxHashSet<Target>,
 }
@@ -151,6 +152,7 @@ impl<'query> ActionGraphBuilder<'query> {
             graph: Dag::new(),
             nodes: FxHashMap::default(),
             options,
+            ignored_dependency_targets: FxHashSet::default(),
             passthrough_targets: FxHashSet::default(),
             primary_targets: FxHashSet::default(),
             changed_files: None,
@@ -166,6 +168,12 @@ impl<'query> ActionGraphBuilder<'query> {
 
         if !self.passthrough_targets.is_empty() {
             for target in mem::take(&mut self.passthrough_targets) {
+                context.set_target_state(target, TargetState::Passthrough);
+            }
+        }
+
+        if !self.ignored_dependency_targets.is_empty() {
+            for target in mem::take(&mut self.ignored_dependency_targets) {
                 context.set_target_state(target, TargetState::Passthrough);
             }
         }
@@ -978,10 +986,15 @@ impl<'query> ActionGraphBuilder<'query> {
         // Insert and then link edges
         let index = self.insert_node(node);
 
-        if !task.deps.is_empty() && should_run_dependencies {
-            child_reqs.skip_affected = true;
+        if !task.deps.is_empty() {
+            if should_run_dependencies {
+                child_reqs.skip_affected = true;
 
-            edges.extend(Box::pin(self.run_task_dependencies(task, &child_reqs, state)).await?);
+                edges.extend(Box::pin(self.run_task_dependencies(task, &child_reqs, state)).await?);
+            } else {
+                self.ignored_dependency_targets
+                    .extend(task.deps.iter().map(|dep| dep.target.clone()));
+            }
         }
 
         self.link_optional_requirements(index, edges)?;

--- a/crates/action-graph/tests/action_graph_builder_test.rs
+++ b/crates/action-graph/tests/action_graph_builder_test.rs
@@ -1702,6 +1702,46 @@ mod action_graph_builder {
             }
 
             #[tokio::test(flavor = "multi_thread")]
+            async fn clears_skipped_deps_when_task_is_revisited_in_scope() {
+                let sandbox = create_sandbox("tasks");
+                let mut container = ActionGraphContainer::new(sandbox.path());
+
+                let wg = container.create_workspace_graph().await;
+                let mut builder = container.create_builder(wg.clone()).await;
+
+                let parent = wg.get_task_from_project("deps", "chain2").unwrap();
+                let task = wg.get_task_from_project("deps", "chain3").unwrap();
+
+                let reqs = RunRequirements {
+                    dependencies: UpstreamScope::Direct,
+                    dependents: DownstreamScope::None,
+                    ..RunRequirements::default()
+                };
+
+                builder.run_task(&parent, &reqs).await.unwrap();
+                builder.run_task(&task, &reqs).await.unwrap();
+
+                let (context, graph) = builder.build();
+
+                assert!(
+                    !context
+                        .ignored_dependencies
+                        .contains_key(&Target::parse("deps:chain3").unwrap())
+                );
+                assert_eq!(
+                    context.ignored_dependencies,
+                    FxHashMap::from_iter([(
+                        Target::parse("deps:chain4").unwrap(),
+                        FxHashSet::from_iter([Target::parse("deps:chain5").unwrap()])
+                    )])
+                );
+                assert!(topo(graph).into_iter().any(|node| matches!(
+                    node,
+                    ActionNode::RunTask(inner) if inner.target == Target::parse("deps:chain4").unwrap()
+                )));
+            }
+
+            #[tokio::test(flavor = "multi_thread")]
             async fn can_set_direct_depth_affected() {
                 let sandbox = create_sandbox("tasks");
                 let mut container = ActionGraphContainer::new(sandbox.path());

--- a/crates/action-graph/tests/action_graph_builder_test.rs
+++ b/crates/action-graph/tests/action_graph_builder_test.rs
@@ -1572,7 +1572,7 @@ mod action_graph_builder {
             }
 
             #[tokio::test(flavor = "multi_thread")]
-            async fn marks_skipped_deps_as_passthrough_for_none_depth() {
+            async fn tracks_skipped_deps_for_none_depth() {
                 let sandbox = create_sandbox("tasks");
                 let mut container = ActionGraphContainer::new(sandbox.path());
 
@@ -1596,10 +1596,10 @@ mod action_graph_builder {
                 let (context, _) = builder.build();
 
                 assert_eq!(
-                    context.get_target_states(),
+                    context.ignored_dependencies,
                     FxHashMap::from_iter([(
-                        Target::parse("deps:chain4").unwrap(),
-                        TargetState::Passthrough
+                        Target::parse("deps:chain3").unwrap(),
+                        FxHashSet::from_iter([Target::parse("deps:chain4").unwrap()])
                     )])
                 );
             }
@@ -1669,7 +1669,7 @@ mod action_graph_builder {
             }
 
             #[tokio::test(flavor = "multi_thread")]
-            async fn marks_skipped_transitive_deps_as_passthrough_for_direct_depth() {
+            async fn tracks_skipped_transitive_deps_for_direct_depth() {
                 let sandbox = create_sandbox("tasks");
                 let mut container = ActionGraphContainer::new(sandbox.path());
 
@@ -1693,10 +1693,10 @@ mod action_graph_builder {
                 let (context, _) = builder.build();
 
                 assert_eq!(
-                    context.get_target_states(),
+                    context.ignored_dependencies,
                     FxHashMap::from_iter([(
-                        Target::parse("deps:chain5").unwrap(),
-                        TargetState::Passthrough
+                        Target::parse("deps:chain4").unwrap(),
+                        FxHashSet::from_iter([Target::parse("deps:chain5").unwrap()])
                     )])
                 );
             }

--- a/crates/action-graph/tests/action_graph_builder_test.rs
+++ b/crates/action-graph/tests/action_graph_builder_test.rs
@@ -1572,6 +1572,39 @@ mod action_graph_builder {
             }
 
             #[tokio::test(flavor = "multi_thread")]
+            async fn marks_skipped_deps_as_passthrough_for_none_depth() {
+                let sandbox = create_sandbox("tasks");
+                let mut container = ActionGraphContainer::new(sandbox.path());
+
+                let wg = container.create_workspace_graph().await;
+                let mut builder = container.create_builder(wg.clone()).await;
+
+                let task = wg.get_task_from_project("deps", "chain3").unwrap();
+
+                builder
+                    .run_task(
+                        &task,
+                        &RunRequirements {
+                            dependencies: UpstreamScope::None,
+                            dependents: DownstreamScope::None,
+                            ..RunRequirements::default()
+                        },
+                    )
+                    .await
+                    .unwrap();
+
+                let (context, _) = builder.build();
+
+                assert_eq!(
+                    context.get_target_states(),
+                    FxHashMap::from_iter([(
+                        Target::parse("deps:chain4").unwrap(),
+                        TargetState::Passthrough
+                    )])
+                );
+            }
+
+            #[tokio::test(flavor = "multi_thread")]
             async fn can_set_none_depth_affected() {
                 let sandbox = create_sandbox("tasks");
                 let mut container = ActionGraphContainer::new(sandbox.path());
@@ -1633,6 +1666,39 @@ mod action_graph_builder {
                 let (_, graph) = builder.build();
 
                 assert_snapshot!(graph.to_dot());
+            }
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn marks_skipped_transitive_deps_as_passthrough_for_direct_depth() {
+                let sandbox = create_sandbox("tasks");
+                let mut container = ActionGraphContainer::new(sandbox.path());
+
+                let wg = container.create_workspace_graph().await;
+                let mut builder = container.create_builder(wg.clone()).await;
+
+                let task = wg.get_task_from_project("deps", "chain3").unwrap();
+
+                builder
+                    .run_task(
+                        &task,
+                        &RunRequirements {
+                            dependencies: UpstreamScope::Direct,
+                            dependents: DownstreamScope::None,
+                            ..RunRequirements::default()
+                        },
+                    )
+                    .await
+                    .unwrap();
+
+                let (context, _) = builder.build();
+
+                assert_eq!(
+                    context.get_target_states(),
+                    FxHashMap::from_iter([(
+                        Target::parse("deps:chain5").unwrap(),
+                        TargetState::Passthrough
+                    )])
+                );
             }
 
             #[tokio::test(flavor = "multi_thread")]

--- a/crates/cli/tests/exec_test.rs
+++ b/crates/cli/tests/exec_test.rs
@@ -989,6 +989,37 @@ mod exec {
             }
 
             #[test]
+            fn upstream_none_ignores_dependency_hashes() {
+                let sandbox = create_pipeline_sandbox();
+
+                sandbox.create_file(
+                    "a/moon.yml",
+                    r#"tasks:
+  task:
+    command: 'exit 0'
+    options:
+      cache: false
+"#,
+                );
+                sandbox.create_file(
+                    "b/moon.yml",
+                    r#"tasks:
+  task:
+    command: 'exit 0'
+    deps: ['a:task']
+    options:
+      cache: false
+"#,
+                );
+
+                let assert = sandbox.run_bin(|cmd| {
+                    cmd.arg("exec").arg("--upstream=none").arg("b:task");
+                });
+
+                assert.success();
+            }
+
+            #[test]
             fn downstream_direct() {
                 let sandbox = create_pipeline_sandbox();
 

--- a/crates/task-hasher/src/task_hashing.rs
+++ b/crates/task-hasher/src/task_hashing.rs
@@ -41,6 +41,11 @@ pub async fn hash_common_task_contents(
         let mut deps = BTreeMap::default();
 
         for dep in &task.deps {
+            if action_context.is_dependency_ignored(&task.target, &dep.target) {
+                deps.insert(&dep.target, "passthrough".into());
+                continue;
+            }
+
             if let Some(entry) = action_context.target_states.get_sync(&dep.target) {
                 match entry.get() {
                     TargetState::Passed(hash) => {

--- a/crates/task-runner/src/task_runner.rs
+++ b/crates/task-runner/src/task_runner.rs
@@ -341,6 +341,10 @@ impl<'task> TaskRunner<'task> {
         }
 
         for dep in &self.task.deps {
+            if context.is_dependency_ignored(&self.task.target, &dep.target) {
+                continue;
+            }
+
             if let Some(dep_state) = context.target_states.get_sync(&dep.target) {
                 if dep_state.get().is_complete() {
                     continue;

--- a/crates/task-runner/tests/task_runner_test.rs
+++ b/crates/task-runner/tests/task_runner_test.rs
@@ -8,6 +8,7 @@ use moon_task::Target;
 use moon_task_runner::TaskRunner;
 use moon_task_runner::output_hydrater::HydrateFrom;
 use moon_time::now_millis;
+use rustc_hash::FxHashSet;
 use utils::*;
 
 mod task_runner {
@@ -631,6 +632,35 @@ mod task_runner {
             let container = TaskRunnerContainer::new("runner", "has-deps").await;
             let runner = container.create_runner();
             let context = ActionContext::default();
+
+            runner.is_dependencies_complete(&context).unwrap();
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn returns_true_if_dep_is_ignored_for_target() {
+            let container = TaskRunnerContainer::new("runner", "has-deps").await;
+            let runner = container.create_runner();
+            let mut context = ActionContext::default();
+
+            context.ignored_dependencies.insert(
+                runner.task.target.clone(),
+                FxHashSet::from_iter([Target::new_project("project", "dep").unwrap()]),
+            );
+
+            assert!(runner.is_dependencies_complete(&context).unwrap());
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        #[should_panic(expected = "Encountered a missing hash for task project:dep")]
+        async fn errors_if_dep_is_ignored_for_another_target() {
+            let container = TaskRunnerContainer::new("runner", "has-deps").await;
+            let runner = container.create_runner();
+            let mut context = ActionContext::default();
+
+            context.ignored_dependencies.insert(
+                Target::new_project("project", "other").unwrap(),
+                FxHashSet::from_iter([Target::new_project("project", "dep").unwrap()]),
+            );
 
             runner.is_dependencies_complete(&context).unwrap();
         }


### PR DESCRIPTION
## Summary
- Mark dependencies skipped by `--upstream=none` as passthrough in the action graph context so task hashing no longer treats them as missing
- Preserve the same passthrough treatment for dependencies skipped by shallower upstream traversal
- Add regression coverage at the action-graph and CLI levels for the upstream-none exec path

## Testing
- `cargo test -p moon_action_graph --test action_graph_builder_test marks_skipped`
- `cargo test -p moon_cli --test exec_test upstream_none_ignores_dependency_hashes`