### PR TITLE
fix: Exclude local index from changed files when an explicit head is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@
   contain read-only objects are healed automatically.
 - Fixed an issue where `moon query changed-files` would include uncommitted changes from the local
   index (`git status`) even when an explicit `--head` revision was provided, causing false positives
-  when comparing 2 revisions. This also applies to affected detection with an explicit head, e.g the
-  `MOON_HEAD` environment variable or `--affected base:head`. Additionally, `MOON_BASE` and
+  when comparing 2 revisions. This also applies to affected detection with an explicit head, e.g.
+  the `MOON_HEAD` environment variable or `--affected base:head`. Additionally, `MOON_BASE` and
   `MOON_HEAD` environment variables that are set but empty are now ignored.
 
 ## 2.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
 - Fixed tasks that emit read-only outputs (e.g. `0444` files) failing on every cache hit with a
   "Permission denied" error when the `casOutputsCache` experiment is enabled. Caches that already
   contain read-only objects are healed automatically.
+- Fixed an issue where `moon query changed-files` would include uncommitted changes from the local
+  index (`git status`) even when an explicit `--head` revision was provided, causing false positives
+  when comparing 2 revisions. This also applies to affected detection with an explicit head, e.g the
+  `MOON_HEAD` environment variable or `--affected base:head`. Additionally, `MOON_BASE` and
+  `MOON_HEAD` environment variables that are set but empty are now ignored.
 
 ## 2.4.2
 

--- a/crates/app/src/queries/changed_files.rs
+++ b/crates/app/src/queries/changed_files.rs
@@ -87,9 +87,17 @@ async fn query_changed_files_without_stdin(
     let bag = GlobalEnvBag::instance();
     let default_branch = vcs.get_default_branch().await?;
     let current_branch = vcs.get_local_branch().await?;
-    let base_value = bag.get("MOON_BASE").or(options.base.clone());
+    // Treat empty values as not provided, as CI templates typically
+    // pass these environment variables through unconditionally
+    let base_value = bag
+        .get("MOON_BASE")
+        .or(options.base.clone())
+        .filter(|value| !value.is_empty());
     let base = base_value.as_deref().unwrap_or(&default_branch);
-    let head_value = bag.get("MOON_HEAD").or(options.head.clone());
+    let head_value = bag
+        .get("MOON_HEAD")
+        .or(options.head.clone())
+        .filter(|value| !value.is_empty());
     let head = head_value.as_deref().unwrap_or("HEAD");
 
     // Determine whether we should check against the previous
@@ -110,7 +118,7 @@ async fn query_changed_files_without_stdin(
         );
     }
 
-    let only_local = options.local && base_value.is_none();
+    let only_local = options.local && base_value.is_none() && head_value.is_none();
     let mut changed_files_map = ChangedFiles::default();
     let mut changed_files = FxHashSet::default();
 
@@ -138,10 +146,14 @@ async fn query_changed_files_without_stdin(
         }
     }
 
