### PR TITLE
Fix affected stdin terminal detection

### DIFF
--- a/crates/app/src/queries/changed_files.rs
+++ b/crates/app/src/queries/changed_files.rs
@@ -225,7 +225,8 @@ pub async fn query_changed_files_for_affected(
     let mut options = QueryChangedFilesOptions {
         default_branch: ci,
         local: !ci,
-        stdin: true,
+        // Only auto-read stdin for piped input, otherwise interactive terminals hang waiting for EOF.
+        stdin: !stdin().is_terminal(),
         ..Default::default()
     };
 

--- a/crates/cli/tests/query_affected_test.rs
+++ b/crates/cli/tests/query_affected_test.rs
@@ -47,6 +47,29 @@ mod query_affected {
     }
 
     #[test]
+    fn includes_project_via_stdin() {
+        let sandbox = create_query_sandbox();
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("query")
+                .arg("affected")
+                .write_stdin("basic/file.txt");
+        });
+
+        let mut affected: Affected = serde_json::from_str(assert.stdout().trim()).unwrap();
+
+        assert!(!affected.projects.contains_key("advanced"));
+        assert_eq!(
+            affected.projects.remove("basic").unwrap(),
+            AffectedProjectState {
+                files: FxHashSet::from_iter(["basic/file.txt".into()]),
+                tasks: FxHashSet::from_iter([Target::parse("basic:dev").unwrap()]),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
     fn includes_task_for_input() {
         let sandbox = create_query_sandbox();
 


### PR DESCRIPTION
## Summary

- Only auto-read changed files from stdin when stdin is not an interactive terminal.
- Adds a comment explaining that interactive terminals would otherwise hang waiting for EOF.
- Adds coverage for `moon query affected` consuming changed files from stdin.

## Validation

- `git diff --check`
- Could not run Rust formatting/tests locally because `cargo` and `rustfmt` are not installed in this container.
