### PR TITLE
fix: Comply with the RE API contract when uploading to a remote cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed remote caching against backends that validate the Bazel RE contract (like Depot), where
+  every upload was rejected with "client should not populate stdout_raw during upload" or "action
+  digest not found in CAS", leaving the cache permanently empty.
+- Fixed cache hits replaying no task output when a remote server returns a stdout/stderr digest
+  without also inlining the raw bytes.
+
 ## 2.4.3
 
 #### 🚀 Updates

--- a/crates/blob/src/blob.rs
+++ b/crates/blob/src/blob.rs
@@ -35,6 +35,7 @@ impl BlobContent {
     }
 }
 
+#[derive(Clone)]
 pub struct BlobInput {
     pub content: BlobContent,
     pub digest: Digest,

--- a/crates/cache-storage/src/manifest.rs
+++ b/crates/cache-storage/src/manifest.rs
@@ -56,19 +56,23 @@ impl Manifest {
             files,
             symlinks,
             exit_code: result.exit_code,
-            stderr_bytes: if result.stderr_digest.is_some() {
-                Some(Bytes::from(result.stderr_raw))
-            } else {
+            // Inlining the raw output is optional for a server, so key off the bytes it
+            // actually sent rather than the presence of a digest. Treating an empty
+            // `stdout_raw` as the payload would mark the manifest hydrated and replay no
+            // output on a cache hit; leaving it `None` lets hydration fetch the blob.
+            stderr_bytes: if result.stderr_raw.is_empty() {
                 None
+            } else {
+                Some(Bytes::from(result.stderr_raw))
             },
             stderr_digest: match result.stderr_digest {
                 Some(digest) => Some(digest.to_internal_digest()?),
                 None => None,
             },
-            stdout_bytes: if result.stdout_digest.is_some() {
-                Some(Bytes::from(result.stdout_raw))
-            } else {
+            stdout_bytes: if result.stdout_raw.is_empty() {
                 None
+            } else {
+                Some(Bytes::from(result.stdout_raw))
             },
             stdout_digest: match result.stdout_digest {
                 Some(digest) => Some(digest.to_internal_digest()?),
@@ -100,16 +104,14 @@ impl Manifest {
                 .map(|symlink| symlink.into_bazel_symlink())
                 .collect(),
             exit_code: self.exit_code,
+            // The RE API reserves `stdout_raw`/`stderr_raw` for server responses: a
+            // client that populates them when calling `UpdateActionResult` is rejected
+            // by backends that validate the contract ("client should not populate
+            // stdout_raw during upload"). The output is already uploaded to the CAS by
+            // `collect_blob_inputs` and referenced here by digest, so leave the raw
+            // fields empty and let the digests carry it.
             stderr_digest: self.stderr_digest.map(|digest| digest.to_external_digest()),
-            stderr_raw: self
-                .stderr_bytes
-                .map(|bytes| bytes.to_vec())
-                .unwrap_or_default(),
             stdout_digest: self.stdout_digest.map(|digest| digest.to_external_digest()),
-            stdout_raw: self
-                .stdout_bytes
-                .map(|bytes| bytes.to_vec())
-                .unwrap_or_default(),
             execution_metadata: Some(ExecutedActionMetadata {
                 worker: "moon".into(),
                 output_upload_completed_timestamp: self

--- a/crates/cache-storage/src/storage.rs
+++ b/crates/cache-storage/src/storage.rs
@@ -250,6 +250,7 @@ impl Storage {
                 digest.to_owned(),
                 manifest.clone(),
                 self.context.workspace_root.clone(),
+                self.context.cache_dir.clone(),
             ))));
         }
 
@@ -353,6 +354,7 @@ impl Storage {
                 digest.to_owned(),
                 manifest.clone(),
                 self.context.workspace_root.clone(),
+                self.context.cache_dir.clone(),
             ))));
         }
     }
