### PR TITLE
feat: Store the workspace graph cache in remote storage backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added a new experiment, `experiments.remoteWorkspaceGraphCache`, that stores the workspace graph
+  cache in remote storage backends (Bazel RE API compatible), so that other machines — most notably
+  ephemeral CI runners — can hydrate the graph instead of rebuilding it from scratch. Rebuilding
+  invokes toolchain plugin calls (like the Go toolchain's `go list --deps`), which can be very slow
+  in large workspaces.
+- When loading the workspace graph from the cache, machine-specific absolute paths (project roots)
+  are now recomputed against the current workspace root, so a cache created in another location
+  (containers, moved workspaces, remote hydration) no longer leaks stale paths.
+- A corrupted workspace graph cache is now discarded and rebuilt, instead of erroring.
+
 ## 2.4.3
 
 #### 🚀 Updates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6148,6 +6148,7 @@ dependencies = [
  "moon_async_utils",
  "moon_bench_utils",
  "moon_cache",
+ "moon_cache_storage",
  "moon_common",
  "moon_config",
  "moon_config_loader",

--- a/crates/config/src/workspace/experiments_config.rs
+++ b/crates/config/src/workspace/experiments_config.rs
@@ -24,5 +24,12 @@ config_struct!(
         /// @since 2.3.0
         #[setting(env = "MOON_EXPERIMENT_NATIVE_FILE_HASHING", parse_env = env::parse_bool)]
         pub native_file_hashing: bool,
+
+        /// Store the workspace graph cache in storage backends (typically
+        /// remote), so that other machines can hydrate it instead of
+        /// rebuilding the graph from scratch.
+        /// @since 2.5.0
+        #[setting(env = "MOON_EXPERIMENT_REMOTE_WORKSPACE_GRAPH_CACHE", parse_env = env::parse_bool)]
+        pub remote_workspace_graph_cache: bool,
     }
 );

--- a/crates/project-graph/tests/project_graph_test.rs
+++ b/crates/project-graph/tests/project_graph_test.rs
@@ -392,6 +392,30 @@ mod project_graph {
             .await
         }
 
+        async fn do_generate_with_plugins_and_storage(
+            root: &Path,
+            async_graph: bool,
+            remote_dir: &Path,
+        ) -> WorkspaceGraph {
+            let mut mock = WorkspaceMocker::new(root)
+                .load_default_configs()
+                .with_default_projects()
+                .with_test_toolchains()
+                .with_inherited_tasks()
+                .update_workspace_config(|config| {
+                    config.experiments.async_graph_building = async_graph;
+                    config.experiments.remote_workspace_graph_cache = true;
+                });
+
+            mock.remote_storage_dir = Some(remote_dir.to_path_buf());
+
+            mock.mock_workspace_graph_with_options(WorkspaceMockOptions {
+                cache: true,
+                ..Default::default()
+            })
+            .await
+        }
+
         async fn build_cached_graph(
             async_graph: bool,
             func: impl FnOnce(&MoonSandbox),
@@ -665,6 +689,108 @@ mod project_graph {
                             },
                         )
                         .await;
