### PR TITLE
docs: respect users' color scheme

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -211,6 +211,11 @@ const config: Config = {
 				'typescript',
 			],
 		},
+		// You can remove this in v4
+		// https://github.com/facebook/docusaurus/issues/11719#:~:text=Enable%20respectPrefersColorScheme%20by%20default
+		colorMode: {
+			respectPrefersColorScheme: true,
+		},
 	} satisfies Preset.ThemeConfig,
 
 	plugins: [


### PR DESCRIPTION
Enables `respectPrefersColorScheme` in Docusaurus. If the devices uses dark mode, the docs site will use dark mode by default.

https://docusaurus.io/docs/api/themes/configuration#respectPrefersColorScheme