### PR TITLE
fix: Expand skipped task dependents when a task is revisited in scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   task `env` option.
 - Fixed an issue where task `outputStyle` was being applied to the primary target. It will only
   apply to transitive targets.
+- Fixed an issue where a task's dependents would not run when requested with a downstream scope
+  (`moon ci`, `--dependents`, `--downstream`), if the task was first added to the action graph as a
+  dependency of another target. For example, `moon run app:build lib:build --dependents` would skip
+  the dependents of `lib:build` when `app:build` depends on it.
 
 ## 2.4.2
 

--- a/crates/action-graph/src/action_graph_builder.rs
+++ b/crates/action-graph/src/action_graph_builder.rs
@@ -133,6 +133,10 @@ pub struct ActionGraphBuilder<'query> {
 
     // Target tracking
     ignored_dependencies: FxHashMap<Target, FxHashSet<Target>>,
+    // Tasks whose dependents were out of scope when their node was created.
+    // Consumed when the task is revisited with dependents in scope, since the
+    // node-exists early return would otherwise skip the expansion entirely.
+    ignored_dependents: FxHashSet<Target>,
     passthrough_targets: FxHashSet<Target>,
     primary_targets: FxHashSet<Target>,
 
@@ -159,6 +163,7 @@ impl<'query> ActionGraphBuilder<'query> {
             nodes: FxHashMap::default(),
             options,
             ignored_dependencies: FxHashMap::default(),
+            ignored_dependents: FxHashSet::default(),
             passthrough_targets: FxHashSet::default(),
             primary_targets: FxHashSet::default(),
             serial_edges: FxHashSet::default(),
@@ -998,6 +1003,12 @@ impl<'query> ActionGraphBuilder<'query> {
             false
         };
 
+        let had_ignored_dependents = if should_run_dependents {
+            self.ignored_dependents.remove(&task.target)
+        } else {
+            false
+        };
+
         // Check if the node exists to avoid all the overhead below
         if let Some(index) = self.get_index_from_node(&node) {
             if had_ignored_dependencies && !task.deps.is_empty() {
@@ -1006,6 +1017,12 @@ impl<'query> ActionGraphBuilder<'query> {
                 let edges = Box::pin(self.run_task_dependencies(task, &child_reqs, state)).await?;
 
                 self.link_optional_requirements(index, edges)?;
+            }
+
+            if had_ignored_dependents {
+                child_reqs.skip_affected = false;
+
+                Box::pin(self.run_task_dependents(task, &child_reqs, state)).await?;
             }
 
             return Ok(Some(index));
@@ -1047,6 +1064,8 @@ impl<'query> ActionGraphBuilder<'query> {
             child_reqs.skip_affected = false;
 
             Box::pin(self.run_task_dependents(task, &child_reqs, state)).await?;
+        } else {
+            self.ignored_dependents.insert(task.target.clone());
         }
 
         Ok(Some(index))

--- a/crates/action-graph/tests/action_graph_builder_test.rs
+++ b/crates/action-graph/tests/action_graph_builder_test.rs
@@ -2049,6 +2049,54 @@ mod action_graph_builder {
 
                 assert_snapshot!(graph.to_dot());
             }
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn expands_skipped_dependents_when_task_is_revisited_in_scope() {
+                let sandbox = create_sandbox("tasks");
+                let mut container = ActionGraphContainer::new(sandbox.path());
+
+                let wg = container.create_workspace_graph().await;
+                let mut builder = container.create_builder(wg.clone()).await;
+
+                let parent = wg.get_task_from_project("deps", "parent1").unwrap();
+                let task = wg.get_task_from_project("deps", "base").unwrap();
+
+                // First insert the task as a dependency of another target,
+                // with dependents out of scope
+                builder
+                    .run_task(
+                        &parent,
+                        &RunRequirements {
+                            dependencies: UpstreamScope::Deep,
+                            dependents: DownstreamScope::None,
+                            ..RunRequirements::default()
+                        },
+                    )
+                    .await
+                    .unwrap();
+
+                // Then run it as an explicit target with dependents in scope
+                builder
+                    .run_task(
+                        &task,
+                        &RunRequirements {
+                            dependencies: UpstreamScope::Deep,
+                            dependents: DownstreamScope::Direct,
+                            ..RunRequirements::default()
+                        },
+                    )
+                    .await
+                    .unwrap();
+
+                let (_, graph) = builder.build();
+
+                assert_snapshot!(graph.to_dot());
+
+                assert!(topo(graph).into_iter().any(|node| matches!(
+                    node,
+                    ActionNode::RunTask(inner) if inner.target == Target::parse("deps:parent2").unwrap()
+                )));
+            }
         }
     }
 

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__run_task__dependents__expands_skipped_dependents_when_task_is_revisited_in_scope.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__run_task__dependents__expands_skipped_dependents_when_task_is_revisited_in_scope.snap
@@ -1,0 +1,23 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+    0 [ label="SyncWorkspace"]
+    1 [ label="SyncProject(deps)"]
+    2 [ label="RunTask(deps:parent1)"]
+    3 [ label="RunTask(deps:base)"]
+    4 [ label="RunTask(deps:parent2)"]
+    5 [ label="SyncProject(deps-external)"]
+    6 [ label="RunTask(deps-external:external)"]
+    1 -> 0 [ label="required"]
+    3 -> 1 [ label="required"]
+    2 -> 1 [ label="required"]
+    2 -> 3 [ label="required"]
+    4 -> 1 [ label="required"]
+    4 -> 3 [ label="required"]
+    5 -> 0 [ label="required"]
+    5 -> 1 [ label="required"]
+    6 -> 5 [ label="required"]
+    6 -> 3 [ label="required"]
+}