@@ -417,8 +419,23 @@ async fn persist_manifest_in_backend(
     digest: Digest,
     mut manifest: Manifest,
     workspace_root: PathBuf,
+    cache_dir: PathBuf,
 ) -> miette::Result<()> {
-    let blob_inputs = manifest.collect_blob_inputs(&workspace_root);
+    let mut blob_inputs = manifest.collect_blob_inputs(&workspace_root);
+
+    // The action digest is the content hash (and byte length) of the hash manifest that
+    // produced it, so that manifest *is* the blob the digest addresses. Upload it with
+    // the outputs: backends that validate the RE contract reject an action result whose
+    // action digest is absent from the CAS ("action digest <hash>/<size> not found in
+    // CAS"), because a client is expected to have uploaded it before referencing it.
+    let action_blob_path = cache_dir.join("hashes").join(format!("{}.json", *digest));
+
+    if action_blob_path.exists() {
+        blob_inputs.push(BlobInput {
+            content: BlobContent::File(action_blob_path),
+            digest: digest.clone(),
+        });
+    }
 
     // Before we store the manifest, we should ensure all associated blobs are stored.
     // This ensures we don't end up with dangling manifests that reference missing blobs.

--- a/crates/cache-storage/src/storage.rs
+++ b/crates/cache-storage/src/storage.rs
@@ -227,6 +227,7 @@ impl Storage {
         &self,
         digest: &Digest,
         manifest: Manifest,
+        action_blob: Option<BlobInput>,
     ) -> miette::Result<()> {
         let mut background_tasks = self.background_tasks.lock().unwrap();
 
@@ -250,7 +251,7 @@ impl Storage {
                 digest.to_owned(),
                 manifest.clone(),
                 self.context.workspace_root.clone(),
-                self.context.cache_dir.clone(),
+                action_blob.clone(),
             ))));
         }
 
@@ -349,12 +350,15 @@ impl Storage {
                 "Warming local storage backend from remote cache hit"
             );
 
+            // No action blob here: warming targets local backends only, which
+            // don't validate the RE contract, so the fingerprint file needn't be
+            // re-stored into the local CAS.
             background_tasks.push(tokio::spawn(Box::pin(persist_manifest_in_backend(
                 Arc::clone(backend),
                 digest.to_owned(),
                 manifest.clone(),
                 self.context.workspace_root.clone(),
-                self.context.cache_dir.clone(),
+                None,
             ))));
         }
     }
