### PR TITLE
fix: skip uninitialized submodules when loading the git tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Fixed an issue where proto's `auto-clean` would remove tools installed by moon as they weren't
   marked as used.
+- Fixed a regression where moon would fail with `Failed to execute git and capture output` when
+  `.gitmodules` referenced a submodule that hadn't been checked out (e.g. `update = none`).
+  Uninitialized submodules are now skipped, matching the v1 behavior.
 
 ## 2.2.3
 

--- a/crates/vcs/src/git/git_client.rs
+++ b/crates/vcs/src/git/git_client.rs
@@ -143,12 +143,27 @@ impl Git {
                         if let Ok(work_dir) = sub.work_dir()
                             && let Ok(rel_path) = sub.path()
                         {
+                            let work_dir = clean_components(if work_dir.is_absolute() {
+                                work_dir
+                            } else {
+                                repository_root.join(work_dir)
+                            });
+
+                            // Ensure the submodule has actually been checked out.
+                            // When a submodule is declared in `.gitmodules` but never
+                            // initialized (e.g. `update = none`), running git in its
+                            // missing work_dir would fail with ENOENT.
+                            if !work_dir.join(".git").exists() {
+                                debug!(
+                                    submodule = ?work_dir,
+                                    "Encountered a submodule that hasn't been checked out, skipping it"
+                                );
+
+                                continue;
+                            }
+
                             submodules.push(GitTree {
-                                work_dir: clean_components(if work_dir.is_absolute() {
-                                    work_dir
-                                } else {
-                                    repository_root.join(work_dir)
-                                }),
+                                work_dir,
                                 git_dir: clean_components(sub.git_dir()),
                                 type_of: GitTreeType::Submodule,
                                 path: RelativePathBuf::from(rel_path.to_string()),

--- a/crates/vcs/tests/git_test.rs
+++ b/crates/vcs/tests/git_test.rs
@@ -169,25 +169,10 @@ mod git {
             assert_eq!(git.worktree.work_dir, sandbox.path());
             assert_eq!(git.worktree.path.as_str(), "");
             assert_eq!(git.worktree.type_of, GitTreeType::Root);
-            assert_eq!(
-                git.submodules,
-                vec![
-                    GitTree {
-                        git_dir: sandbox.path().join("modules/submodules/mono"),
-                        path: "submodules/mono".into(),
-                        type_of: GitTreeType::Submodule,
-                        work_dir: sandbox.path().join("submodules/mono"),
-                        ..Default::default()
-                    },
-                    GitTree {
-                        git_dir: sandbox.path().join("modules/submodules/poly"),
-                        path: "submodules/poly".into(),
-                        type_of: GitTreeType::Submodule,
-                        work_dir: sandbox.path().join("submodules/poly"),
-                        ..Default::default()
-                    }
-                ]
-            )
+            // Bare clones don't materialize submodule worktrees on disk,
+            // so they're filtered out (otherwise spawning git in a missing
+            // dir fails with ENOENT).
+            assert!(git.submodules.is_empty());
         }
 
         #[tokio::test]
@@ -569,7 +554,11 @@ mod git {
 
             let git = Git::load(sandbox.path(), "master", &["origin".into()]).unwrap();
 
-            assert!(!git.submodules.is_empty());
+            assert!(git.submodules.is_empty());
+
+            // Spawning git in a missing submodule dir would fail with ENOENT,
+            // so verify a command that fans out across all trees still works.
+            git.get_changed_files().await.unwrap();
         }
     }
 


### PR DESCRIPTION
## Summary
After upgrading to moon v2, any `moon run` fails immediately if `.gitmodules` references a submodule whose path hasn't been checked out (e.g. `update = none`, or a clone without `--recurse-submodules`). The error surfaces as the misleading:

```
Error: process::capture::failed
  × Failed to execute git and capture output.
  ╰─▶ No such file or directory (os error 2)
```

This re-applies the v1 fix from #1955 that was lost in the Git v2 rewrite (#2184).

Fixes #2510

## Root cause
`Git::load` in `crates/vcs/src/git/git_client.rs` iterates every submodule listed in `.gitmodules` and adds it to `git.submodules` without checking whether the path is actually checked out on disk. Subsequent fan-out commands (`get_changed_files`, `get_changed_files_between_revisions`, `get_file_tree`) spawn `git` with `cwd = <submodule work_dir>`. When the directory doesn't exist, `posix_spawn` returns `ENOENT` before the command can run, which is why the trace's `Running command` log never fires for the failing spawn.

The v1 implementation in `crates/vcs/src/gitx/tree.rs` filtered submodules whose `<work_dir>/.git` was missing. That check wasn't carried over in #2184.

## What changed
- `crates/vcs/src/git/git_client.rs`: filter submodules at load time on `<work_dir>/.git` existing, with a debug log when one is skipped. Matches the v1 behavior verbatim.
- `crates/vcs/tests/git_test.rs`:
  - `git::submodules::doesnt_error_if_submodules_arent_checked_out` was inadvertently asserting the buggy behavior (`!is_empty()`); flipped to `is_empty()` and added a `get_changed_files().await.unwrap()` call so the test exercises the fan-out spawn path that was failing.
  - `git::root::loads_trees_when_bare`: bare clones with `--recurse-submodules --bare` don't materialize submodule worktrees on disk, so `submodules` is now empty after the filter. Updated the assertion accordingly.
  - `git::worktree::loads_trees{,_when_bare}`: unchanged — those sandboxes run `git submodule update`, so the work_dirs do exist.
- `CHANGELOG.md`: Unreleased entry.

## Verification
- `cargo test -p moon_vcs --test git_test 'submodules' -- --test-threads=1`
- `cargo test -p moon_vcs --test git_test 'loads_trees' -- --test-threads=1`

Both pass. The repro from #2510 (synthetic repo with `update = none` submodule) succeeds with this change.