### PR TITLE
fix(toolchain): support build-from-source tier-3 toolchains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8693,9 +8693,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_console"
-version = "0.6.29"
+version = "0.6.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b11aad63c3ab7b6dfcbbce2357cbb583bd3bf5d0a3e4329f84166f47cb7b6017"
+checksum = "7e43e0375e24c13e6af8024e76a759aba61a695d0ad3445b4dc0446ded41888e"
 dependencies = [
  "crossterm",
  "iocraft",
@@ -8739,9 +8739,9 @@ dependencies = [
 
 [[package]]
 name = "starbase_shell"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd0cac48b0878b82ed08b93578640cc010be0bb73bb400520feb4434fde8539"
+checksum = "906e4773d01742ce1b70ccfdc03bdccdfa5202f7cb0d18e49efe71d517faca16"
 dependencies = [
  "base64 0.22.1",
  "miette 7.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6074,6 +6074,7 @@ dependencies = [
  "moon_test_utils",
  "moon_toolchain",
  "proto_core",
+ "proto_pdk_api",
  "rustc-hash",
  "scc",
  "starbase_sandbox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,10 +70,10 @@ starbase_archive = { version = "0.13.2", default-features = false, features = [
   "zip-all",
 ] }
 starbase_args = { version = "0.1.11" }
-starbase_console = { version = "0.6.29", features = ["miette"] }
+starbase_console = { version = "0.6.31", features = ["miette"] }
 starbase_id = { version = "0.3.3", features = ["miette", "schematic"] }
 starbase_sandbox = "0.11.1"
-starbase_shell = "0.12.5"
+starbase_shell = "0.12.6"
 starbase_styles = { version = "0.6.1", features = ["relative-path"] }
 starbase_utils = { version = "0.13.8", default-features = false, features = [
   "editor-config",

--- a/crates/actions/src/actions/setup_toolchain.rs
+++ b/crates/actions/src/actions/setup_toolchain.rs
@@ -9,6 +9,7 @@ use moon_env_var::GlobalEnvBag;
 use moon_hash::fingerprint;
 use moon_pdk_api::SetupToolchainInput;
 use moon_toolchain::is_using_global_toolchain;
+use proto_core::reporter::{ProtoReporter, ReporterFormat};
 use std::sync::Arc;
 use tracing::{debug, instrument};
 
@@ -90,6 +91,9 @@ pub async fn setup_toolchain(
     );
 
     let setup_op = Operation::setup_operation(action.get_prefix())?;
+    let proto_console = app_context
+        .console
+        .with_reporter(ProtoReporter::new(ReporterFormat::Text));
     let output = toolchain
         .setup_toolchain(
             SetupToolchainInput {
@@ -98,6 +102,7 @@ pub async fn setup_toolchain(
                 toolchain_config: app_context.toolchain_registry.create_config(&toolchain.id),
                 version: None,
             },
+            Some(proto_console),
             || {
                 app_context.console.print_checkpoint(
                     Checkpoint::Setup,

--- a/crates/toolchain-plugin/Cargo.toml
+++ b/crates/toolchain-plugin/Cargo.toml
@@ -26,6 +26,7 @@ futures = { workspace = true }
 indexmap = { workspace = true }
 miette = { workspace = true }
 proto_core = { workspace = true }
+proto_pdk_api = { workspace = true }
 rustc-hash = { workspace = true }
 scc = { workspace = true }
 starbase_utils = { workspace = true, features = ["glob", "json"] }

--- a/crates/toolchain-plugin/src/toolchain_plugin.rs
+++ b/crates/toolchain-plugin/src/toolchain_plugin.rs
@@ -9,10 +9,13 @@ use proto_core::flow::install::InstallOptions;
 use proto_core::flow::locate::Locator;
 use proto_core::flow::manage::Manager;
 use proto_core::flow::resolve::Resolver;
+use proto_core::reporter::ProtoConsole;
+use proto_core::utils::log::LogWriter;
 use proto_core::{
     PluginLocator, PluginType as ProtoPluginType, Tool, ToolContext, ToolSpec,
     UnresolvedVersionSpec, locate_plugin,
 };
+use proto_pdk_api::InstallStrategy;
 use scc::hash_map::Entry;
 use starbase_utils::glob::{self, GlobSet};
 use std::fmt;
@@ -150,7 +153,8 @@ impl ToolchainPlugin {
         self.has_func("setup_toolchain").await
             || self.tool.is_some()
                 && (self.has_func("download_prebuilt").await
-                    || self.has_func("native_install").await)
+                    || self.has_func("native_install").await
+                    || self.has_func("build_instructions").await)
     }
 
     #[instrument(skip(self))]
@@ -529,6 +533,16 @@ impl ToolchainPlugin {
                 if !tool.is_installed(&spec) {
                     on_setup()?;
 
+                    // Honor the tool's declared install strategy (e.g. Ruby
+                    // builds from source); otherwise proto defaults to a
+                    // prebuilt download and errors for source-only tools.
+                    let strategy = tool.metadata.default_install_strategy;
+
+                    // Only the build-from-source path routes through proto's
+                    // Builder, which requires a console + log writer. Prebuilt
+                    // installs don't, so leave them `None` to avoid the
+                    // allocation and any change to prebuilt logging behavior.
+                    let building = matches!(strategy, InstallStrategy::BuildFromSource);
                     let mut manager = Manager::new(&mut tool);
 
                     output.installed = manager
@@ -537,6 +551,9 @@ impl ToolchainPlugin {
                             InstallOptions {
                                 skip_prompts: true,
                                 skip_ui: true,
+                                strategy,
+                                console: building.then(|| ProtoConsole::new(false)),
+                                log_writer: building.then(LogWriter::default),
                                 ..Default::default()
                             },
                         )

--- a/crates/toolchain-plugin/src/toolchain_plugin.rs
+++ b/crates/toolchain-plugin/src/toolchain_plugin.rs
@@ -515,6 +515,7 @@ impl ToolchainPlugin {
     pub async fn setup_toolchain(
         &self,
         mut input: SetupToolchainInput,
+        console: Option<ProtoConsole>,
         on_setup: impl FnOnce() -> miette::Result<()>,
     ) -> miette::Result<SetupToolchainOutput> {
         let mut output = SetupToolchainOutput::default();
@@ -552,7 +553,7 @@ impl ToolchainPlugin {
                                 skip_prompts: true,
                                 skip_ui: true,
                                 strategy,
-                                console: building.then(|| ProtoConsole::new(false)),
+                                console: building.then_some(console).flatten(),
                                 log_writer: building.then(LogWriter::default),
                                 ..Default::default()
                             },

--- a/crates/toolchain-plugin/src/toolchain_registry_actions.rs
+++ b/crates/toolchain-plugin/src/toolchain_registry_actions.rs
@@ -377,7 +377,7 @@ impl ToolchainRegistry {
             "setup_toolchain",
             self.get_plugin_ids(),
             input_factory,
-            |toolchain, input| async move { toolchain.setup_toolchain(input, || Ok(())).await },
+            |toolchain, input| async move { toolchain.setup_toolchain(input, None, || Ok(())).await },
             true,
         )
         .await


### PR DESCRIPTION
Two gaps blocked build-from-source toolchains:

1. supports_tier_3() only recognized download_prebuilt/native_install, so moon never scheduled a SetupToolchain action for source-only tools.
2. setup_toolchain() called proto's Manager::install with a default InstallOptions, so strategy defaulted to prebuilt and errored (prebuilt_unsupported) for source-only tools.