### PR DESCRIPTION
Part of #2198 (does not close it — the affected-tracker defects in that issue are separate and still open).

## Problem

When a task node was first added to the action graph as a **dependency** of another target, its dependents were never expanded: the node-exists early return in `internal_run_task` skipped the `run_task_dependents` block on every subsequent visit, even when the revisit requested a downstream scope.

Reproduction (tracker-free, deterministic):

- `moon run lib:build --dependents` → runs `lib:build` + all direct dependents ✅
- `moon run app:build lib:build --dependents` (where `app` depends on `lib`) → runs **only** `app:build` and `lib:build` ❌ — `app:build` inserts `lib:build` as a dependency first, and the early return then swallows the dependent expansion on `lib:build`'s own visit.

This is the v2 incarnation of the "skips tasks if it's processed before" behavior called out in #2198.

## Fix

Mirror the existing `ignored_dependencies` bookkeeping with an `ignored_dependents` set:

- When a node is created with dependents **out of scope**, record its target.
- When the task is revisited with dependents **in scope**, consume the entry and replay `run_task_dependents` from the node-exists branch, with the same `skip_affected` semantics and depth as the main path.

The set stays builder-internal — unlike `ignored_dependencies`, nothing at runtime needs to query it (a never-inserted dependent is simply not awaited). The passthrough early return was intentionally left alone: reaching the same hole there requires a `runInCI: true` task depending on a `runInCI: false` task, which config validation forbids.

## Verification

- New regression test `expands_skipped_dependents_when_task_is_revisited_in_scope` — fails without the fix; its snapshot shows both previously-swallowed dependents (`deps:parent2`, `deps-external:external`) in the graph.
- `moon_action_graph`: 126/126 pass with **no changes to existing snapshots** (no unintended graph shape changes).
- `moon_cli` `exec_test` + `action_graph_test`: 174/174 pass.
- E2E on a 7-project repro workspace: the two-target run above goes from 2 tasks to the full dependent set, single-target behavior unchanged, and the full `moon ci` matrix (default/`-g`, sync/async tracking) is byte-identical to before — no over-inclusion introduced (transitive dependents stay excluded under `direct`).
- `cargo fmt` + `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)