### PR TITLE
fix: Preserve non-UTF-8 output in captured task logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   task `env` option.
 - Fixed an issue where task `outputStyle` was being applied to the primary target. It will only
   apply to transitive targets.
+- Fixed an issue where captured task output containing non-UTF-8 bytes (for example, Windows
+  codepage output from Python) was discarded entirely, resulting in empty `stdout.log`/`stderr.log`
+  state files, cache hits replaying no output, and missing output in run reports. Invalid bytes are
+  now replaced with `�` instead.
 
 ## 2.4.2
 

--- a/crates/action/src/operation.rs
+++ b/crates/action/src/operation.rs
@@ -148,8 +148,10 @@ impl Operation {
                 output.exit_status = Some(status);
             }
 
-            output.set_stderr(String::from_utf8(stderr).unwrap_or_default());
-            output.set_stdout(String::from_utf8(stdout).unwrap_or_default());
+            // Lossy conversion, as output from foreign processes may not
+            // be UTF-8 (Windows codepages, etc), and we can't lose it all
+            output.set_stderr(String::from_utf8_lossy(&stderr).into_owned());
+            output.set_stdout(String::from_utf8_lossy(&stdout).into_owned());
         }
 
         self.finish(if success {

--- a/crates/action/tests/operation_test.rs
+++ b/crates/action/tests/operation_test.rs
@@ -1,0 +1,44 @@
+use moon_action::Operation;
+
+mod finish_from_output {
+    use super::*;
+
+    #[test]
+    fn preserves_utf8_output() {
+        let mut operation = Operation::task_execution("pytest");
+
+        operation.finish_from_output(
+            None,
+            b"tests passed\n".to_vec(),
+            b"warning issued\n".to_vec(),
+        );
+
+        let output = operation.get_exec_output().unwrap();
+
+        assert_eq!(output.stdout.as_deref().unwrap(), "tests passed\n");
+        assert_eq!(output.stderr.as_deref().unwrap(), "warning issued\n");
+    }
+
+    #[test]
+    fn preserves_non_utf8_output_lossily() {
+        let mut operation = Operation::task_execution("pytest");
+
+        // 0xFC is `ü` in Windows codepage 1252, but invalid UTF-8
+        operation.finish_from_output(
+            None,
+            b"person=\"Hans M\xfcller\",\nFAILED tests\n".to_vec(),
+            b"locator(\"Absenden f\xfcr alle\")\n".to_vec(),
+        );
+
+        let output = operation.get_exec_output().unwrap();
+
+        assert_eq!(
+            output.stdout.as_deref().unwrap(),
+            "person=\"Hans M\u{fffd}ller\",\nFAILED tests\n"
+        );
+        assert_eq!(
+            output.stderr.as_deref().unwrap(),
+            "locator(\"Absenden f\u{fffd}r alle\")\n"
+        );
+    }
+}


### PR DESCRIPTION
Closes #2394 — the last remaining defect behind the pytest output truncation report.

## Root cause

The reporter's pytest output is cp1252 (German-locale Windows, Python ≤ 3.14 uses the ANSI codepage for piped stdout), so `ü` arrives as the single byte `0xFC` — invalid UTF-8. The truncation as originally reported was caused by the strict UTF-8 line readers in `moon_process` (`break` on read error until #2463, per-line drops until the bytes rework in #2567 / v2.4.0). Streaming has been byte-exact since v2.4.0.

However, `Operation::finish_from_output` still converted the captured bytes with `String::from_utf8(...).unwrap_or_default()`, so a single invalid byte silently erased the **entire** captured stdout/stderr. Verified fallout on v2.4.2:

- `stdout.log` / `stderr.log` state files written as 0 bytes (also empty inside the cache archive)
- cache hits replay no output at all (an ASCII-only control task replays fine)
- run reports and `print_operation_output` paths (`bufferOnlyFailure`, retry/pipeline-failure summaries) lose all output

## Change

- Convert captured output lossily (`String::from_utf8_lossy`), matching the existing hydration path (`task_runner.rs`) and `output_to_error` (`moon_process`). Invalid bytes render as `�` in persisted logs; the live stream is unaffected (it never goes through this conversion).
- Regression tests for `finish_from_output` with valid and invalid UTF-8.
- Changelog entry.

## Verification

Repro harness: a task printing a pytest-style failure with `0xFC` bytes mid-output. Before: 0-byte `stdout.log`, silent cache replays. After: full log content with `�` replacements, cache hits replay all lines. `cargo nextest run -p moon_action`, `cargo clippy -p moon_action --all-targets`, and `cargo fmt --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)