### PR TITLE
feat(config): register unstable_ruby toolchain locator

### DIFF
--- a/crates/config-loader/src/toolchains_config_ext.rs
+++ b/crates/config-loader/src/toolchains_config_ext.rs
@@ -24,6 +24,7 @@ impl ToolchainsConfigExt {
             "unstable_pip" => Some(locate("python_pip_toolchain", "0.1.2")),
             "unstable_poetry" => Some(locate("python_poetry_toolchain", "0.1.0")),
             "unstable_uv" => Some(locate("python_uv_toolchain", "0.1.3")),
+            "unstable_ruby" => Some(locate("ruby_toolchain", "0.1.0")),
             "yarn" => Some(locate("node_depman_toolchain", "1.0.3")),
             "system" => Some(PluginLocator::Data(Box::new(DataLocator {
                 data: "data://system_toolchain".into(),
@@ -128,7 +129,7 @@ impl ToolchainsConfigExt {
             match id.as_str() {
                 "bun" | "deno" | "go" | "javascript" | "node" | "npm" | "pnpm" | "rust"
                 | "system" | "typescript" | "unstable_python" | "unstable_pip"
-                | "unstable_poetry" | "unstable_uv" | "yarn" => {
+                | "unstable_poetry" | "unstable_uv" | "unstable_ruby" | "yarn" => {
                     config.plugin = Self::get_plugin_locator(id);
                 }
                 #[cfg(debug_assertions)]


### PR DESCRIPTION
Map the `unstable_ruby` toolchain id to the ruby_toolchain WASM plugin (moonrepo/plugins) in get_plugin_locator and inherit_plugin_locators. Part of Ruby tier 3 support.

pairs with https://github.com/moonrepo/plugins/pull/152