### PR TITLE
fix: Query changed-files now respects --head and avoids local status mixing

### DIFF
--- a/crates/app/src/queries/changed_files.rs
+++ b/crates/app/src/queries/changed_files.rs
@@ -133,10 +133,12 @@ async fn query_changed_files_without_stdin(
         }
     }
 
-    // Always include local changes
-    trace!("Against local index");
+    // Only include local changes when not explicitly comparing two revisions
+    if head_value.is_none() || options.local {
+        trace!("Against local index");
 
-    changed_files_map.merge(vcs.get_changed_files().await?);
+        changed_files_map.merge(vcs.get_changed_files().await?);
+    }
 
     if options.status.is_empty() {
         debug!(

--- a/crates/vcs/src/git/git_client.rs
+++ b/crates/vcs/src/git/git_client.rs
@@ -530,7 +530,7 @@ impl Vcs for Git {
             .unwrap_or(base_revision);
 
         // Load from root repo
-        changed_files.merge(self.worktree.exec_diff(merge_base_revision, "").await?);
+        changed_files.merge(self.worktree.exec_diff(merge_base_revision, head_revision).await?);
 
         // Load from each submodule
         if !self.submodules.is_empty() {


### PR DESCRIPTION
## Summary
Fixes #2511.

When `--base` and `--head` were both passed to `moon query changed-files`, the `--head` revision was silently ignored and the command fell back to a one-argument `git diff <base>` (base → working tree). It also unconditionally merged `git status` output, so commits after `--head` and local uncommitted changes appeared as false positives.

## Changes
- **git_client.rs:** Pass `head_revision` into `exec_diff` instead of an empty string, so `git diff` runs with two explicit revisions.
- **changed_files.rs:** Only merge local `git status` changes when `head` is not explicitly set. When the user asks for a diff between two SHAs, we return a pure tree-to-tree diff.

## Verification
- `moon query changed-files --base <X> --head <Y>` now returns the same files as `git diff --name-only <X> <Y>`.
- Open-ended queries (no `--head`) still include local working tree changes, preserving existing behavior.