### PR TITLE
fix: Apply output styles to transitive tasks only

### DIFF
--- a/crates/cli/tests/exec_test.rs
+++ b/crates/cli/tests/exec_test.rs
@@ -2606,6 +2606,35 @@ mod exec {
                     .not()
                     .eval(&output)
             );
+            assert!(
+                predicate::str::contains("outputStyles:none | stderr")
+                    .not()
+                    .eval(&output)
+            );
+        }
+
+        #[test]
+        fn ignores_style_for_direct_tasks() {
+            let sandbox = create_cases_sandbox();
+
+            let assert = sandbox.run_bin(|cmd| {
+                cmd.arg("run").arg("outputStyles:none");
+            });
+
+            let output = assert.output();
+
+            assert!(predicate::str::contains("stdout").eval(&output));
+            assert!(predicate::str::contains("stderr").eval(&output));
+
+            let assert = sandbox.run_bin(|cmd| {
+                cmd.arg("run").arg("outputStyles:none");
+            });
+
+            let output = assert.output();
+
+            assert!(predicate::str::contains("cached").eval(&output));
+            assert!(predicate::str::contains("stdout").eval(&output));
+            assert!(predicate::str::contains("stderr").eval(&output));
         }
 
         #[test]

--- a/crates/task-runner/src/task_executor.rs
+++ b/crates/task-runner/src/task_executor.rs
@@ -297,10 +297,12 @@ impl<'task> TaskExecutor<'task> {
 
         // When the primary target, always stream the output for a better developer experience.
         // However, transitive targets can opt into streaming as well.
-        self.stream = if let Some(output_style) = &self.task.options.output_style {
+        self.stream = if is_primary {
+            true
+        } else if let Some(output_style) = &self.task.options.output_style {
             matches!(output_style, TaskOutputStyle::Stream)
         } else {
-            is_primary || is_ci
+            is_ci
         };
 
         // If only a single persistent task is being ran, we should not prefix the output.

--- a/crates/task-runner/src/task_runner.rs
+++ b/crates/task-runner/src/task_runner.rs
@@ -128,7 +128,15 @@ impl<'task> TaskRunner<'task> {
         context: &ActionContext,
         node: &ActionNode,
     ) -> miette::Result<TaskRunResult> {
+        let is_primary = context.is_primary_target(&self.task.target);
+
         self.report.output_prefix = Some(context.get_target_prefix(&self.task.target));
+        self.report.output_style = if is_primary {
+            None
+        } else {
+            self.task.options.output_style
+        };
+        self.report.primary = is_primary;
 
         let result = self.internal_run(context, node).await;
 

--- a/website/docs/config/project.mdx
+++ b/website/docs/config/project.mdx
@@ -1597,9 +1597,9 @@ tasks:
 
 <HeadingApiLink to="/api/types/interface/TaskOptionsConfig#outputStyle" />
 
-Controls how stdout/stderr is displayed when the task is ran as a _transitive target_. By default,
-this setting is not defined and defers to the action pipeline, but can be overridden with one of the
-following values:
+Controls how stdout/stderr is displayed when the task is run as a _transitive (non-primary) target_.
+Primary targets always display their output and ignore this setting. By default, this setting is not
+defined and defers to the action pipeline, but can be overridden with one of the following values:
 
 - `buffer` - Buffers output and displays after the task has exited (either success or failure).
 - `buffer-only-failure` - Like `buffer`, but only displays on failures.


### PR DESCRIPTION
## Summary

- Apply `outputStyle` only to transitive (non-primary) tasks.
- Keep primary-task output visible on both execution and cache replay.
- Document the primary/transitive distinction and add regression coverage.

## Root cause

An explicit output style overrode the primary-target streaming default and was retained when replaying cached logs.

## Validation

- `cargo fmt --all -- --check`
- `just lint`
- `cargo nextest run -p moon_cli --test exec_test output_styles::none --no-fail-fast`
- `cargo nextest run -p moon_cli --test exec_test output_styles::ignores_style_for_direct_tasks --no-fail-fast`

Closes #2004.