### PR TITLE
fix: Support git hooks in workspaces with submodule projects.

### DIFF
--- a/crates/vcs/src/process_cache.rs
+++ b/crates/vcs/src/process_cache.rs
@@ -38,6 +38,19 @@ impl ProcessCache {
         let mut command = Command::new(&self.bin);
         command.args(args);
         command.envs(&self.env);
+        // Strip git's per-invocation environment. In a hook, git sets a relative
+        // GIT_INDEX_FILE (.git/index); since we run with the cwd in a project
+        // directory, for a submodule (where `.git` is a file) that resolves to
+        // `<submodule>/.git/index` and fails with "index file open failed: Not a
+        // directory". Clearing it lets each call resolve its repo from its cwd.
+        command.envs_remove([
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_PREFIX",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_COMMON_DIR",
+        ]);
         // Run from workspace root instead of git root so that we can avoid
         // prefixing all file paths to ensure everything is relative and accurate.
         command.cwd(&self.workspace_root);

--- a/crates/vcs/tests/git_test.rs
+++ b/crates/vcs/tests/git_test.rs
@@ -560,6 +560,28 @@ mod git {
             // so verify a command that fans out across all trees still works.
             git.get_changed_files().await.unwrap();
         }
+
+        #[tokio::test]
+        async fn changed_files_with_inherited_relative_git_index_file() {
+            use moon_env_var::GlobalEnvBag;
+
+            // Submodules are checked out, so each submodule's `.git` is a file
+            // (a gitdir pointer), not a directory.
+            let (_sandbox, git) = create_root_sandbox(false);
+
+            // In a hook, git sets a relative GIT_INDEX_FILE. A status run in a
+            // submodule (where `.git` is a file) resolves `.git/index` to
+            // `<submodule>/.git/index` and fails unless the inherited value is
+            // stripped.
+            let bag = GlobalEnvBag::instance();
+            bag.set("GIT_INDEX_FILE", ".git/index");
+
+            let result = git.get_changed_files().await;
+
+            bag.remove("GIT_INDEX_FILE");
+
+            result.unwrap();
+        }
     }
 
     mod root_detection {


### PR DESCRIPTION
### Problem

In a workspace where one or more moon projects are git submodules, a `pre-commit`
hook that uses `--affected` aborts every commit:

```
Process git failed: exit code 128
fatal: .git/index: index file open failed: Not a directory
```

The only workaround is `git commit --no-verify`, which skips the hook.

### Cause

When git invokes a hook it exports `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_PREFIX`, etc.
into the environment. On common git versions `GIT_INDEX_FILE` is relative
(`.git/index`).

moon's changed-files detection runs `git status` with the cwd set to each project
directory (`ProcessCache::create_command_in_cwd`, used in
`crates/vcs/src/git/tree.rs`). For a submodule project, `.git` is a file (a gitdir
pointer), so the inherited relative `GIT_INDEX_FILE=.git/index` resolves to
`<submodule>/.git/index` and git fails with "Not a directory".

`ProcessCache::create_command` injects `self.env` but never clears the inherited
`GIT_*` vars, so they reach every git subprocess.

### Fix

Clear git's per-invocation environment in `ProcessCache::create_command`. Both
`create_command` and `create_command_in_cwd` route through this factory, so every
git call resolves its repository from its own cwd. Outside hooks these vars are
unset, so the removal is a no-op.

### Test

Added a test under `git::submodules` that checks out the `moonrepo/git-test`
submodule fixture (a submodule's `.git` is a file), sets a relative
`GIT_INDEX_FILE`, and asserts `get_changed_files()` succeeds. It fails without the
fix with the error above and passes with it.

`cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` pass.