+                    }
+                }
+
+                mod storage {
+                    use super::*;
+
+                    #[tokio::test(flavor = "multi_thread")]
+                    async fn hydrates_graph_from_storage_on_other_machine() {
+                        let sandbox1 = create_moon_sandbox("dependencies");
+                        sandbox1.enable_git();
+
+                        // Shared "remote" storage, outside of both workspaces
+                        let remote_dir = sandbox1.path().join(".remote-storage");
+
+                        let graph1 = do_generate_with_plugins_and_storage(
+                            sandbox1.path(),
+                            $async_graph,
+                            &remote_dir,
+                        )
+                        .await;
+
+                        // Cold build calls plugins and persists to storage
+                        assert!(sandbox1.path().join(MARKER_PATH).exists());
+                        assert!(remote_dir.join("manifests").exists());
+
+                        // A second machine: same repo contents, different path,
+                        // no local graph cache
+                        let sandbox2 = create_moon_sandbox("dependencies");
+                        sandbox2.enable_git();
+
+                        let graph2 = do_generate_with_plugins_and_storage(
+                            sandbox2.path(),
+                            $async_graph,
+                            &remote_dir,
+                        )
+                        .await;
+
+                        // Hydrated from storage: plugins were never called,
+                        // and the local cache + state now exist
+                        assert!(!sandbox2.path().join(MARKER_PATH).exists());
+                        assert!(sandbox2.path().join(CACHE_PATH).exists());
+                        assert_eq!(
+                            load_state(&sandbox1).last_hash,
+                            load_state(&sandbox2).last_hash
+                        );
+                        assert_eq!(
+                            graph1.projects.get_node_keys(),
+                            graph2.projects.get_node_keys()
+                        );
+
+                        // And machine-specific paths point into THIS workspace
+                        let project = graph2.get_project("a").unwrap();
+
+                        assert_eq!(project.root, sandbox2.path().join("a"));
+                    }
+
+                    #[tokio::test(flavor = "multi_thread")]
+                    async fn rehydrates_stale_project_roots_from_local_cache() {
+                        let (sandbox, _graph) = build_cached_graph($async_graph, |sandbox| {
+                            sandbox.enable_git();
+                        })
+                        .await;
+
+                        // Simulate the workspace having moved on disk by
+                        // poisoning the serialized absolute roots
+                        let cache_file = sandbox.path().join(CACHE_PATH);
+                        let content = fs::read_file(&cache_file).unwrap();
+
+                        fs::write_file(
+                            &cache_file,
+                            content.replace(
+                                sandbox.path().to_str().unwrap(),
+                                "/a/stale/workspace/root",
+                            ),
+                        )
+                        .unwrap();
+
+                        let graph = do_generate(sandbox.path(), $async_graph).await;
+                        let project = graph.get_project("a").unwrap();
+
+                        assert_eq!(project.root, sandbox.path().join("a"));
+                    }
+
+                    #[tokio::test(flavor = "multi_thread")]
+                    async fn rebuilds_if_cached_graph_is_corrupt() {
+                        let (sandbox, graph) = build_cached_graph($async_graph, |sandbox| {
+                            sandbox.enable_git();
+                        })
+                        .await;
+
+                        sandbox.create_file(CACHE_PATH, "{ not valid json !");
+
+                        let rebuilt_graph = do_generate(sandbox.path(), $async_graph).await;
+
+                        // The async builder inserts nodes in a nondeterministic
+                        // order, so compare as sets
+                        let mut expected = graph.projects.get_node_keys();
+                        let mut actual = rebuilt_graph.projects.get_node_keys();
+                        expected.sort();
+                        actual.sort();
+
+                        assert_eq!(expected, actual);
                     }
                 }
             };