-    // Always include local changes
-    debug!("Against local index");
+    // Only include local changes when the head is the working tree;
+    // an explicit head requests a comparison between 2 revisions,
+    // of which the local index is not a part of
+    if head_value.is_none() {
+        debug!("Against local index");
 
-    changed_files_map.merge(vcs.get_changed_files().await?);
+        changed_files_map.merge(vcs.get_changed_files().await?);
+    }
 
     if options.status.is_empty() {
         debug!(

--- a/crates/app/src/queries/changed_files.rs
+++ b/crates/app/src/queries/changed_files.rs
@@ -88,14 +88,17 @@ async fn query_changed_files_without_stdin(
     let default_branch = vcs.get_default_branch().await?;
     let current_branch = vcs.get_local_branch().await?;
     // Treat empty values as not provided, as CI templates typically
-    // pass these environment variables through unconditionally
+    // pass these environment variables through unconditionally. An empty
+    // environment variable must not mask an explicit option either
     let base_value = bag
         .get("MOON_BASE")
+        .filter(|value| !value.is_empty())
         .or(options.base.clone())
         .filter(|value| !value.is_empty());
     let base = base_value.as_deref().unwrap_or(&default_branch);
     let head_value = bag
         .get("MOON_HEAD")
+        .filter(|value| !value.is_empty())
         .or(options.head.clone())
         .filter(|value| !value.is_empty());
     let head = head_value.as_deref().unwrap_or("HEAD");

--- a/crates/cli/tests/query_changed_files_test.rs
+++ b/crates/cli/tests/query_changed_files_test.rs
@@ -49,6 +49,106 @@ mod query_changed_files {
     }
 
     #[test]
+    fn excludes_local_index_with_explicit_head() {
+        let sandbox = create_query_sandbox();
+
+        sandbox.create_file("basic/committed.txt", "contents");
+
+        sandbox.run_git(|cmd| {
+            cmd.args(["add", "--all", "."]);
+        });
+
+        sandbox.run_git(|cmd| {
+            cmd.args(["commit", "-m", "Commit"]);
+        });
+
+        // Should not appear in the revision to revision diff
+        sandbox.create_file("basic/dirty.txt", "contents");
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("query")
+                .arg("changed-files")
+                .args(["--base", "HEAD~1", "--head", "HEAD"]);
+        });
+
+        let json: QueryChangedFilesResult = serde_json::from_str(assert.stdout().trim()).unwrap();
+
+        assert_eq!(
+            json.files.into_iter().collect::<Vec<_>>(),
+            ["basic/committed.txt"]
+        );
+    }
+
+    #[test]
+    fn includes_local_index_without_explicit_head() {
+        let sandbox = create_query_sandbox();
+
+        sandbox.create_file("basic/committed.txt", "contents");
+
+        sandbox.run_git(|cmd| {
+            cmd.args(["add", "--all", "."]);
+        });
+
+        sandbox.run_git(|cmd| {
+            cmd.args(["commit", "-m", "Commit"]);
+        });
+
+        sandbox.create_file("basic/dirty.txt", "contents");
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("query")
+                .arg("changed-files")
+                .args(["--base", "HEAD~1"]);
+        });
+
+        let json: QueryChangedFilesResult = serde_json::from_str(assert.stdout().trim()).unwrap();
+
+        let mut files = json
+            .files
+            .into_iter()
+            .filter(|file| !file.as_str().starts_with(".moon"))
+            .collect::<Vec<_>>();
+        files.sort();
+
+        assert_eq!(files, ["basic/committed.txt", "basic/dirty.txt"]);
+    }
+
+    #[test]
+    fn treats_empty_head_as_working_tree() {
+        let sandbox = create_query_sandbox();
+
+        sandbox.create_file("basic/committed.txt", "contents");
+
+        sandbox.run_git(|cmd| {
+            cmd.args(["add", "--all", "."]);
+        });
+
+        sandbox.run_git(|cmd| {
+            cmd.args(["commit", "-m", "Commit"]);
+        });
+
+        sandbox.create_file("basic/dirty.txt", "contents");
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("query")
+                .arg("changed-files")
+                .args(["--base", "HEAD~1"])
+                .env("MOON_HEAD", "");
+        });
+
+        let json: QueryChangedFilesResult = serde_json::from_str(assert.stdout().trim()).unwrap();
+
+        let mut files = json
+            .files
+            .into_iter()
+            .filter(|file| !file.as_str().starts_with(".moon"))
+            .collect::<Vec<_>>();
+        files.sort();
+
+        assert_eq!(files, ["basic/committed.txt", "basic/dirty.txt"]);
+    }
+
+    #[test]
     fn can_supply_multi_status() {
         let sandbox = create_query_sandbox();
 

--- a/crates/cli/tests/query_changed_files_test.rs
+++ b/crates/cli/tests/query_changed_files_test.rs
@@ -149,6 +149,38 @@ mod query_changed_files {
     }
 
     #[test]
+    fn empty_env_vars_dont_mask_explicit_args() {
+        let sandbox = create_query_sandbox();
+
+        sandbox.create_file("basic/committed.txt", "contents");
+
+        sandbox.run_git(|cmd| {
+            cmd.args(["add", "--all", "."]);
+        });
+
+        sandbox.run_git(|cmd| {
+            cmd.args(["commit", "-m", "Commit"]);
+        });
+
+        sandbox.create_file("basic/dirty.txt", "contents");
+
+        let assert = sandbox.run_bin(|cmd| {
+            cmd.arg("query")
+                .arg("changed-files")
+                .args(["--base", "HEAD~1", "--head", "HEAD"])
+                .env("MOON_BASE", "")
+                .env("MOON_HEAD", "");
+        });
+
+        let json: QueryChangedFilesResult = serde_json::from_str(assert.stdout().trim()).unwrap();
+
+        assert_eq!(
+            json.files.into_iter().collect::<Vec<_>>(),
+            ["basic/committed.txt"]
+        );
+    }
+
+    #[test]
     fn can_supply_multi_status() {
         let sandbox = create_query_sandbox();
 

--- a/website/docs/commands/query/changed-files.mdx
+++ b/website/docs/commands/query/changed-files.mdx
@@ -15,8 +15,9 @@ Changed files are determined using the following logic:
   uses.
 - If `--local` is provided, changed files are based on your local index only (`git status`).
 - Otherwise, then compare the defined base (`--base`) against head (`--head`).
-- Additionally, unless an explicit `--head` revision is provided, changed files in your local index
-  (`git status`) are also included.
+- When no explicit `--head` is provided, the comparison targets your working tree, so changed files
+  in your local index (`git status`) are also included. An explicit `--head` is a pure revision to
+  revision comparison, and does not include the local index.
 
 ```shell
 # Return all files

--- a/website/docs/commands/query/changed-files.mdx
+++ b/website/docs/commands/query/changed-files.mdx
@@ -15,6 +15,8 @@ Changed files are determined using the following logic:
   uses.
 - If `--local` is provided, changed files are based on your local index only (`git status`).
 - Otherwise, then compare the defined base (`--base`) against head (`--head`).
+- Additionally, unless an explicit `--head` revision is provided, changed files in your local index
+  (`git status`) are also included.
 
 ```shell
 # Return all files


### PR DESCRIPTION
Closes #2511 — the remaining half. The v2.4 VCS rework (#2569) fixed the dropped `--head` (two-arg diff via merge-base), but `moon query changed-files` still unconditionally merged `git status` into the results, so local uncommitted changes and untracked files appeared as false positives even when both `--base` and `--head` were explicit revisions. This broke commit-by-commit walks (release notes, per-commit affected gating) on dirty checkouts.

## Changes

- **`git status` is only consulted when no explicit head is provided.** An explicit head requests a revision-to-revision comparison, of which the working tree is not a part. Base-only queries (head defaults to the working tree) keep today's behavior.
- **Head-only queries now honor the head.** Previously `--head X` (or `MOON_HEAD` alone) in local mode returned local status only, silently ignoring the head — the same bug in different clothing. It now diffs `merge-base(defaultBranch, X)..X`. Without this, the status gate above would have made such queries return nothing at all.
- **Set-but-empty `MOON_BASE`/`MOON_HEAD` (and `--base`/`--head`) are treated as not provided**, since CI templates commonly pass these env vars through unconditionally.

## Verification

- 3 new CLI tests covering: explicit head excludes dirty files, no head includes them, empty `MOON_HEAD` behaves as unset.
- Reproduced the issue's scenario (linear commits, dirty tree): `--base PARENT --head MID` now returns exactly `git diff --name-only PARENT MID`, and trace logs confirm no `git status` invocation.
- `cargo nextest run -p moon_cli query exec`: 208/208 pass; clippy and rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)