### PR TITLE
fix: Prevent `BASH_ENV` from overwriting the injected task `PATH`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Fixed `moon ci` failing in certain CI provider pull request builds, where the base branch is
   provided as a fully-qualified `refs/heads/<branch>` ref that couldn't be resolved in a detached
   `HEAD` checkout.
+- Fixed task binaries failing with "command not found" in CI providers like CircleCI, where an
+  `export PATH=...` in the `$BASH_ENV` file would overwrite the `PATH` that moon injects for tasks.
+  `BASH_ENV` is no longer passed to `bash` wrapped child processes, unless explicitly set with the
+  task `env` option.
 
 ## 2.4.2
 

--- a/crates/process/src/exec_command.rs
+++ b/crates/process/src/exec_command.rs
@@ -397,14 +397,29 @@ impl Command {
         // string of the full command line with args quoted correctly, as
         // it's passed as a single argument to the shell: `bash -c "command line"`
         let mut command = if self.shell.is_some() || self.exe.requires_shell() {
-            let shell = self.shell.unwrap_or_default().build();
+            let shell_type = self.shell.unwrap_or_default();
+            let shell = shell_type.build();
 
             let script = match &self.exe {
                 CommandExecutable::Binary(bin) => join_exe_args(&shell, bin, &self.args, false),
                 CommandExecutable::Script(script) => script.to_owned(),
             };
 
-            shell.create_wrapped_command_with(script)
+            let mut command = shell.create_wrapped_command_with(script);
+
+            // Non-interactive bash sources the file referenced by `BASH_ENV`
+            // on startup, after the process environment has been applied.
+            // CI providers like CircleCI persist environment variables between
+            // steps through this file, so an `export PATH=...` within it will
+            // overwrite the `PATH` we explicitly set for this process.
+            // https://github.com/moonrepo/moon/issues/1998
+            if matches!(shell_type, starbase_shell::ShellType::Bash)
+                && !self.env.contains_key(OsStr::new("BASH_ENV"))
+            {
+                command.env_remove("BASH_ENV");
+            }
+
+            command
         }
         // When the command is not in a shell, we can create a standard command
         // and pass the non-quoted args separately


### PR DESCRIPTION
Closes #1998

## Root cause

Non-interactive bash sources the file referenced by `$BASH_ENV` on startup — *after* the process environment has been applied, right before the command runs. CI providers like CircleCI set `BASH_ENV` for every step, and their documented way to persist environment variables between steps is appending `export` statements to that file. A persisted `export PATH="..."` snapshot therefore overwrites the `PATH` that moon explicitly constructs for each task child process (with `node_modules/.bin`, proto shims, etc. prepended), producing `tsc: command not found` even though moon set everything correctly.

`sh`/dash never reads `BASH_ENV`, which is why the issue tracked shell selection: on 1.x the task shell came from runtime detection, and single-command CI steps hit bash's exec-the-last-command optimization (moon's parent became `circleci-agent`, detection fell back to `sh` → passed) while multi-command steps kept `bash` as the parent (detected bash → failed). Since the default unix task shell is now deterministically bash whenever it's installed, the failure is consistent rather than intermittent.

## Fix

Strip `BASH_ENV` from bash-wrapped child processes in `create_sync_command`, unless it was explicitly set on the command (e.g. through the task `env` option). This is safe because moon's own environment was already produced by a shell that sourced `BASH_ENV`, so the child inherits everything that file would provide — re-sourcing it inside the task shell can only re-apply stale overrides on top of values moon deliberately set.

Applied at the `StdCommand` level, so command cache keys and hashes are unaffected.

## Verification

Reproduced locally against `master` with a sandbox workspace, a fake binary on moon's inherited `PATH`, and a `BASH_ENV` file exporting a stale `PATH` snapshot (mimicking CircleCI):

- **Before**: every bash-wrapped task (command and script) saw the stale `PATH` and failed with `bash: fake-tsc: command not found`; a `unixShell: sh` task was unaffected — exactly matching the reported pass/fail split.
- **After**: all tasks see moon's constructed `PATH` and resolve the binary; a task explicitly setting `BASH_ENV` via `env` still gets the file sourced (opt-in preserved).

`cargo clippy -p moon_process`, `moon_process` tests (68/68), and `moon_task_runner` tests (237/237) pass.

## Notes

- Behavior change: nested bash scripts spawned by a task no longer see `BASH_ENV` unless the task sets it explicitly (changelog entry included).
- zsh's `~/.zshenv` is the same class of clobbering for `unixShell: zsh` tasks, but can't be disabled via an environment variable — that would need `NO_RCS`/`ZDOTDIR` handling in starbase_shell, left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