--- a/crates/test-utils/src/workspace_mocker.rs
+++ b/crates/test-utils/src/workspace_mocker.rs
@@ -34,6 +34,9 @@ pub struct WorkspaceMocker {
     pub proto_env: ProtoEnvironment,
     pub extensions_config: ExtensionsConfig,
     pub toolchains_config: ToolchainsConfig,
+    /// When set, adds a local CAS at this directory as a *remote* storage
+    /// backend, for testing remote-dependent flows without a real server.
+    pub remote_storage_dir: Option<PathBuf>,
     pub working_dir: PathBuf,
     pub workspace_config: WorkspaceConfig,
     pub workspace_root: PathBuf,
@@ -371,6 +374,12 @@ impl WorkspaceMocker {
         engine.storage.add_local_backend(
             LocalStorage::new(context.clone(), &context.cache_dir, false).unwrap(),
         );
+
+        if let Some(remote_dir) = &self.remote_storage_dir {
+            engine
+                .storage
+                .add_remote_backend(LocalStorage::new(context.clone(), remote_dir, false).unwrap());
+        }
 
         engine
     }

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -15,6 +15,7 @@ harness = false
 [dependencies]
 moon_async_utils = { path = "../async-utils" }
 moon_cache = { path = "../cache" }
+moon_cache_storage = { path = "../cache-storage" }
 moon_common = { path = "../common" }
 moon_config = { path = "../config" }
 moon_config_loader = { path = "../config-loader" }

--- a/crates/workspace/src/workspace_builder.rs
+++ b/crates/workspace/src/workspace_builder.rs
@@ -40,7 +40,7 @@ use starbase_utils::json;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 pub const LOCK_FILE_NAME: &str = "workspaceGraph.lock";
 pub const STATE_GRAPH_FILE_NAME: &str = "workspaceGraph.json";
@@ -172,31 +172,54 @@ impl WorkspaceBuilder {
             .state
             .resolve_path(STATE_GRAPH_FILE_NAME);
 
-        if digest.hash == state.data.last_hash && cache_path.exists() {
-            let mut cache: WorkspaceBuilder = json::read_file(&cache_path)?;
+        let use_storage = is_remote_graph_cache_enabled(&context).await;
+        let mut cache_hit = digest.hash == state.data.last_hash && cache_path.exists();
 
-            // Verify that the cached projects match the current projects
-            // on disk. If a project has been added or removed since the
-            // cache was created, we need to rebuild the graph
-            let cached_ids: FxHashSet<&Id> = cache.project_data.keys().collect();
-            let current_ids: FxHashSet<&Id> = graph.project_data.keys().collect();
+        // On a local cache miss, attempt to hydrate the serialized graph
+        // from storage backends (typically remote), keyed by the same digest
+        if !cache_hit && use_storage {
+            cache_hit = load_graph_from_storage(&context, &digest, &cache_path).await;
+        }
 
-            if cached_ids == current_ids {
-                debug!(
-                    cache = ?cache_path,
-                    "Loading workspace graph with {} projects from cache",
-                    cache.project_data.len(),
-                );
+        if cache_hit {
+            match json::read_file::<WorkspaceBuilder>(&cache_path) {
+                Ok(mut cache) => {
+                    // Verify that the cached projects match the current projects
+                    // on disk. If a project has been added or removed since the
+                    // cache was created, we need to rebuild the graph
+                    let cached_ids: FxHashSet<&Id> = cache.project_data.keys().collect();
+                    let current_ids: FxHashSet<&Id> = graph.project_data.keys().collect();
 
-                cache.context = graph.context;
+                    if cached_ids == current_ids {
+                        debug!(
+                            cache = ?cache_path,
+                            "Loading workspace graph with {} projects from cache",
+                            cache.project_data.len(),
+                        );
 
-                return Ok(cache);
+                        cache.context = graph.context;
+                        cache.rehydrate_machine_specific_state();
+
+                        if state.data.last_hash != digest.hash {
+                            state.data.last_hash = digest.hash;
+                            state.save()?;
+                        }
+
+                        return Ok(cache);
+                    }
+
+                    debug!(
+                        cache = ?cache_path,
+                        "Cached workspace graph has mismatched projects, rebuilding",
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        cache = ?cache_path,
+                        "Failed to load cached workspace graph, rebuilding: {error}",
+                    );
+                }
             }
-
-            debug!(
-                cache = ?cache_path,
-                "Cached workspace graph has mismatched projects, rebuilding",
-            );
         }
 
         // Build the graph, update the state, and save the cache
@@ -209,12 +232,36 @@ impl WorkspaceBuilder {
         graph.load_projects().await?;
         graph.load_tasks().await?;
 
-        state.data.last_hash = digest.hash;
+        state.data.last_hash = digest.hash.clone();
         state.save()?;
 
-        json::write_file(cache_path, &graph, false)?;
+        json::write_file(&cache_path, &graph, false)?;
+
+        // Persist the serialized graph to storage backends (typically
+        // remote), so that other machines can hydrate it
+        if use_storage {
+            save_graph_to_storage(&context, &digest, &cache_path).await;
+        }
 
         Ok(graph)
+    }
+
+    /// Recompute machine-specific values after loading a serialized graph
+    /// from the cache. The cache may have been created on another machine
+    /// (when hydrated from a remote storage backend), or the workspace may
+    /// have moved on disk, leaving stale absolute paths behind.
+    fn rehydrate_machine_specific_state(&mut self) {
+        let workspace_root = &self
+            .context
+            .as_ref()
+            .expect("Missing workspace builder context!")
+            .workspace_root;
+
+        for node in self.project_graph.node_weights_mut() {
+            if let NodeState::Loaded(project) = node {
+                project.root = project.source.to_logical_path(workspace_root);
+            }
+        }
     }
 
     /// Build the project graph and return a new structure.

--- a/crates/workspace/src/workspace_builder_async.rs
+++ b/crates/workspace/src/workspace_builder_async.rs
@@ -3,14 +3,14 @@ use crate::tasks_builder::*;
 use crate::workspace_builder::*;
 use crate::workspace_cache::*;
 use moon_common::Id;
-use moon_graph_utils::GraphExpanderContext;
+use moon_graph_utils::{GraphExpanderContext, NodeState};
 use moon_hash::Digest;
 use moon_workspace_graph::WorkspaceGraph;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use starbase_utils::json;
 use std::sync::Arc;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 #[derive(Deserialize, Serialize)]
 pub struct WorkspaceBuilderAsync {
@@ -77,32 +77,55 @@ impl WorkspaceBuilderAsync {
             .state
             .resolve_path(STATE_GRAPH_FILE_NAME);
 
-        if digest.hash == state.data.last_hash && cache_path.exists() {
-            let mut cache: WorkspaceBuilderAsync = json::read_file(&cache_path)?;
+        let use_storage = is_remote_graph_cache_enabled(&context).await;
+        let mut cache_hit = digest.hash == state.data.last_hash && cache_path.exists();
 
-            // Verify that the cached projects match the current projects
-            // on disk. If a project has been added or removed since the
-            // cache was created, we need to rebuild the graph
-            let cached_ids: FxHashSet<&Id> = cache.projects.ids_to_indexes.keys().collect();
-            let current_ids: FxHashSet<&Id> = graph.projects.build_data.keys().collect();
+        // On a local cache miss, attempt to hydrate the serialized graph
+        // from storage backends (typically remote), keyed by the same digest
+        if !cache_hit && use_storage {
+            cache_hit = load_graph_from_storage(&context, &digest, &cache_path).await;
+        }
 
-            if cached_ids == current_ids {
-                debug!(
-                    cache = ?cache_path,
-                    "Loading workspace graph with {} projects from cache",
-                    cache.projects.ids_to_indexes.len(),
-                );
+        if cache_hit {
+            match json::read_file::<WorkspaceBuilderAsync>(&cache_path) {
+                Ok(mut cache) => {
+                    // Verify that the cached projects match the current projects
+                    // on disk. If a project has been added or removed since the
+                    // cache was created, we need to rebuild the graph
+                    let cached_ids: FxHashSet<&Id> = cache.projects.ids_to_indexes.keys().collect();
+                    let current_ids: FxHashSet<&Id> = graph.projects.build_data.keys().collect();
 
-                cache.projects.context = graph.projects.context.take();
-                cache.context = graph.context;
+                    if cached_ids == current_ids {
+                        debug!(
+                            cache = ?cache_path,
+                            "Loading workspace graph with {} projects from cache",
+                            cache.projects.ids_to_indexes.len(),
+                        );
 
-                return Ok(cache);
+                        cache.projects.context = graph.projects.context.take();
+                        cache.context = graph.context;
+                        cache.rehydrate_machine_specific_state();
+
+                        if state.data.last_hash != digest.hash {
+                            state.data.last_hash = digest.hash;
+                            state.save()?;
+                        }
+
+                        return Ok(cache);
+                    }
+
+                    debug!(
+                        cache = ?cache_path,
+                        "Cached workspace graph has mismatched projects, rebuilding",
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        cache = ?cache_path,
+                        "Failed to load cached workspace graph, rebuilding: {error}",
+                    );
+                }
             }
-
-            debug!(
-                cache = ?cache_path,
-                "Cached workspace graph has mismatched projects, rebuilding",
-            );
         }
 
         // Build the graph, update the state, and save the cache
@@ -113,12 +136,36 @@ impl WorkspaceBuilderAsync {
 
         graph.load_graphs().await?;
 
-        state.data.last_hash = digest.hash;
+        state.data.last_hash = digest.hash.clone();
         state.save()?;
 
-        json::write_file(cache_path, &graph, false)?;
+        json::write_file(&cache_path, &graph, false)?;
+
+        // Persist the serialized graph to storage backends (typically
+        // remote), so that other machines can hydrate it
+        if use_storage {
+            save_graph_to_storage(&context, &digest, &cache_path).await;
+        }
 
         Ok(graph)
+    }
+
+    /// Recompute machine-specific values after loading a serialized graph
+    /// from the cache. The cache may have been created on another machine
+    /// (when hydrated from a remote storage backend), or the workspace may
+    /// have moved on disk, leaving stale absolute paths behind.
+    fn rehydrate_machine_specific_state(&mut self) {
+        let workspace_root = &self
+            .context
+            .as_ref()
+            .expect("Missing workspace builder context!")
+            .workspace_root;
+
+        for node in self.projects.graph.node_weights_mut() {
+            if let NodeState::Loaded(project) = node {
+                project.root = project.source.to_logical_path(workspace_root);
+            }
+        }
     }
 
     pub async fn preload(&mut self) -> miette::Result<()> {

--- a/crates/workspace/src/workspace_cache.rs
+++ b/crates/workspace/src/workspace_cache.rs
@@ -2,13 +2,17 @@ use crate::projects_builder::{ProjectBuildData, ProjectBuildDataMap};
 use crate::workspace_builder::WorkspaceBuilderContext;
 use miette::IntoDiagnostic;
 use moon_cache::{ContentHash, cache_item};
+use moon_cache_storage::{Manifest, ManifestFile};
 use moon_common::path::WorkspaceRelativePathBuf;
 use moon_common::{Id, is_docker};
 use moon_env_var::GlobalEnvBag;
 use moon_hash::{Digest, fingerprint};
 use rustc_hash::FxHashMap;
+use starbase_utils::fs;
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 use std::sync::Arc;
+use tracing::{debug, warn};
 
 cache_item!(
     pub struct WorkspaceGraphCacheState {
@@ -208,4 +212,143 @@ pub async fn generate_graph_cache_digest(
         .cache_engine
         .hash
         .save_manifest_without_hasher("workspace-graph", &fingerprint)
+}
+
+/// Check whether the serialized workspace graph should also be persisted
+/// to storage backends (typically remote), and if so, connect the backends.
+/// The graph is built before the pipeline's sync workspace action, which
+/// normally connects the backends, so we must connect here. Connecting is
+/// idempotent, and failures disable the offending backend.
+pub async fn is_remote_graph_cache_enabled(context: &WorkspaceBuilderContext) -> bool {
+    if !context
+        .workspace_config
+        .experiments
+        .remote_workspace_graph_cache
+        || !context.cache_engine.storage.is_remote_enabled()
+    {
+        return false;
+    }
+
+    if let Err(error) = context.cache_engine.storage.connect_backends().await {
+        warn!("Failed to connect to storage backends for workspace graph caching: {error}");
+
+        return false;
+    }
+
+    true
+}
+
+/// Attempt to hydrate the serialized workspace graph from storage backends
+/// (typically remote) when the local state is missing or stale. The graph
+/// is keyed by the same fingerprint digest as the local state, so a fetched
+/// entry always matches the current workspace inputs. Failures are lossy
+/// and non-fatal, as this is purely an optimization over rebuilding.
+pub async fn load_graph_from_storage(
+    context: &WorkspaceBuilderContext,
+    digest: &Digest,
+    cache_path: &Path,
+) -> bool {
+    let storage = &context.cache_engine.storage;
+
+    let result: miette::Result<bool> = async {
+        let Some(source) = storage.load_manifest(digest).await? else {
+            return Ok(false);
+        };
+
+        let Some(manifest) = storage.hydrate_manifest(digest, source).await? else {
+            return Ok(false);
+        };
+
+        let Some(file) = manifest.files.first() else {
+            return Ok(false);
+        };
+
+        if let Some(bytes) = &file.bytes {
+            fs::write_file(cache_path, bytes)?;
+        } else if let Some(source_path) = &file.source_path {
+            fs::copy_file(source_path, cache_path)?;
+        } else {
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+    .await;
+
+    match result {
+        Ok(hydrated) => {
+            if hydrated {
+                debug!(
+                    hash = digest.hash.as_str(),
+                    "Hydrated workspace graph from storage backends"
+                );
+            }
+
+            hydrated
+        }
+        Err(error) => {
+            warn!(
+                hash = digest.hash.as_str(),
+                "Failed to hydrate workspace graph from storage backends: {error}"
+            );
+
+            false
+        }
+    }
+}
+
+/// Persist the serialized workspace graph to storage backends (typically
+/// remote), keyed by its fingerprint digest, so that other machines can
+/// hydrate it instead of rebuilding the graph from scratch. The upload is
+/// awaited so that short-lived commands don't drop it. Failures are non-fatal.
+pub async fn save_graph_to_storage(
+    context: &WorkspaceBuilderContext,
+    digest: &Digest,
+    cache_path: &Path,
+) {
+    let result: miette::Result<()> = async {
+        // The cache directory can technically be relocated outside of the
+        // workspace, in which case a workspace relative path can not be
+        // created, so simply don't persist the graph.
+        let Ok(relative_path) = cache_path.strip_prefix(&context.workspace_root) else {
+            return Ok(());
+        };
+
+        let Some(relative_path) = relative_path.to_str() else {
+            return Ok(());
+        };
+
+        let manifest = Manifest {
+            files: vec![ManifestFile {
+                digest: Some(Digest::from_file(cache_path)?),
+                path: WorkspaceRelativePathBuf::from(relative_path),
+                source_path: Some(cache_path.to_path_buf()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        context
+            .cache_engine
+            .storage
+            .archive_manifest(digest, manifest)
+            .await?;
+
+        // Archiving queues the upload as a background task, which is only
+        // awaited when a task pipeline runs, so await it here for
+        // graph-only commands (query, docker, etc.)
+        context
+            .cache_engine
+            .storage
+            .wait_for_background_tasks()
+            .await
+    }
+    .await;
+
+    if let Err(error) = result {
+        warn!(
+            hash = digest.hash.as_str(),
+            "Failed to persist workspace graph to storage backends: {error}"
+        );
+    }
 }

--- a/packages/types/src/workspace-config.ts
+++ b/packages/types/src/workspace-config.ts
@@ -201,6 +201,15 @@ export interface ExperimentsConfig {
 	 * @env MOON_EXPERIMENT_NATIVE_FILE_HASHING
 	 */
 	nativeFileHashing: boolean;
+	/**
+	 * Store the workspace graph cache in storage backends (typically
+	 * remote), so that other machines can hydrate it instead of
+	 * rebuilding the graph from scratch.
+	 * @since 2.5.0
+	 *
+	 * @env MOON_EXPERIMENT_REMOTE_WORKSPACE_GRAPH_CACHE
+	 */
+	remoteWorkspaceGraphCache: boolean;
 }
 
 /** Configures the generator for scaffolding from templates. */
@@ -890,6 +899,15 @@ export interface PartialExperimentsConfig {
 	 * @env MOON_EXPERIMENT_NATIVE_FILE_HASHING
 	 */
 	nativeFileHashing?: boolean | null;
+	/**
+	 * Store the workspace graph cache in storage backends (typically
+	 * remote), so that other machines can hydrate it instead of
+	 * rebuilding the graph from scratch.
+	 * @since 2.5.0
+	 *
+	 * @env MOON_EXPERIMENT_REMOTE_WORKSPACE_GRAPH_CACHE
+	 */
+	remoteWorkspaceGraphCache?: boolean | null;
 }
 
 /** Configures the generator for scaffolding from templates. */

--- a/website/docs/config/workspace.mdx
+++ b/website/docs/config/workspace.mdx
@@ -404,6 +404,25 @@ Can also be enabled with the `MOON_EXPERIMENT_NATIVE_FILE_HASHING` environment v
 
 > The hasher can be tuned through the top-level [`cache`](#cache) setting.
 
+### `remoteWorkspaceGraphCache`<VersionLabel version="2.5.0" />
+
+<HeadingApiLink to="/api/types/interface/ExperimentsConfig#remoteWorkspaceGraphCache" />
+
+Stores the workspace graph cache in remote [storage backends](../guides/remote-cache) (in addition
+to the local state), so that other machines — most notably ephemeral CI runners — can hydrate the
+serialized graph instead of rebuilding it from scratch. Rebuilding the graph invokes toolchain
+plugin calls (like the Go toolchain's `go list --deps`), which can be very slow in large
+workspaces. Defaults to `false`.
+
+```yaml title=".moon/workspace.yml" {2}
+experiments:
+  remoteWorkspaceGraphCache: true
+```
+
+Can also be enabled with the `MOON_EXPERIMENT_REMOTE_WORKSPACE_GRAPH_CACHE` environment variable.
+
+> Requires [`remote`](#remote) to be configured, otherwise does nothing.
+
 ## `generator`
 
 <HeadingApiLink to="/api/types/interface/WorkspaceConfig#generator" />

--- a/website/static/schemas/v2/workspace.json
+++ b/website/static/schemas/v2/workspace.json
@@ -495,6 +495,11 @@
           "title": "nativeFileHashing",
           "description": "Use native file hashing instead of using the VCS. @since 2.3.0",
           "type": "boolean"
+        },
+        "remoteWorkspaceGraphCache": {
+          "title": "remoteWorkspaceGraphCache",
+          "description": "Store the workspace graph cache in storage backends (typically remote), so that other machines can hydrate it instead of rebuilding the graph from scratch. @since 2.5.0",
+          "type": "boolean"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Adds a new experiment, `experiments.remoteWorkspaceGraphCache` (`MOON_EXPERIMENT_REMOTE_WORKSPACE_GRAPH_CACHE`), that persists the serialized workspace graph to storage backends — most usefully a remote Bazel RE API backend — keyed by the existing graph fingerprint digest. On a local cache miss, the graph is hydrated from a backend instead of being rebuilt.

## Motivation

Since #2602, a workspace graph cache hit skips all `extend_project_graph` plugin calls. In our Go monorepo (~130 modules) that's the difference between ~0.2s and ~10s+ of startup for every moon command. But the graph state is local-only, so ephemeral CI runners rebuild it (and re-run `go list --deps` across the whole repo) on every single run — remote caching only covers task outputs. With this experiment, the first runner to build a given graph digest uploads ~one small JSON blob, and every other runner (and fresh clone/devcontainer) hydrates it.

## Implementation

- **Storage**: reuses the existing `Storage` manifest/blob APIs unchanged — the graph JSON is archived as a single-file `Manifest` keyed by the fingerprint digest (maps to `ActionCache` + CAS for the gRPC backend). Upload is awaited so graph-only commands don't drop it; failures are non-fatal and only log a warning.
- **Portability**: the graph is built before `sync_workspace` connects the backends, so the experiment path connects them itself (idempotent). `Project.root` is the only absolute path in the serialization closure (everything else is workspace-relative), so it's recomputed from `project.source` against the current workspace root whenever a cached graph is loaded — from remote *or* local. This also fixes stale roots when a workspace moves on disk, complementing the existing `in_docker` fingerprint flag.
- **Robustness**: a cache file that fails to deserialize is now discarded and rebuilt instead of hard-erroring (previously a corrupt `workspaceGraph.json` was fatal).
- Both the sync and async builders are covered.

## Testing

Extended the existing `cache_tests!` suite (runs against both builders):
- `hydrates_graph_from_storage_on_other_machine` — two sandboxes (different absolute paths) sharing a mocked remote backend; asserts the second build performs zero `extend_project_graph` calls (via the tc-tier1 marker), state hashes match, and project roots point into the *second* workspace.
- `rehydrates_stale_project_roots_from_local_cache` — poisons serialized roots, asserts they're recomputed on load.
- `rebuilds_if_cached_graph_is_corrupt` — garbage cache file rebuilds instead of erroring.

The test mocker gained a `remote_storage_dir` option that registers a `LocalStorage` CAS as a *remote* backend.

Docs, JSON schema, TS types, and CHANGELOG updated. Marked draft to get feedback on the approach first — happy to adjust (naming, whether root rehydration should be unconditional, whether the upload should stay fire-and-forget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)