### PR TITLE
security: Harden remote cache output hydration against undeclared paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### 🛡️ Security
+
+- Fixed a security issue where task outputs being hydrated from the remote cache can overwrite files
+  outside the output list, if the manifest in the remote cache has been compromised.
+
 ## 2.3.2
 
 #### 🚀 Updates

--- a/crates/daemon-server/src/daemon_server.rs
+++ b/crates/daemon-server/src/daemon_server.rs
@@ -82,13 +82,11 @@ impl MoonDaemon for DaemonService {
         // TODO populate the action digest/bytes!
         let task_state = TaskRunState::new(&state.app_context, &task);
 
-        let archived = OutputArchiver {
-            app_context: &state.app_context,
-            task: &task,
-        }
-        .archive(&req.hash, &task_state)
-        .await
-        .map_err(|error| Status::unknown(error.to_string()))?;
+        let archived = OutputArchiver::new(&state.app_context, &task)
+            .map_err(|error| Status::unknown(error.to_string()))?
+            .archive(&req.hash, &task_state)
+            .await
+            .map_err(|error| Status::unknown(error.to_string()))?;
 
         Ok(Response::new(ArchiveTaskOutputsResponse { archived }))
     }

--- a/crates/task-runner/src/output_archiver.rs
+++ b/crates/task-runner/src/output_archiver.rs
@@ -20,11 +20,18 @@ use tracing::{debug, instrument, warn};
 /// so that subsequent builds are faster, and any local outputs
 /// can be hydrated easily.
 pub struct OutputArchiver<'task> {
-    pub app_context: &'task Arc<AppContext>,
-    pub task: &'task Arc<Task>,
+    app_context: &'task Arc<AppContext>,
+    task: &'task Arc<Task>,
 }
 
 impl OutputArchiver<'_> {
+    pub fn new<'task>(
+        app_context: &'task Arc<AppContext>,
+        task: &'task Arc<Task>,
+    ) -> miette::Result<OutputArchiver<'task>> {
+        Ok(OutputArchiver { task, app_context })
+    }
+
     #[instrument(skip(self, state))]
     pub async fn archive(&self, hash: &str, state: &TaskRunState) -> miette::Result<bool> {
         // Check that outputs actually exist

--- a/crates/task-runner/src/output_hydrater.rs
+++ b/crates/task-runner/src/output_hydrater.rs
@@ -1,15 +1,20 @@
 use crate::remote_compat::*;
 use crate::run_state::TaskRunState;
+use crate::task_runner_error::TaskRunnerError;
 use bazel_remote_apis::build::bazel::remote::execution::v2::ActionResult;
 use miette::IntoDiagnostic;
 use moon_app_context::AppContext;
-use moon_common::color;
+use moon_common::{
+    color,
+    path::{PathExt, clean_components},
+};
 use moon_remote::{RemoteDigestExt, RemoteService};
 use moon_task::Task;
 use starbase_archive::Archiver;
 use starbase_archive::tar::TarUnpacker;
-use starbase_utils::fs;
+use starbase_utils::{fs, glob::GlobSet};
 use std::fmt::Debug;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::task::spawn_blocking;
 use tracing::{debug, instrument, warn};
@@ -34,11 +39,23 @@ impl Debug for HydrateFrom {
 }
 
 pub struct OutputHydrater<'task> {
-    pub app_context: &'task Arc<AppContext>,
-    pub task: &'task Arc<Task>,
+    app_context: &'task Arc<AppContext>,
+    task: &'task Arc<Task>,
+    task_output_globset: GlobSet<'static>,
 }
 
 impl OutputHydrater<'_> {
