### PR TITLE
fix: Place synced VCS hooks alongside the workspace config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 - Fixed tasks that emit read-only outputs (e.g. `0444` files) failing on every cache hit with a
   "Permission denied" error when the `casOutputsCache` experiment is enabled. Caches that already
   contain read-only objects are healed automatically.
+- Fixed an issue where synced VCS hooks were always written to `.moon/hooks`, even when the workspace
+  configuration lived in `.config/moon`. Hooks are now placed alongside the config, in
+  `.config/moon/hooks`.
 
 ## 2.4.2
 

--- a/crates/vcs-hooks/tests/hooks_generator_test.rs
+++ b/crates/vcs-hooks/tests/hooks_generator_test.rs
@@ -211,6 +211,41 @@ mod vcs_hooks {
         assert!(config.contains("hooksPath ="));
     }
 
+    #[tokio::test]
+    async fn places_hooks_alongside_config_moon_dir() {
+        let sandbox = create_empty_sandbox();
+        sandbox.enable_git();
+
+        // Workspace config lives at `.config/moon` instead of `.moon`
+        sandbox.create_file(".config/moon/workspace.yml", "");
+
+        run_generator(sandbox.path()).await;
+
+        // Hooks are placed alongside the config, not in `.moon`
+        assert!(
+            sandbox
+                .path()
+                .join(".config/moon/hooks/pre-commit")
+                .exists()
+        );
+        assert!(sandbox.path().join(".config/moon/hooks/post-push").exists());
+        assert!(!sandbox.path().join(".moon/hooks").exists());
+
+        // And the git config points to the correct directory
+        let config = fs::read_to_string(sandbox.path().join(".git/config")).unwrap();
+
+        assert!(config.contains(".config/moon/hooks"));
+
+        clean_generator(sandbox.path()).await;
+
+        assert!(!sandbox.path().join(".config/moon/hooks").exists());
+        assert!(
+            !fs::read_to_string(sandbox.path().join(".git/config"))
+                .unwrap()
+                .contains("hooksPath =")
+        );
+    }
+
     #[cfg(unix)]
     mod unix {
         use super::*;

--- a/crates/vcs-hooks/tests/hooks_generator_test.rs
+++ b/crates/vcs-hooks/tests/hooks_generator_test.rs
@@ -231,8 +231,12 @@ mod vcs_hooks {
         assert!(sandbox.path().join(".config/moon/hooks/post-push").exists());
         assert!(!sandbox.path().join(".moon/hooks").exists());
 
-        // And the git config points to the correct directory
-        let config = fs::read_to_string(sandbox.path().join(".git/config")).unwrap();
+        // And the git config points to the correct directory. Normalize the
+        // separators, as Git stores Windows paths with escaped backslashes.
+        let config = fs::read_to_string(sandbox.path().join(".git/config"))
+            .unwrap()
+            .replace(r"\\", "/")
+            .replace('\\', "/");
 
         assert!(config.contains(".config/moon/hooks"));
 

--- a/crates/vcs/src/git/git_client.rs
+++ b/crates/vcs/src/git/git_client.rs
@@ -12,6 +12,7 @@ use gix::{
 use miette::IntoDiagnostic;
 use moon_common::path::{
     PathExt, RelativePathBuf, WorkspaceRelativePath, WorkspaceRelativePathBuf, clean_components,
+    locate_config_dir,
 };
 use moon_process::find_command_on_path;
 use semver::Version;
@@ -731,8 +732,9 @@ impl Vcs for Git {
             ..Default::default()
         };
 
-        // The hooks directory that moon owns and manages
-        let hooks_dir = self.workspace_root.join(".moon").join("hooks");
+        // The hooks directory that moon owns and manages. This lives alongside
+        // the workspace config, which may be `.moon` or `.config/moon`.
+        let hooks_dir = locate_config_dir(&self.workspace_root).join("hooks");
 
         // Check if the path has already been configured. Only accept the
         // exact moon-owned directory, otherwise we may adopt a directory

--- a/website/docs/guides/vcs-hooks.mdx
+++ b/website/docs/guides/vcs-hooks.mdx
@@ -115,7 +115,8 @@ When hooks are [enabled](#enabling-hooks), the following processes will take pla
 1. The configured [hooks](#defining-hooks) will be generated as individual script files in the
    `.moon/hooks` directory. Whether or not you commit or ignore these script files is your choice.
    They are written to the `.moon` directory so that they can be reviewed, audited, and easily
-   tested, but _are required_.
+   tested, but _are required_. If your workspace configuration lives in `.config/moon` instead of
+   `.moon`, the hooks are written to `.config/moon/hooks`.
 
 2. We then sync these generated hook scripts with the current VCS. For Git, we set `core.hooksPath`
    to point to the `.moon/hooks` directory, which tells Git to look for hook scripts in that


### PR DESCRIPTION
## Summary

Fixes #2574.

When a workspace configuration lives in `.config/moon` instead of `.moon`, synced VCS hooks were **always** written to `.moon/hooks` — along with the `core.hooksPath` git config pointing there — mixing the two directory trees.

`Git::setup_hooks` hardcoded the directory:

```rust
let hooks_dir = self.workspace_root.join(".moon").join("hooks");
```

This was a leftover from #2569, which already taught the hook **cleanup** path (`hooks_generator.rs`) about `.config/moon/hooks` but missed the **generation** path in the git client.

## Fix

Resolve the hooks directory from the actual config location using the same `locate_config_dir` helper the rest of the codebase uses:

```rust
let hooks_dir = locate_config_dir(&self.workspace_root).join("hooks");
```

When `.config/moon` exists it wins (matching `config_loader.locate_dir`); otherwise it falls back to `.moon`, so default setups are unaffected.

## Test plan

- New `places_hooks_alongside_config_moon_dir` test verifying placement in `.config/moon/hooks`, the `core.hooksPath` git config, and cleanup.
- `moon_vcs_hooks`: 11/11 pass · `moon_vcs` + `moon_actions` hooks tests: 5/5 pass.
- `just format` clean · `cargo clippy` (`-D warnings`) clean.
- CHANGELOG + `vcs-hooks.mdx` docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)