### PR TITLE
fix: Invalidate cached project graph when a source project is removed

### DIFF
--- a/crates/app/src/session_atomic.rs
+++ b/crates/app/src/session_atomic.rs
@@ -28,6 +28,17 @@ impl MoonSession {
         });
     }
 
+    pub fn rebuild_context(&self, state: AtomicDaemonState) -> JoinHandle<()> {
+        let session = self.clone();
+
+        tokio::spawn(async move {
+            if let Ok(app_context) = session.get_app_context().await {
+                let mut state = state.write().await;
+                state.app_context = app_context;
+            }
+        })
+    }
+
     pub fn rebuild_graphs(&self, state: AtomicDaemonState) -> JoinHandle<()> {
         debug!("Rebuilding project and task graphs");
 

--- a/crates/app/src/session_atomic.rs
+++ b/crates/app/src/session_atomic.rs
@@ -34,8 +34,12 @@ impl MoonSession {
         let session = self.clone();
 
         tokio::spawn(async move {
-            if let Ok(graph) = session.get_workspace_graph().await {
-                state.write().await.workspace_graph = graph;
+            if let Ok(graph) = session.get_workspace_graph().await
+                && let Ok(app_context) = session.get_app_context().await
+            {
+                let mut state = state.write().await;
+                state.app_context = app_context;
+                state.workspace_graph = graph;
             }
         })
     }

--- a/crates/app/src/watchers/workspace_watcher.rs
+++ b/crates/app/src/watchers/workspace_watcher.rs
@@ -14,6 +14,7 @@ use tokio::task::JoinHandle;
 use tracing::debug;
 
 pub struct WorkspaceWatcher {
+    context_handle: Option<JoinHandle<()>>,
     graph_handle: Option<JoinHandle<()>>,
     session: MoonSession,
 
@@ -27,6 +28,7 @@ impl WorkspaceWatcher {
         let exts_group = format!("({})", session.config_loader.extensions.join("|"));
 
         Self {
+            context_handle: None,
             graph_handle: None,
             session,
             project_config_regex: Regex::new(&format!(r"(^|/)moon\.{exts_group}$")).unwrap(),
@@ -123,6 +125,18 @@ impl WorkspaceWatcher {
         Ok(false)
     }
 
+    async fn rebuild_context(&mut self, state: &AtomicDaemonState) -> miette::Result<()> {
+        // Abort any existing graph building
+        if let Some(handle) = self.context_handle.take() {
+            handle.abort();
+        }
+
+        // Rebuild the graphs in a background thread
+        self.context_handle = Some(self.session.rebuild_context(Arc::clone(state)));
+
+        Ok(())
+    }
+
     async fn rebuild_graphs(&mut self, state: &AtomicDaemonState) -> miette::Result<()> {
         // Abort any existing graph building
         if let Some(handle) = self.graph_handle.take() {
@@ -149,7 +163,7 @@ impl WorkspaceWatcher {
 
         self.session.proto_env = Arc::new(env);
         self.session.reset_components();
-        self.rebuild_graphs(state).await?;
+        self.rebuild_context(state).await?;
 
         Ok(())
     }
@@ -171,10 +185,10 @@ impl WorkspaceWatcher {
         // Invalidate the extensions registry if the extensions config changed
         if invalidate {
             self.session.reset_components();
-            self.rebuild_graphs(state).await?;
-        } else {
-            state.write().await.app_context = self.session.get_app_context().await?;
+            self.session.download_extensions();
         }
+
+        self.rebuild_context(state).await?;
 
         Ok(())
     }
@@ -204,7 +218,7 @@ impl WorkspaceWatcher {
             self.session.reset_components();
             self.rebuild_graphs(state).await?;
         } else {
-            state.write().await.app_context = self.session.get_app_context().await?;
+            self.rebuild_context(state).await?;
         }
 
         Ok(())
@@ -227,10 +241,10 @@ impl WorkspaceWatcher {
         // Invalidate the toolchain registry if the toolchains config changed
         if invalidate {
             self.session.reset_components();
-            self.rebuild_graphs(state).await?;
-        } else {
-            state.write().await.app_context = self.session.get_app_context().await?;
+            self.session.download_toolchains();
         }
+
+        self.rebuild_context(state).await?;
 
         Ok(())
     }
@@ -275,7 +289,7 @@ impl WorkspaceWatcher {
         if rebuild {
             self.rebuild_graphs(state).await?;
         } else {
-            state.write().await.app_context = self.session.get_app_context().await?;
+            self.rebuild_context(state).await?;
         }
 
         Ok(())

--- a/crates/app/src/watchers/workspace_watcher.rs
+++ b/crates/app/src/watchers/workspace_watcher.rs
@@ -149,8 +149,7 @@ impl WorkspaceWatcher {
 
         self.session.proto_env = Arc::new(env);
         self.session.reset_components();
-
-        state.write().await.app_context = self.session.get_app_context().await?;
+        self.rebuild_graphs(state).await?;
 
         Ok(())
     }
@@ -172,10 +171,10 @@ impl WorkspaceWatcher {
         // Invalidate the extensions registry if the extensions config changed
         if invalidate {
             self.session.reset_components();
-            self.session.download_extensions();
+            self.rebuild_graphs(state).await?;
+        } else {
+            state.write().await.app_context = self.session.get_app_context().await?;
         }
-
-        state.write().await.app_context = self.session.get_app_context().await?;
 
         Ok(())
     }
@@ -204,9 +203,9 @@ impl WorkspaceWatcher {
         if invalidate {
             self.session.reset_components();
             self.rebuild_graphs(state).await?;
+        } else {
+            state.write().await.app_context = self.session.get_app_context().await?;
         }
-
-        state.write().await.app_context = self.session.get_app_context().await?;
 
         Ok(())
     }
@@ -228,10 +227,10 @@ impl WorkspaceWatcher {
         // Invalidate the toolchain registry if the toolchains config changed
         if invalidate {
             self.session.reset_components();
-            self.session.download_toolchains();
+            self.rebuild_graphs(state).await?;
+        } else {
+            state.write().await.app_context = self.session.get_app_context().await?;
         }
-
-        state.write().await.app_context = self.session.get_app_context().await?;
 
         Ok(())
     }
@@ -275,9 +274,9 @@ impl WorkspaceWatcher {
         // Must run after the new config has been set!
         if rebuild {
             self.rebuild_graphs(state).await?;
+        } else {
+            state.write().await.app_context = self.session.get_app_context().await?;
         }
-
-        state.write().await.app_context = self.session.get_app_context().await?;
 
         Ok(())
     }

--- a/crates/project-graph/tests/project_graph_test.rs
+++ b/crates/project-graph/tests/project_graph_test.rs
@@ -607,6 +607,27 @@ mod project_graph {
                     }
 
                     #[tokio::test(flavor = "multi_thread")]
+                    async fn invalidates_with_removed_source() {
+                        // Prime the cache with a project that is removed before
+                        // the next graph build. This mirrors reverting a newly
+                        // created project from a workspace.
+                        let sandbox = build_plugins_cached_graph($async_graph, |sandbox| {
+                            sandbox.create_file("z/moon.yml", "# Changes");
+                        })
+                        .await;
+
+                        let state1 = load_state(&sandbox);
+
+                        fs::remove_dir_all(sandbox.path().join("z")).unwrap();
+
+                        let graph = do_generate_with_plugins(sandbox.path(), $async_graph).await;
+                        let state2 = load_state(&sandbox);
+
+                        assert_ne!(state1.last_hash, state2.last_hash);
+                        assert!(graph.get_project("z").is_err());
+                    }
+
+                    #[tokio::test(flavor = "multi_thread")]
                     async fn invalidates_with_new_manifest_file() {
                         test_plugins_invalidate(
                             $async_graph,


### PR DESCRIPTION
## Summary
- Add coverage for the case where a cached graph includes a project that is later deleted from disk.
- Verify the graph hash changes after the removal and the deleted project is no longer returned.

## Testing
- Added a regression test covering cache invalidation after removing a project directory.
- Not run (not requested)