@@ -419,23 +423,17 @@ async fn persist_manifest_in_backend(
     digest: Digest,
     mut manifest: Manifest,
     workspace_root: PathBuf,
-    cache_dir: PathBuf,
+    action_blob: Option<BlobInput>,
 ) -> miette::Result<()> {
     let mut blob_inputs = manifest.collect_blob_inputs(&workspace_root);
 
-    // The action digest is the content hash (and byte length) of the hash manifest that
-    // produced it, so that manifest *is* the blob the digest addresses. Upload it with
-    // the outputs: backends that validate the RE contract reject an action result whose
-    // action digest is absent from the CAS ("action digest <hash>/<size> not found in
-    // CAS"), because a client is expected to have uploaded it before referencing it.
-    let action_blob_path = cache_dir.join("hashes").join(format!("{}.json", *digest));
-
-    if action_blob_path.exists() {
-        blob_inputs.push(BlobInput {
-            content: BlobContent::File(action_blob_path),
-            digest: digest.clone(),
-        });
-    }
+    // The action digest addresses the hash manifest that produced it, so that
+    // file *is* the blob the digest names. The task runner (which owns the cache
+    // layout) supplies it, and it's uploaded with the outputs: backends that
+    // validate the RE contract reject an action result whose action digest is
+    // absent from the CAS ("action digest <hash>/<size> not found in CAS"),
+    // because a client is expected to have uploaded it before referencing it.
+    blob_inputs.extend(action_blob);
 
     // Before we store the manifest, we should ensure all associated blobs are stored.
     // This ensures we don't end up with dangling manifests that reference missing blobs.

--- a/crates/cache-storage/tests/manifest_test.rs
+++ b/crates/cache-storage/tests/manifest_test.rs
@@ -73,6 +73,54 @@ mod from_bazel {
     }
 
     #[test]
+    fn empty_stdio_raw_with_digest_keeps_no_inline_bytes() {
+        // Inlining the raw output is optional for a server, so a digest can arrive
+        // without bytes. Treating the empty raw as the payload would mark the manifest
+        // hydrated and replay no output on a cache hit.
+        let result = ActionResult {
+            stdout_digest: Some(BazelDigest {
+                hash: hex('c'),
+                size_bytes: 13,
+            }),
+            stdout_raw: vec![],
+            stderr_digest: Some(BazelDigest {
+                hash: hex('d'),
+                size_bytes: 4,
+            }),
+            stderr_raw: vec![],
+            ..Default::default()
+        };
+
+        let manifest = Manifest::from_bazel_action_result(result).unwrap();
+
+        assert!(manifest.stdout_bytes.is_none());
+        assert!(manifest.stderr_bytes.is_none());
+        assert!(!manifest.is_hydrated());
+        assert_eq!(manifest.collect_unhydrated_blob_digests().len(), 2);
+    }
+
+    #[test]
+    fn upload_never_populates_the_raw_stdio_fields() {
+        // The RE API reserves `stdout_raw`/`stderr_raw` for server responses; a client
+        // that populates them on `UpdateActionResult` is rejected by backends that
+        // validate the contract. The digests carry the output instead.
+        let manifest = Manifest {
+            stdout_bytes: Some(Bytes::from_static(b"out")),
+            stdout_digest: Some(digest('c', 3)),
+            stderr_bytes: Some(Bytes::from_static(b"err")),
+            stderr_digest: Some(digest('d', 3)),
+            ..Default::default()
+        };
+
+        let result = manifest.into_bazel_action_result();
+
+        assert!(result.stdout_raw.is_empty());
+        assert!(result.stderr_raw.is_empty());
+        assert!(result.stdout_digest.is_some());
+        assert!(result.stderr_digest.is_some());
+    }
+
+    #[test]
     fn action_result_round_trip() {
         let result = ActionResult {
             exit_code: 7,

--- a/crates/cache-storage/tests/storage_test.rs
+++ b/crates/cache-storage/tests/storage_test.rs
@@ -220,7 +220,7 @@ mod storage {
         let blob = Digest::from_bytes(b"output").unwrap();
 
         storage
-            .archive_manifest(&action, manifest_with_file(&blob))
+            .archive_manifest(&action, manifest_with_file(&blob), None)
             .await
             .unwrap();
         storage.wait_for_background_tasks().await.unwrap();
@@ -309,7 +309,7 @@ mod storage {
         let action = digest('a', 0);
 
         storage
-            .archive_manifest(&action, Manifest::default())
+            .archive_manifest(&action, Manifest::default(), None)
             .await
             .unwrap();
         storage.wait_for_background_tasks().await.unwrap();
@@ -317,6 +317,36 @@ mod storage {
         assert!(
             storage.load_manifest(&action).await.unwrap().is_some(),
             "a blob-less manifest should still be stored"
+        );
+    }
+
+    #[tokio::test]
+    async fn archives_the_provided_action_blob() {
+        // The action digest addresses the fingerprint hash manifest. When the
+        // caller supplies it as a blob, it must be uploaded to the CAS alongside
+        // the outputs so an RE-compliant backend can resolve the action result.
+        let backend = MemoryBackend::new("mem");
+        let blobs = Arc::clone(&backend.blobs);
+
+        let mut storage = create_storage();
+        storage.add_local_backend(backend);
+
+        let action = digest('a', 6);
+        let output_blob = Digest::from_bytes(b"output").unwrap();
+        let action_blob = BlobInput {
+            content: BlobContent::Inline(Bytes::from_static(b"action")),
+            digest: action.clone(),
+        };
+
+        storage
+            .archive_manifest(&action, manifest_with_file(&output_blob), Some(action_blob))
+            .await
+            .unwrap();
+        storage.wait_for_background_tasks().await.unwrap();
+
+        assert!(
+            blobs.lock().unwrap().contains_key(&action),
+            "the action blob must be uploaded to the CAS"
         );
     }
 
@@ -331,7 +361,7 @@ mod storage {
         let blob = Digest::from_bytes(b"output").unwrap();
 
         storage
-            .archive_manifest(&action, manifest_with_file(&blob))
+            .archive_manifest(&action, manifest_with_file(&blob), None)
             .await
             .unwrap();
         // A failed upload must not surface as a program error.
@@ -354,7 +384,7 @@ mod storage {
         let blob = Digest::from_bytes(b"output").unwrap();
 
         storage
-            .archive_manifest(&action, manifest_with_file(&blob))
+            .archive_manifest(&action, manifest_with_file(&blob), None)
             .await
             .unwrap();
         storage.wait_for_background_tasks().await.unwrap();

--- a/crates/task-runner/src/output_archiver.rs
+++ b/crates/task-runner/src/output_archiver.rs
@@ -3,6 +3,7 @@ use crate::run_state::TaskRunState;
 use crate::task_runner_error::TaskRunnerError;
 use miette::IntoDiagnostic;
 use moon_app_context::AppContext;
+use moon_blob::{BlobContent, BlobInput};
 use moon_cache::{Manifest, StorageOptions};
 use moon_common::color;
 use moon_task::Task;
@@ -72,6 +73,8 @@ impl OutputArchiver<'_> {
 
         // Store the manifest in the local/remote caches
         if use_local || use_remote {
+            let manifest = self.create_cache_manifest(state).await?;
+
             self.app_context
                 .cache_engine
                 .storage
@@ -80,7 +83,7 @@ impl OutputArchiver<'_> {
                     include_remote: use_remote,
                     ..Default::default()
                 })
-                .archive_manifest(&state.digest, self.create_cache_manifest(state).await?)
+                .archive_manifest(&state.digest, manifest, self.get_action_blob(state))
                 .await?;
         }
 
@@ -90,6 +93,26 @@ impl OutputArchiver<'_> {
         }
 
         Ok(ArchiveOutcome::Queued)
+    }
+
+    /// The action digest addresses moon's fingerprint hash manifest at
+    /// `.moon/cache/hashes/<hash>.json` — that file *is* the blob the digest
+    /// names. Backends that validate the Bazel RE contract reject an action
+    /// result whose action digest is absent from the CAS, so it must be
+    /// uploaded alongside the outputs. Returns `None` when the file is absent
+    /// (e.g. archiving without a computed fingerprint), leaving the upload a
+    /// no-op rather than an error.
+    fn get_action_blob(&self, state: &TaskRunState) -> Option<BlobInput> {
+        let path = self
+            .app_context
+            .cache_engine
+            .hash
+            .get_manifest_path(&state.digest.hash);
+
+        path.exists().then(|| BlobInput {
+            content: BlobContent::File(path),
+            digest: state.digest.clone(),
+        })
     }
 
     #[instrument(skip(self))]

--- a/crates/task-runner/tests/output_archiver_test.rs
+++ b/crates/task-runner/tests/output_archiver_test.rs
@@ -480,6 +480,62 @@ mod output_archiver {
         }
 
         #[tokio::test(flavor = "multi_thread")]
+        async fn stores_the_action_blob_in_storage() {
+            // The action digest addresses moon's fingerprint hash manifest at
+            // `.moon/cache/hashes/<hash>.json`, which must be uploaded to the CAS
+            // so an RE-compliant backend can resolve the action result.
+            let container = TaskRunnerContainer::new("archive", "file-outputs").await;
+            container.sandbox.create_file("project/file.txt", "");
+
+            // Stand in for the fingerprint file the hash engine writes during
+            // hashing, and point the digest at it (content-addressed by
+            // construction so the local CAS accepts it).
+            let fingerprint = b"[\"hash123\"]";
+            let digest = Digest::from_bytes(fingerprint).unwrap();
+            container.sandbox.create_file(
+                format!(".moon/cache/hashes/{}.json", digest.hash),
+                std::str::from_utf8(fingerprint).unwrap(),
+            );
+
+            let archiver = container.create_archiver();
+            let mut state = container.create_state();
+            state.local_cas_enabled = true;
+            state.digest = digest.clone();
+
+            archiver.archive("hash123", &state).await.unwrap();
+            container.flush_storage().await;
+
+            assert!(
+                container.blob_exists(&digest).await,
+                "the action blob must be uploaded alongside the outputs"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn skips_the_action_blob_when_the_hash_file_is_missing() {
+            // Without a fingerprint file on disk there is no action blob to
+            // upload; archiving must still succeed and store the manifest.
+            let container = TaskRunnerContainer::new("archive", "file-outputs").await;
+            container.sandbox.create_file("project/file.txt", "");
+
+            let archiver = container.create_archiver();
+            let mut state = container.create_state();
+            setup_cas_state(&mut state);
+
+            archiver.archive("hash123", &state).await.unwrap();
+            container.flush_storage().await;
+
+            assert!(
+                !container.blob_exists(&state.digest).await,
+                "no action blob is uploaded when the fingerprint file is absent"
+            );
+            assert!(
+                container.manifest_exists(&state.digest).await,
+                "the manifest is still stored"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
         async fn doesnt_create_a_local_archive() {
             let container = TaskRunnerContainer::new("archive", "file-outputs").await;
             container.sandbox.create_file("project/file.txt", "");


### PR DESCRIPTION
Remote cache uploads are rejected by backends that validate the Bazel Remote Execution contract, so the cache never fills and every task re-runs. I hit this pointing moon at [Depot Cache](https://depot.dev/docs/cache/integrations/moonrepo); on a real repo **6 of 6 tasks failed to upload**.

The failures are non-fatal warnings, so it looks like remote caching is simply doing nothing rather than erroring.

## Causes

**1. `UpdateActionResult` populates `stdout_raw`/`stderr_raw`.**

```
Failed to store cache manifest storage="grpc-remote-cache"
error="Client specified an invalid argument: client should not populate stdout_raw during upload"
```

The API reserves those fields for server responses. `collect_blob_inputs` already uploads stdout/stderr to the CAS and `into_bazel_action_result` references them by digest, so the inline copy was redundant as well as rejected.

**2. The action digest is never uploaded to the CAS.**

```
error="Some requested entity was not found: action digest <hash>/2585 not found in CAS"
```

`store_manifest` calls `UpdateActionResult` with an action digest the server cannot resolve. Conveniently, `ContentHasher::generate_hash` is `hash_bytes(serialize())` and `HashEngine::save_manifest` sets `size = data.len()` over those same bytes — so the action digest is exactly `(sha256(json), len(json))` of the hash manifest already written to `.moon/cache/hashes/<hash>.json`. That manifest *is* the blob the digest addresses, so uploading it alongside the outputs satisfies the check, with content-addressing correct by construction and no change to cache keying.

**3. (Latent, surfaced by fixing 1.) Raw stdio bytes were trusted whenever a digest was present.**

`from_bazel_action_result` set `stdout_bytes` from `stdout_raw` if a *digest* existed. Inlining is optional for a server, so a digest-only response yields `Some(empty)` → `is_hydrated()` returns true → the blob is never fetched → **a cache hit replays no task output**. Now keyed off whether the server actually sent bytes. This is independent of the above and affects any digest-only backend.

## Verification

Against Depot Cache, on a ~30-project repo:

- Before: `store failures: 6` of 6 tasks; nothing ever cached.
- After: `store failures: 0`, and with `.moon/cache` deleted entirely:

```
Tasks: 2 completed (2 cached)   Time: 731ms
Cache hit on manifest  storage="grpc-remote-cache"
Running cache hydration operation  hydrate_from=Storage(grpc-remote-cache)
```

Existing tests pass (`moon_cache_storage`, and `moon_task_runner` `output_hydrater_test`, which already covers the stdout-from-CAS path). Added two regression tests: one asserting the raw fields stay empty on upload, one asserting a digest-only response stays unhydrated so the blob is fetched.

Happy to adjust the approach for (2) — reading the hash manifest from `cache_dir` keeps the change small, but I am glad to plumb the bytes through from the task runner instead if you would prefer that.