### PR TITLE
ci: Add cache-moon-workspace composite action

### DIFF
--- a/.github/actions/cache-moon-workspace/README.md
+++ b/.github/actions/cache-moon-workspace/README.md
@@ -1,0 +1,64 @@
+# Cache moon workspace graph
+
+A composite action that persists moon's workspace graph cache
+(`.moon/cache/states/workspaceGraph.json` and `workspaceGraphStateV1.json`) between CI runs using
+[`actions/cache`](https://github.com/actions/cache).
+
+## Why?
+
+As of moon 2.4.2, the workspace graph cache avoids all `extend_project_graph` plugin calls on a
+cache hit — for example the Go toolchain's `go list -deps`, which can take minutes in large
+workspaces. However, this cache is _local state_ and is **not** covered by remote caching (remote
+caching only stores task hashes and output archives). On ephemeral CI runners the graph is
+therefore rebuilt from scratch on every run.
+
+This action restores and saves those state files so warm CI runs skip the expensive plugin calls.
+
+Restoring a stale cache is always safe: moon computes its own digest (from project sources, config
+files, toolchain manifests, plugin versions, and environment) and rebuilds the graph if it doesn't
+match.
+
+## Usage
+
+Add the action after checkout and before the first `moon` command:
+
+```yaml
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: moonrepo/moon/.github/actions/cache-moon-workspace@master
+      - uses: moonrepo/setup-toolchain@v0
+      - run: moon ci
+```
+
+## Inputs
+
+| Input            | Default                                        | Description                                                                            |
+| ---------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `workspace-root` | `.`                                            | Relative path from the repository root to the moon workspace root.                     |
+| `key-prefix`     | `moon-workspace-graph`                         | Prefix for the cache key. Change it to force a fresh cache.                            |
+| `manifests`      | `**/go.mod`, `**/package.json`, `**/Cargo.toml` | Newline-separated globs of toolchain manifest files that feed the workspace digest.    |
+
+Tune `manifests` to the toolchains enabled in your workspace, e.g. for a Go-only workspace:
+
+```yaml
+- uses: moonrepo/moon/.github/actions/cache-moon-workspace@master
+  with:
+    manifests: |
+      **/go.mod
+```
+
+## Caveats
+
+- The cached graph stores absolute paths, so it's only reused when the checkout path is identical
+  between runs. GitHub-hosted runners use a stable path; self-hosted runners with varying work
+  directories won't get hits.
+- moon's digest includes the moon version, so the first run after a moon upgrade is always a miss.
+- Jobs running in a `container:` produce a different digest than jobs running directly on the
+  runner, so the two won't share a cache.
+- `actions/cache` only saves on an exact key miss. The `restore-keys` fallback still helps, since
+  moon re-validates the restored state itself.

--- a/.github/actions/cache-moon-workspace/action.yml
+++ b/.github/actions/cache-moon-workspace/action.yml
@@ -1,0 +1,42 @@
+name: Cache moon workspace graph
+description: >
+  Persists moon's workspace graph cache between CI runs, avoiding expensive toolchain plugin calls
+  (like the Go toolchain's `go list -deps`) when the graph hasn't changed. Remote caching only
+  stores task hashes and outputs, so without this action the workspace graph is rebuilt from
+  scratch on every run.
+author: moonrepo
+branding:
+  icon: layers
+  color: purple
+
+inputs:
+  workspace-root:
+    description: Relative path from the repository root to the moon workspace root.
+    required: false
+    default: '.'
+  key-prefix:
+    description: Prefix for the cache key. Change it to force a fresh cache.
+    required: false
+    default: moon-workspace-graph
+  manifests:
+    description: >
+      Newline-separated globs of toolchain manifest files that contribute to the workspace graph
+      digest. Include the manifests of every toolchain enabled in the workspace.
+    required: false
+    default: |
+      **/go.mod
+      **/package.json
+      **/Cargo.toml
+
+runs:
+  using: composite
+  steps:
+    - name: Cache workspace graph state
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ inputs.workspace-root }}/.moon/cache/states/workspaceGraph.json
+          ${{ inputs.workspace-root }}/.moon/cache/states/workspaceGraphStateV1.json
+        key: ${{ inputs.key-prefix }}-${{ runner.os }}-${{ hashFiles(format('{0}/.moon/*.yml', inputs.workspace-root), format('{0}/.moon/tasks/**', inputs.workspace-root), format('{0}/**/moon.yml', inputs.workspace-root), inputs.manifests) }}
+        restore-keys: |
+          ${{ inputs.key-prefix }}-${{ runner.os }}-


### PR DESCRIPTION
## Summary

Adds a reusable composite action at `.github/actions/cache-moon-workspace` that persists moon's workspace graph cache (`.moon/cache/states/workspaceGraph.json` + `workspaceGraphStateV1.json`) between CI runs via `actions/cache`.

## Why

Since 2.4.2 (#2602), the workspace graph cache skips all `extend_project_graph` plugin calls on a cache hit — e.g. the Go toolchain's `go list -deps`, which can take minutes in large workspaces. But this cache is local state and is not covered by remote caching (which only stores task hashes and output archives), so ephemeral CI runners rebuild the graph from scratch on every run.

With this action, warm CI runs restore the state files and moon skips the expensive plugin calls entirely. Restoring a stale cache is safe: moon computes its own digest (project sources, config files, toolchain manifests, plugin versions, env) and rebuilds if it doesn't match.

## Usage

```yaml
- uses: actions/checkout@v6
- uses: moonrepo/moon/.github/actions/cache-moon-workspace@master
- uses: moonrepo/setup-toolchain@v0
- run: moon ci
```

Inputs: `workspace-root`, `key-prefix`, and `manifests` (newline-separated globs of toolchain manifests that feed the digest; defaults cover Go/Node/Rust). See the action's README for caveats (absolute paths, moon version busting, container vs bare runners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)