### PR TITLE
docs: Clarify CI report file name

### DIFF
--- a/website/docs/commands/ci.mdx
+++ b/website/docs/commands/ci.mdx
@@ -10,6 +10,9 @@ environment, as it does all the heavy lifting necessary for effectively running 
 By default this will run all tasks that are affected by changed files and have the
 [`runInCI`](../config/project#runinci) task option enabled.
 
+After execution, moon writes the generated report to `.moon/cache/ciReport.json`. The non-CI task
+execution commands write the same report format to `.moon/cache/runReport.json`.
+
 ```shell
 $ moon ci
 ```

--- a/website/docs/commands/ci.mdx
+++ b/website/docs/commands/ci.mdx
@@ -10,9 +10,6 @@ environment, as it does all the heavy lifting necessary for effectively running 
 By default this will run all tasks that are affected by changed files and have the
 [`runInCI`](../config/project#runinci) task option enabled.
 
-After execution, moon writes the generated report to `.moon/cache/ciReport.json`. The non-CI task
-execution commands write the same report format to `.moon/cache/runReport.json`.
-
 ```shell
 $ moon ci
 ```
@@ -30,6 +27,14 @@ View the official [continuous integration guide](../guides/ci) for a more in-dep
 utilize this command.
 
 :::
+
+### Reports
+
+After execution, moon writes the generated report to `.moon/cache/ciReport.json`. The non-CI task
+execution commands write the same report format to `.moon/cache/runReport.json`.
+
+These reports live in `.moon/cache`, so they may be overwritten or deleted between runs. Copy the
+report elsewhere if you need to persist it, like uploading it as a CI artifact.
 
 ### Arguments
 

--- a/website/docs/guides/ci.mdx
+++ b/website/docs/guides/ci.mdx
@@ -258,6 +258,10 @@ If you're using GitHub Actions as your CI provider, we suggest using our
 action will report the results of a [`moon ci`](../commands/ci) run to a pull request as a comment
 and workflow summary.
 
+When `moon ci` completes, moon writes the report to `.moon/cache/ciReport.json`. Other task
+execution commands, like `moon run`, `moon check`, and `moon exec`, write the same run report format
+to `.moon/cache/runReport.json`.
+
 ```yaml title=".github/workflows/ci.yml"
 # ...
 jobs:

--- a/website/docs/guides/ci.mdx
+++ b/website/docs/guides/ci.mdx
@@ -258,9 +258,8 @@ If you're using GitHub Actions as your CI provider, we suggest using our
 action will report the results of a [`moon ci`](../commands/ci) run to a pull request as a comment
 and workflow summary.
 
-When `moon ci` completes, moon writes the report to `.moon/cache/ciReport.json`. Other task
-execution commands, like `moon run`, `moon check`, and `moon exec`, write the same run report format
-to `.moon/cache/runReport.json`.
+For the generated report file locations and caching caveats, refer to the
+[`moon ci` reports documentation](../commands/ci#reports).
 
 ```yaml title=".github/workflows/ci.yml"
 # ...

--- a/website/docs/guides/open-source.mdx
+++ b/website/docs/guides/open-source.mdx
@@ -56,9 +56,8 @@ We also suggest using our
 action. This action will report the results of a [`moon ci`](../commands/ci) run to a pull request
 as a comment and workflow summary.
 
-When `moon ci` completes, moon writes the report to `.moon/cache/ciReport.json`. Other task
-execution commands, like `moon run`, `moon check`, and `moon exec`, write the same run report format
-to `.moon/cache/runReport.json`.
+For the generated report file locations and caching caveats, refer to the
+[`moon ci` reports documentation](../commands/ci#reports).
 
 ```yaml title=".github/workflows/ci.yml"
 # ...

--- a/website/docs/guides/open-source.mdx
+++ b/website/docs/guides/open-source.mdx
@@ -56,6 +56,10 @@ We also suggest using our
 action. This action will report the results of a [`moon ci`](../commands/ci) run to a pull request
 as a comment and workflow summary.
 
+When `moon ci` completes, moon writes the report to `.moon/cache/ciReport.json`. Other task
+execution commands, like `moon run`, `moon check`, and `moon exec`, write the same run report format
+to `.moon/cache/runReport.json`.
+
 ```yaml title=".github/workflows/ci.yml"
 # ...
 jobs:


### PR DESCRIPTION
Clarifies which report filename moon writes for CI versus non-CI task execution commands.

- Documents that `moon ci` writes `.moon/cache/ciReport.json`.
- Documents that `moon run`, `moon check`, and `moon exec` write the same format to `.moon/cache/runReport.json`.