+    pub fn new<'task>(
+        app_context: &'task Arc<AppContext>,
+        task: &'task Arc<Task>,
+    ) -> miette::Result<OutputHydrater<'task>> {
+        Ok(OutputHydrater {
+            task_output_globset: GlobSet::new_owned(task.output_globs.keys())?,
+            task,
+            app_context,
+        })
+    }
+
     #[instrument(skip(self, state))]
     pub async fn hydrate(
         &self,
@@ -276,24 +293,76 @@ impl OutputHydrater<'_> {
     fn write_outputs(&self, result: &ActionResult) -> miette::Result<()> {
         for file in &result.output_files {
             if file.digest.is_some() {
-                write_output_file(
-                    self.app_context.workspace_root.join(&file.path),
-                    &file.contents,
-                    file,
-                )?;
+                let output_path = self.resolve_declared_output_path(&file.path)?;
+
+                write_output_file(output_path, &file.contents, file)?;
             }
         }
 
         // Create symlinks after output files have been written,
         // as the link target may reference one of these outputs
         for link in &result.output_symlinks {
-            link_output_file(
-                self.app_context.workspace_root.join(&link.target),
-                self.app_context.workspace_root.join(&link.path),
-                link,
-            )?;
+            let target_path = self.resolve_workspace_path(&link.target).map_err(|_| {
+                TaskRunnerError::OutputSymlinkOutsideOfWorkspace {
+                    output: PathBuf::from(&link.path),
+                    target: PathBuf::from(&link.target),
+                }
+            })?;
+            let link_path = self.resolve_declared_output_path(&link.path)?;
+
+            link_output_file(target_path, link_path, link)?;
         }
 
         Ok(())
+    }
+
+    fn resolve_workspace_path(&self, raw_path: &str) -> miette::Result<PathBuf> {
+        let raw_path = Path::new(raw_path);
+
+        if raw_path.is_absolute() {
+            return Err(TaskRunnerError::OutputFileOutsideOfWorkspace {
+                output: raw_path.to_path_buf(),
+            }
+            .into());
+        }
+
+        let output_path = clean_components(self.app_context.workspace_root.join(raw_path));
+
+        if !output_path.starts_with(&self.app_context.workspace_root) {
+            return Err(TaskRunnerError::OutputFileOutsideOfWorkspace {
+                output: output_path,
+            }
+            .into());
+        }
+
+        Ok(output_path)
+    }
+
+    fn resolve_declared_output_path(&self, raw_path: &str) -> miette::Result<PathBuf> {
+        let output_path = self.resolve_workspace_path(raw_path)?;
+        let rel_path = output_path
+            .relative_to(&self.app_context.workspace_root)
+            .into_diagnostic()?;
+
+        if self.task.output_files.contains_key(&rel_path) {
+            return Ok(output_path);
+        }
+
+        for declared_output in self.task.output_files.keys() {
+            if rel_path.starts_with(declared_output) {
+                return Ok(output_path);
+            }
+        }
+
+        if !self.task.output_globs.is_empty() && self.task_output_globset.matches(rel_path.as_str())
+        {
+            return Ok(output_path);
+        }
+
+        Err(TaskRunnerError::OutputFileNotDeclared {
+            target: self.task.target.clone(),
+            output: output_path,
+        }
+        .into())
     }
 }

--- a/crates/task-runner/src/task_runner.rs
+++ b/crates/task-runner/src/task_runner.rs
@@ -69,8 +69,8 @@ impl<'task> TaskRunner<'task> {
         Ok(Self {
             state: TaskRunState::new(app_context, task),
             cache,
-            archiver: OutputArchiver { app_context, task },
-            hydrater: OutputHydrater { app_context, task },
+            archiver: OutputArchiver::new(app_context, task)?,
+            hydrater: OutputHydrater::new(app_context, task)?,
             project,
             report: TaskReportItem {
                 output_style: task.options.output_style,

--- a/crates/task-runner/src/task_runner_error.rs
+++ b/crates/task-runner/src/task_runner_error.rs
@@ -47,4 +47,12 @@ pub enum TaskRunnerError {
         .output.style(Style::Path),
     )]
     OutputFileOutsideOfWorkspace { output: PathBuf },
+
+    #[diagnostic(code(task_runner::output::undeclared_output))]
+    #[error(
+        "Unable to hydrate cached output for task {}, as the file {} is not declared as an output.",
+        .target.style(Style::Label),
+        .output.style(Style::Path),
+    )]
+    OutputFileNotDeclared { target: Target, output: PathBuf },
 }

--- a/crates/task-runner/src/task_runner_error.rs
+++ b/crates/task-runner/src/task_runner_error.rs
@@ -35,7 +35,7 @@ pub enum TaskRunnerError {
 
     #[diagnostic(code(task_runner::output::symlink_outside_workspace))]
     #[error(
-        "Unable to cache output, as the file {} is a symlink to {}, which exists outside of the workspace.",
+        "Invalid task output, as the file {} is a symlink to {}, which exists outside of the workspace.",
         .output.style(Style::Path),
         .target.style(Style::Path),
     )]
@@ -43,7 +43,7 @@ pub enum TaskRunnerError {
 
     #[diagnostic(code(task_runner::output::file_outside_workspace))]
     #[error(
-        "Unable to cache output, as the file {} exists outside of the workspace.",
+        "Invalid task output, as the file {} exists outside of the workspace.",
         .output.style(Style::Path),
     )]
     OutputFileOutsideOfWorkspace { output: PathBuf },

--- a/crates/task-runner/tests/output_hydrater_test.rs
+++ b/crates/task-runner/tests/output_hydrater_test.rs
@@ -138,6 +138,8 @@ mod output_hydrater {
 
     mod local_cas {
         use super::*;
+        use bazel_remote_apis::build::bazel::remote::execution::v2::OutputFile;
+        use moon_remote::LocalDigestExt;
         use starbase_utils::json::serde_json;
 
         fn setup_cas_state(state: &mut TaskRunState) {
@@ -304,6 +306,179 @@ mod output_hydrater {
         }
 
         #[tokio::test(flavor = "multi_thread")]
+        async fn hydrates_file_inside_declared_output_directory() {
+            let container = TaskRunnerContainer::new("archive", "output-one-dir").await;
+            container
+                .sandbox
+                .create_file("project/dir/file.txt", "contents");
+
+            let mut state = container.create_state();
+            setup_cas_state(&mut state);
+
+            populate_cas(&container, &state).await;
+
+            fs::remove_dir_all(container.sandbox.path().join("project/dir")).unwrap();
+
+            let result = read_action_result(&container, &state);
+
+            assert!(
+                container
+                    .create_hydrator()
+                    .hydrate(&mut HydrateFrom::LocalCache(result), "hash123", &state)
+                    .await
+                    .unwrap()
+            );
+
+            assert_eq!(
+                fs::read_to_string(container.sandbox.path().join("project/dir/file.txt")).unwrap(),
+                "contents"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn rejects_untrusted_action_result_path_outside_workspace() {
+            let container = TaskRunnerContainer::new("archive", "file-outputs").await;
+
+            let mut state = container.create_state();
+            setup_cas_state(&mut state);
+
+            let outside_name = format!(
+                "{}-remote-cache-outside-marker.txt",
+                container
+                    .sandbox
+                    .path()
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+            );
+            let outside_path = container
+                .sandbox
+                .path()
+                .parent()
+                .unwrap()
+                .join(&outside_name);
+            let _ = fs::remove_file(&outside_path);
+
+            let digest = container
+                .app_context
+                .cache_engine
+                .cas
+                .write_bytes(b"REMOTE_CACHE_OUTSIDE_WORKSPACE_WRITE")
+                .unwrap();
+
+            let mut result = ActionResult::default();
+            result.output_files.push(OutputFile {
+                path: format!("../{outside_name}"),
+                digest: Some(digest.to_remote_digest()),
+                ..Default::default()
+            });
+
+            assert!(!outside_path.exists());
+
+            assert!(
+                container
+                    .create_hydrator()
+                    .hydrate(&mut HydrateFrom::LocalCache(result), "hash123", &state)
+                    .await
+                    .is_err()
+            );
+
+            assert!(!outside_path.exists());
+
+            let _ = fs::remove_file(&outside_path);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn rejects_untrusted_action_result_absolute_path_outside_workspace() {
+            let container = TaskRunnerContainer::new("archive", "file-outputs").await;
+
+            let mut state = container.create_state();
+            setup_cas_state(&mut state);
+
+            let outside_name = format!(
+                "{}-remote-cache-absolute-marker.txt",
+                container
+                    .sandbox
+                    .path()
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+            );
+            let outside_path = container
+                .sandbox
+                .path()
+                .parent()
+                .unwrap()
+                .join(&outside_name);
+            let _ = fs::remove_file(&outside_path);
+
+            let digest = container
+                .app_context
+                .cache_engine
+                .cas
+                .write_bytes(b"REMOTE_CACHE_ABSOLUTE_PATH_WORKSPACE_WRITE")
+                .unwrap();
+
+            let mut result = ActionResult::default();
+            result.output_files.push(OutputFile {
+                path: outside_path.to_string_lossy().to_string(),
+                digest: Some(digest.to_remote_digest()),
+                ..Default::default()
+            });
+
+            assert!(!outside_path.exists());
+
+            assert!(
+                container
+                    .create_hydrator()
+                    .hydrate(&mut HydrateFrom::LocalCache(result), "hash123", &state)
+                    .await
+                    .is_err()
+            );
+
+            assert!(!outside_path.exists());
+
+            let _ = fs::remove_file(&outside_path);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn rejects_untrusted_action_result_undeclared_workspace_output() {
+            let container = TaskRunnerContainer::new("archive", "file-outputs").await;
+
+            let mut state = container.create_state();
+            setup_cas_state(&mut state);
+
+            let undeclared_path = container.sandbox.path().join("project/runner.js");
+            let _ = fs::remove_file(&undeclared_path);
+
+            let digest = container
+                .app_context
+                .cache_engine
+                .cas
+                .write_bytes(b"REMOTE_CACHE_UNDECLARED_WORKSPACE_OUTPUT")
+                .unwrap();
+
+            let mut result = ActionResult::default();
+            result.output_files.push(OutputFile {
+                path: "project/runner.js".to_owned(),
+                digest: Some(digest.to_remote_digest()),
+                ..Default::default()
+            });
+
+            assert!(!undeclared_path.exists());
+
+            assert!(
+                container
+                    .create_hydrator()
+                    .hydrate(&mut HydrateFrom::LocalCache(result), "hash123", &state)
+                    .await
+                    .is_err()
+            );
+
+            assert!(!undeclared_path.exists());
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
         async fn hydrates_empty_files_even_when_empty_blob_missing_from_cas() {
             // Action results downloaded from a remote cache reference content
             // by digest, but the bytes only land at output paths (not in the
@@ -311,9 +486,6 @@ mod output_hydrater {
             // reason, an empty output file's digest (e3b0c4…) would not
             // resolve in local CAS — the hydrater must handle that without
             // erroring.
-            use bazel_remote_apis::build::bazel::remote::execution::v2::OutputFile;
-            use moon_remote::LocalDigestExt;
-
             let container = TaskRunnerContainer::new("archive", "output-many-files").await;
 
             let mut state = container.create_state();

--- a/crates/task-runner/tests/utils.rs
+++ b/crates/task-runner/tests/utils.rs
@@ -84,17 +84,11 @@ impl TaskRunnerContainer {
     }
 
     pub fn create_archiver(&self) -> OutputArchiver<'_> {
-        OutputArchiver {
-            app_context: &self.app_context,
-            task: &self.task,
-        }
+        OutputArchiver::new(&self.app_context, &self.task).unwrap()
     }
 
     pub fn create_hydrator(&self) -> OutputHydrater<'_> {
-        OutputHydrater {
-            app_context: &self.app_context,
-            task: &self.task,
-        }
+        OutputHydrater::new(&self.app_context, &self.task).unwrap()
     }
 
     pub fn create_state(&self) -> TaskRunState {


### PR DESCRIPTION
## Summary
- Normalize remote cache output paths before writing them to disk.
- Reject absolute paths, traversal outside the workspace, and cache entries that are not declared outputs.
- Keep declared directory outputs working while also protecting symlink targets.
- Add a security note to the changelog and a regression suite covering the malicious cache cases.

## Testing
- `cargo test -p moon_task_runner --test output_hydrater_test -- --nocapture`
- `cargo check -p moon_task_runner`
- `cargo clippy -p moon_task_runner --all-targets -- -D warnings`
- Local validation confirmed the new tests block traversal, absolute-path, and undeclared-output hydration while preserving valid directory hydration.