### PR TITLE
new: Add workspace root level `setup_environment` and `install_dependencies` actions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
       service name.
     - The destination and transport are configured with the standard `OTEL_EXPORTER_OTLP_*`
       environment variables.
+  - Updated the `moon setup` action to also setup the toolchain environment, if their dependency
+    root is the same as the workspace root. Nested dependency roots will not be setup, as they are
+    expected to be setup by their parent project.
 - **Config**
   - Added an `env` setting to `.moon/tasks/**/*` configs. These environment variables are inherited
     by all matching projects, and are merged into each project's `env` setting, with project-level
@@ -48,9 +51,9 @@
   not re-synced when placeholder nodes were removed.
 - Fixed an issue where the async graph builder would fail with "unknown target" when a task
   dependency referenced a project by its alias.
-- Fixed an issue where the async graph builder would produce differently ordered graphs across
-  runs, as projects were inserted in completion order instead of a stable order. This could cause
-  unstable hashes and `--dot`/`--json` output.
+- Fixed an issue where the async graph builder would produce differently ordered graphs across runs,
+  as projects were inserted in completion order instead of a stable order. This could cause unstable
+  hashes and `--dot`/`--json` output.
 - Fixed an issue where a task with `runDepsInParallel: false` would not be linked to all of its
   dependencies when a serial ordering edge was skipped to avoid a cycle, allowing the task to run
   before a dependency had finished.

--- a/crates/action-graph/src/action_graph_builder.rs
+++ b/crates/action-graph/src/action_graph_builder.rs
@@ -9,11 +9,13 @@ use moon_action::{
 use moon_action_context::{ActionContext, TargetState};
 use moon_affected::{AffectedTracker, DownstreamScope, UpstreamScope};
 use moon_app_context::AppContext;
-use moon_common::path::{PathExt, WorkspaceRelativePathBuf};
+use moon_common::path::{PathExt, RelativePathBuf, WorkspaceRelativePathBuf};
 use moon_common::{Id, color, is_ci};
 use moon_config::{EnvMap, PipelineActionSwitch, TaskDependencyConfig, TaskDependencyType};
 use moon_exec_plan::{ExecutionPlan, TargetsBlock};
-use moon_pdk_api::{DefineRequirementsInput, LocateDependenciesRootInput};
+use moon_pdk_api::{
+    DefineRequirementsInput, LocateDependenciesRootInput, LocateDependenciesRootOutput,
+};
 use moon_project::{Project, ProjectError};
 use moon_query::{Criteria, build_query};
 use moon_task::{Target, TargetError, TargetLocator, TargetProjectScope, TargetTaskScope, Task};
@@ -318,10 +320,10 @@ impl<'query> ActionGraphBuilder<'query> {
     }
 
     #[instrument(skip(self))]
-    pub async fn install_dependencies(
+    async fn internal_install_dependencies(
         &mut self,
         spec: &ToolchainSpec,
-        project: &Project,
+        project: Option<&Project>,
     ) -> miette::Result<Option<NodeIndex>> {
         // Explicitly disabled
         if spec.is_system()
@@ -336,7 +338,7 @@ impl<'query> ActionGraphBuilder<'query> {
         }
 
         let sync_workspace_index = self.sync_workspace().await?;
-        let setup_toolchain_index = self.setup_toolchain(spec, Some(project)).await?;
+        let setup_toolchain_index = self.setup_toolchain(spec, project).await?;
         let toolchain_registry = &self.app_context.toolchain_registry;
         let toolchain = toolchain_registry.load(&spec.id).await?;
 
@@ -345,14 +347,11 @@ impl<'query> ActionGraphBuilder<'query> {
             return Ok(setup_toolchain_index);
         }
 
-        let output = toolchain
-            .locate_dependencies_root(LocateDependenciesRootInput {
-                context: toolchain_registry.create_context(),
-                starting_dir: toolchain.to_virtual_path(&project.root),
-                toolchain_config: toolchain_registry
-                    .create_merged_config(&toolchain.id, &project.config),
-            })
-            .await?;
+        let output = self.locate_dependencies_root(spec, project).await?;
+        let target_root = match project {
+            Some(project) => &project.root,
+            None => &self.app_context.workspace_root,
+        };
 
         // Only insert this action if a root was located
         if let Some(abs_root) = output.root.as_ref() {
@@ -361,19 +360,21 @@ impl<'query> ActionGraphBuilder<'query> {
                 .into_diagnostic()?;
 
             // Determine if we're in the dependencies workspace
-            let in_workspace = toolchain.in_dependencies_workspace(&output, &project.root)?;
+            let in_workspace = toolchain.in_dependencies_workspace(&output, target_root)?;
 
             // If not in the dependencies workspace (if there is one),
             // or is a stand-alone project with its own lockfile,
             // we must extract the project ID and source (root)
             let (project_id, root) = if in_workspace {
                 (None, rel_root)
-            } else {
+            } else if let Some(project) = project {
                 (Some(project.id.clone()), project.source.clone())
+            } else {
+                (None, RelativePathBuf::new())
             };
 
             let setup_env_index = self
-                .setup_environment(spec, &root, project_id.as_ref().map(|_| project))
+                .internal_setup_environment(spec, &root, project_id.as_ref().and(project))
                 .await?;
 
             // Only create this action if the plugin supports it
@@ -412,6 +413,16 @@ impl<'query> ActionGraphBuilder<'query> {
     }
 
     #[instrument(skip(self))]
+    pub async fn install_dependencies(
+        &mut self,
+        spec: &ToolchainSpec,
+        project: &Project,
+    ) -> miette::Result<Option<NodeIndex>> {
+        self.internal_install_dependencies(spec, Some(project))
+            .await
+    }
+
+    #[instrument(skip(self))]
     pub async fn install_dependencies_by_project(
         &mut self,
         project: &Project,
@@ -435,6 +446,63 @@ impl<'query> ActionGraphBuilder<'query> {
         }
 
         Ok(indexes)
+    }
+
+    #[instrument(skip(self))]
+    pub async fn install_dependencies_root(
+        &mut self,
+        spec: &ToolchainSpec,
+    ) -> miette::Result<Option<NodeIndex>> {
+        // Explicitly disabled
+        if spec.is_system()
+            || !self.options.install_dependencies.is_enabled(&spec.id)
+            || self
+                .app_context
+                .toolchains_config
+                .get_plugin_config(&spec.id)
+                .is_some_and(|cfg| !cfg.install_dependencies)
+        {
+            return Ok(None);
+        }
+
+        // Only insert actions if the dependencies root is the workspace root
+        if self
+            .locate_dependencies_root(spec, None)
+            .await?
+            .root
+            .is_none_or(|root| root != self.app_context.workspace_root)
+        {
+            return Ok(None);
+        }
+
+        self.internal_install_dependencies(spec, None).await
+    }
+
+    async fn locate_dependencies_root(
+        &self,
+        spec: &ToolchainSpec,
+        project: Option<&Project>,
+    ) -> miette::Result<LocateDependenciesRootOutput> {
+        let toolchain_registry = &self.app_context.toolchain_registry;
+        let toolchain = toolchain_registry.load(&spec.id).await?;
+
+        let output = toolchain
+            .locate_dependencies_root(match project {
+                Some(project) => LocateDependenciesRootInput {
+                    context: toolchain_registry.create_context(),
+                    starting_dir: toolchain.to_virtual_path(&project.root),
+                    toolchain_config: toolchain_registry
+                        .create_merged_config(&toolchain.id, &project.config),
+                },
+                None => LocateDependenciesRootInput {
+                    context: toolchain_registry.create_context(),
+                    starting_dir: toolchain.to_virtual_path(&self.app_context.workspace_root),
+                    toolchain_config: toolchain_registry.create_config(&toolchain.id),
+                },
+            })
+            .await?;
+
+        Ok(output)
     }
 
     #[instrument(skip(self))]
@@ -1069,7 +1137,7 @@ impl<'query> ActionGraphBuilder<'query> {
     }
 
     #[instrument(skip(self))]
-    pub async fn setup_environment(
+    async fn internal_setup_environment(
         &mut self,
         spec: &ToolchainSpec,
         root: &WorkspaceRelativePathBuf,
@@ -1102,6 +1170,44 @@ impl<'query> ActionGraphBuilder<'query> {
         self.link_first_requirement(index, vec![setup_toolchain_index, sync_workspace_index])?;
 
         Ok(Some(index))
+    }
+
+    #[instrument(skip(self))]
+    pub async fn setup_environment(
+        &mut self,
+        spec: &ToolchainSpec,
+        root: &WorkspaceRelativePathBuf,
+        project: &Project,
+    ) -> miette::Result<Option<NodeIndex>> {
+        self.internal_setup_environment(spec, root, Some(project))
+            .await
+    }
+
+    /// Setup the environment in the workspace root, without an associated
+    /// project. Unlike the project-based flow, this inserts no actions at
+    /// all unless the located dependencies root is the workspace root.
+    #[instrument(skip(self))]
+    pub async fn setup_environment_root(
+        &mut self,
+        spec: &ToolchainSpec,
+    ) -> miette::Result<Option<NodeIndex>> {
+        // Explicitly disabled
+        if !self.options.setup_environment.is_enabled(&spec.id) || spec.is_system() {
+            return Ok(None);
+        }
+
+        // Only insert actions if the dependencies root is the workspace root
+        if self
+            .locate_dependencies_root(spec, None)
+            .await?
+            .root
+            .is_none_or(|root| root != self.app_context.workspace_root)
+        {
+            return Ok(None);
+        }
+
+        self.internal_setup_environment(spec, &WorkspaceRelativePathBuf::new(), None)
+            .await
     }
 
     #[instrument(skip(self))]

--- a/crates/action-graph/src/action_graph_builder.rs
+++ b/crates/action-graph/src/action_graph_builder.rs
@@ -486,6 +486,12 @@ impl<'query> ActionGraphBuilder<'query> {
         let toolchain_registry = &self.app_context.toolchain_registry;
         let toolchain = toolchain_registry.load(&spec.id).await?;
 
+        // Toolchain does not support locating a root, so return
+        // an empty output instead of failing the function call
+        if !toolchain.supports_tier_2().await {
+            return Ok(LocateDependenciesRootOutput::default());
+        }
+
         let output = toolchain
             .locate_dependencies_root(match project {
                 Some(project) => LocateDependenciesRootInput {

--- a/crates/action-graph/tests/action_graph_builder_test.rs
+++ b/crates/action-graph/tests/action_graph_builder_test.rs
@@ -719,6 +719,26 @@ mod action_graph_builder {
         }
 
         #[tokio::test(flavor = "multi_thread")]
+        async fn doesnt_graph_if_tier1() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec(1);
+
+            let index = builder.install_dependencies_root(&spec).await.unwrap();
+
+            assert!(index.is_none());
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(topo(graph), vec![]);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
         async fn doesnt_add_if_disabled() {
             let sandbox = create_sandbox("projects");
             let mut container = ActionGraphContainer::new(sandbox.path());
@@ -3381,6 +3401,252 @@ mod action_graph_builder {
         }
     }
 
+    mod setup_env {
+        use super::*;
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn graphs_if_supported() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec_with_name("tc-tier2-setup-env");
+
+            let project = wg.get_project("bar").unwrap();
+            let index = builder
+                .setup_environment(&spec, &project.source, &project)
+                .await
+                .unwrap();
+
+            assert!(index.is_some());
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(
+                topo(graph),
+                vec![
+                    ActionNode::sync_workspace(),
+                    ActionNode::setup_environment(SetupEnvironmentNode {
+                        project_id: Some(Id::raw("bar")),
+                        root: WorkspaceRelativePathBuf::from("bar"),
+                        toolchain_id: spec.id,
+                    })
+                ]
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn graphs_multiple_projects() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec_with_name("tc-tier2-setup-env");
+
+            let bar = wg.get_project("bar").unwrap();
+            builder
+                .setup_environment(&spec, &bar.source, &bar)
+                .await
+                .unwrap();
+
+            let baz = wg.get_project("baz").unwrap();
+            builder
+                .setup_environment(&spec, &baz.source, &baz)
+                .await
+                .unwrap();
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(
+                topo(graph),
+                vec![
+                    ActionNode::sync_workspace(),
+                    ActionNode::setup_environment(SetupEnvironmentNode {
+                        project_id: Some(Id::raw("bar")),
+                        root: WorkspaceRelativePathBuf::from("bar"),
+                        toolchain_id: spec.id.clone(),
+                    }),
+                    ActionNode::setup_environment(SetupEnvironmentNode {
+                        project_id: Some(Id::raw("baz")),
+                        root: WorkspaceRelativePathBuf::from("baz"),
+                        toolchain_id: spec.id,
+                    })
+                ]
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn ignores_dupes() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec_with_name("tc-tier2-setup-env");
+
+            let project = wg.get_project("bar").unwrap();
+            let index1 = builder
+                .setup_environment(&spec, &project.source, &project)
+                .await
+                .unwrap();
+            let index2 = builder
+                .setup_environment(&spec, &project.source, &project)
+                .await
+                .unwrap();
+
+            assert_eq!(index1, index2);
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(
+                topo(graph),
+                vec![
+                    ActionNode::sync_workspace(),
+                    ActionNode::setup_environment(SetupEnvironmentNode {
+                        project_id: Some(Id::raw("bar")),
+                        root: WorkspaceRelativePathBuf::from("bar"),
+                        toolchain_id: spec.id,
+                    })
+                ]
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn doesnt_graph_if_unsupported() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            // Supports tier 2 but not `setup_environment`
+            let spec = create_tier_spec(2);
+
+            let project = wg.get_project("bar").unwrap();
+            let index = builder
+                .setup_environment(&spec, &project.source, &project)
+                .await
+                .unwrap();
+
+            assert!(index.is_none());
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(topo(graph), vec![]);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn doesnt_add_if_disabled() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container
+                .create_builder_with_options(
+                    wg.clone(),
+                    ActionGraphBuilderOptions {
+                        setup_environment: false.into(),
+                        ..Default::default()
+                    },
+                )
+                .await;
+
+            let spec = create_tier_spec_with_name("tc-tier2-setup-env");
+
+            let project = wg.get_project("bar").unwrap();
+            builder
+                .setup_environment(&spec, &project.source, &project)
+                .await
+                .unwrap();
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(topo(graph), vec![]);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn doesnt_add_if_not_listed() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container
+                .create_builder_with_options(
+                    wg.clone(),
+                    ActionGraphBuilderOptions {
+                        setup_environment: PipelineActionSwitch::Only(vec![Id::raw("rust")]),
+                        ..Default::default()
+                    },
+                )
+                .await;
+
+            let spec = create_tier_spec_with_name("tc-tier2-setup-env");
+
+            let project = wg.get_project("bar").unwrap();
+            builder
+                .setup_environment(&spec, &project.source, &project)
+                .await
+                .unwrap();
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(topo(graph), vec![]);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn adds_if_listed() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container
+                .create_builder_with_options(
+                    wg.clone(),
+                    ActionGraphBuilderOptions {
+                        setup_environment: PipelineActionSwitch::Only(vec![Id::raw(
+                            "tc-tier2-setup-env",
+                        )]),
+                        ..Default::default()
+                    },
+                )
+                .await;
+
+            let spec = create_tier_spec_with_name("tc-tier2-setup-env");
+
+            let project = wg.get_project("bar").unwrap();
+            builder
+                .setup_environment(&spec, &project.source, &project)
+                .await
+                .unwrap();
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(
+                topo(graph),
+                vec![
+                    ActionNode::sync_workspace(),
+                    ActionNode::setup_environment(SetupEnvironmentNode {
+                        project_id: Some(Id::raw("bar")),
+                        root: WorkspaceRelativePathBuf::from("bar"),
+                        toolchain_id: spec.id,
+                    })
+                ]
+            );
+        }
+    }
+
     mod setup_env_root {
         use super::*;
 
@@ -3446,6 +3712,26 @@ mod action_graph_builder {
 
             // Supports tier 2 but not `setup_environment`
             let spec = create_tier_spec(2);
+
+            let index = builder.setup_environment_root(&spec).await.unwrap();
+
+            assert!(index.is_none());
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(topo(graph), vec![]);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn doesnt_graph_if_tier1() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec(1);
 
             let index = builder.setup_environment_root(&spec).await.unwrap();
 

--- a/crates/action-graph/tests/action_graph_builder_test.rs
+++ b/crates/action-graph/tests/action_graph_builder_test.rs
@@ -529,6 +529,272 @@ mod action_graph_builder {
         }
     }
 
+    mod install_deps_root {
+        use super::*;
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn graphs_if_deps_root_is_workspace_root() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec(2);
+
+            let index = builder.install_dependencies_root(&spec).await.unwrap();
+
+            assert!(index.is_some());
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(
+                topo(graph),
+                vec![
+                    ActionNode::sync_workspace(),
+                    ActionNode::install_dependencies(InstallDependenciesNode {
+                        members: None,
+                        project_id: None,
+                        root: WorkspaceRelativePathBuf::new(),
+                        toolchain_id: spec.id,
+                    })
+                ]
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn graphs_setup_toolchain_if_tier3() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec(3);
+
+            builder.install_dependencies_root(&spec).await.unwrap();
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(
+                topo(graph),
+                vec![
+                    ActionNode::sync_workspace(),
+                    ActionNode::setup_proto(create_proto_version()),
+                    ActionNode::setup_toolchain(SetupToolchainNode {
+                        toolchain: spec.clone()
+                    }),
+                    ActionNode::install_dependencies(InstallDependenciesNode {
+                        members: None,
+                        project_id: None,
+                        root: WorkspaceRelativePathBuf::new(),
+                        toolchain_id: spec.id,
+                    })
+                ]
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn graphs_setup_env_chain_if_defined() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec_with_name("tc-tier2-setup-env");
+
+            builder.install_dependencies_root(&spec).await.unwrap();
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(
+                topo(graph),
+                vec![
+                    ActionNode::sync_workspace(),
+                    ActionNode::setup_environment(SetupEnvironmentNode {
+                        project_id: None,
+                        root: WorkspaceRelativePathBuf::new(),
+                        toolchain_id: spec.id.clone(),
+                    }),
+                    ActionNode::install_dependencies(InstallDependenciesNode {
+                        members: None,
+                        project_id: None,
+                        root: WorkspaceRelativePathBuf::new(),
+                        toolchain_id: spec.id,
+                    })
+                ]
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn graphs_members_if_in_deps_workspace() {
+            let sandbox = create_sandbox("dep-workspace");
+            let mut container = ActionGraphContainer::new(sandbox.path())
+                // Plugin matches based on cwd
+                .set_working_dir(sandbox.path().join("in"));
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec(2);
+
+            builder.install_dependencies_root(&spec).await.unwrap();
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(
+                topo(graph),
+                vec![
+                    ActionNode::sync_workspace(),
+                    ActionNode::install_dependencies(InstallDependenciesNode {
+                        members: Some(vec!["in".into()]),
+                        project_id: None,
+                        root: WorkspaceRelativePathBuf::new(),
+                        toolchain_id: spec.id,
+                    })
+                ]
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn dedupes_with_project_based_flow() {
+            let sandbox = create_sandbox("dep-workspace");
+            let mut container = ActionGraphContainer::new(sandbox.path())
+                // Plugin matches based on cwd
+                .set_working_dir(sandbox.path().join("in"));
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec(2);
+
+            let project = wg.get_project("in").unwrap();
+            let project_index = builder.install_dependencies(&spec, &project).await.unwrap();
+            let root_index = builder.install_dependencies_root(&spec).await.unwrap();
+
+            assert_eq!(project_index, root_index);
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(
+                topo(graph),
+                vec![
+                    ActionNode::sync_workspace(),
+                    ActionNode::install_dependencies(InstallDependenciesNode {
+                        members: Some(vec!["in".into()]),
+                        project_id: None,
+                        root: WorkspaceRelativePathBuf::new(),
+                        toolchain_id: spec.id,
+                    })
+                ]
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn doesnt_graph_if_deps_root_isnt_workspace_root() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path())
+                // Plugin matches based on cwd
+                .set_working_dir(sandbox.path().join("bar"));
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec(2);
+
+            let index = builder.install_dependencies_root(&spec).await.unwrap();
+
+            assert!(index.is_none());
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(topo(graph), vec![]);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn doesnt_add_if_disabled() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container
+                .create_builder_with_options(
+                    wg.clone(),
+                    ActionGraphBuilderOptions {
+                        install_dependencies: false.into(),
+                        ..Default::default()
+                    },
+                )
+                .await;
+
+            let spec = create_tier_spec(2);
+
+            builder.install_dependencies_root(&spec).await.unwrap();
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(topo(graph), vec![]);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn doesnt_add_if_disabled_in_config() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let spec = create_tier_spec(2);
+
+            container.mocker = container.mocker.update_toolchains_config(|cfg| {
+                if let Some(inner) = cfg.plugins.get_mut(&spec.id) {
+                    inner.install_dependencies = false;
+                }
+            });
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            builder.install_dependencies_root(&spec).await.unwrap();
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(topo(graph), vec![]);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn doesnt_add_if_not_listed() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container
+                .create_builder_with_options(
+                    wg.clone(),
+                    ActionGraphBuilderOptions {
+                        install_dependencies: PipelineActionSwitch::Only(vec![Id::raw("rust")]),
+                        ..Default::default()
+                    },
+                )
+                .await;
+
+            let spec = create_tier_spec(2);
+
+            builder.install_dependencies_root(&spec).await.unwrap();
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(topo(graph), vec![]);
+        }
+    }
+
     mod run_task {
         use super::*;
 
@@ -3112,6 +3378,109 @@ mod action_graph_builder {
 
             assert_eq!(context.primary_targets.len(), 2);
             assert_snapshot!(graph.to_dot());
+        }
+    }
+
+    mod setup_env_root {
+        use super::*;
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn graphs_if_deps_root_is_workspace_root() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec_with_name("tc-tier2-setup-env");
+
+            let index = builder.setup_environment_root(&spec).await.unwrap();
+
+            assert!(index.is_some());
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(
+                topo(graph),
+                vec![
+                    ActionNode::sync_workspace(),
+                    ActionNode::setup_environment(SetupEnvironmentNode {
+                        project_id: None,
+                        root: WorkspaceRelativePathBuf::new(),
+                        toolchain_id: spec.id,
+                    })
+                ]
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn doesnt_graph_if_deps_root_isnt_workspace_root() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path())
+                // Plugin matches based on cwd
+                .set_working_dir(sandbox.path().join("bar"));
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            let spec = create_tier_spec_with_name("tc-tier2-setup-env");
+
+            let index = builder.setup_environment_root(&spec).await.unwrap();
+
+            assert!(index.is_none());
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(topo(graph), vec![]);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn doesnt_graph_if_unsupported() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container.create_builder(wg.clone()).await;
+
+            // Supports tier 2 but not `setup_environment`
+            let spec = create_tier_spec(2);
+
+            let index = builder.setup_environment_root(&spec).await.unwrap();
+
+            assert!(index.is_none());
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(topo(graph), vec![]);
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn doesnt_add_if_disabled() {
+            let sandbox = create_sandbox("projects");
+            let mut container = ActionGraphContainer::new(sandbox.path());
+
+            let wg = container.create_workspace_graph().await;
+            let mut builder = container
+                .create_builder_with_options(
+                    wg.clone(),
+                    ActionGraphBuilderOptions {
+                        setup_environment: false.into(),
+                        ..Default::default()
+                    },
+                )
+                .await;
+
+            let spec = create_tier_spec_with_name("tc-tier2-setup-env");
+
+            builder.setup_environment_root(&spec).await.unwrap();
+
+            let (_, graph) = builder.build();
+
+            assert_snapshot!(graph.to_dot());
+            assert_eq!(topo(graph), vec![]);
         }
     }
 

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__dedupes_with_project_based_flow.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__dedupes_with_project_based_flow.snap
@@ -1,0 +1,9 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+    0 [ label="SyncWorkspace"]
+    1 [ label="InstallDependencies(tc-tier2)"]
+    1 -> 0 [ label="required"]
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__doesnt_add_if_disabled.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__doesnt_add_if_disabled.snap
@@ -1,0 +1,6 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__doesnt_add_if_disabled_in_config.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__doesnt_add_if_disabled_in_config.snap
@@ -1,0 +1,6 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__doesnt_add_if_not_listed.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__doesnt_add_if_not_listed.snap
@@ -1,0 +1,6 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__doesnt_graph_if_deps_root_isnt_workspace_root.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__doesnt_graph_if_deps_root_isnt_workspace_root.snap
@@ -1,0 +1,6 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__doesnt_graph_if_tier1.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__doesnt_graph_if_tier1.snap
@@ -1,0 +1,6 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__graphs_if_deps_root_is_workspace_root.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__graphs_if_deps_root_is_workspace_root.snap
@@ -1,0 +1,9 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+    0 [ label="SyncWorkspace"]
+    1 [ label="InstallDependencies(tc-tier2)"]
+    1 -> 0 [ label="required"]
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__graphs_members_if_in_deps_workspace.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__graphs_members_if_in_deps_workspace.snap
@@ -1,0 +1,9 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+    0 [ label="SyncWorkspace"]
+    1 [ label="InstallDependencies(tc-tier2)"]
+    1 -> 0 [ label="required"]
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__graphs_setup_env_chain_if_defined.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__graphs_setup_env_chain_if_defined.snap
@@ -1,0 +1,11 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+    0 [ label="SyncWorkspace"]
+    1 [ label="SetupEnvironment(tc-tier2-setup-env)"]
+    2 [ label="InstallDependencies(tc-tier2-setup-env)"]
+    1 -> 0 [ label="required"]
+    2 -> 1 [ label="required"]
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__graphs_setup_toolchain_if_tier3.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__install_deps_root__graphs_setup_toolchain_if_tier3.snap
@@ -1,0 +1,13 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+    0 [ label="SyncWorkspace"]
+    1 [ label="SetupProto(1.2.3)"]
+    2 [ label="SetupToolchain(tc-tier3:1.2.3)"]
+    3 [ label="InstallDependencies(tc-tier3)"]
+    2 -> 0 [ label="required"]
+    2 -> 1 [ label="required"]
+    3 -> 2 [ label="required"]
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__adds_if_listed.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__adds_if_listed.snap
@@ -1,0 +1,9 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+    0 [ label="SyncWorkspace"]
+    1 [ label="SetupEnvironment(tc-tier2-setup-env, bar)"]
+    1 -> 0 [ label="required"]
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__doesnt_add_if_disabled.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__doesnt_add_if_disabled.snap
@@ -1,0 +1,6 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__doesnt_add_if_not_listed.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__doesnt_add_if_not_listed.snap
@@ -1,0 +1,6 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__doesnt_graph_if_unsupported.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__doesnt_graph_if_unsupported.snap
@@ -1,0 +1,6 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__graphs_if_supported.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__graphs_if_supported.snap
@@ -1,0 +1,9 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+    0 [ label="SyncWorkspace"]
+    1 [ label="SetupEnvironment(tc-tier2-setup-env, bar)"]
+    1 -> 0 [ label="required"]
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__graphs_multiple_projects.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__graphs_multiple_projects.snap
@@ -1,0 +1,11 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+    0 [ label="SyncWorkspace"]
+    1 [ label="SetupEnvironment(tc-tier2-setup-env, bar)"]
+    2 [ label="SetupEnvironment(tc-tier2-setup-env, baz)"]
+    1 -> 0 [ label="required"]
+    2 -> 0 [ label="required"]
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__ignores_dupes.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env__ignores_dupes.snap
@@ -1,0 +1,9 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+    0 [ label="SyncWorkspace"]
+    1 [ label="SetupEnvironment(tc-tier2-setup-env, bar)"]
+    1 -> 0 [ label="required"]
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env_root__doesnt_add_if_disabled.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env_root__doesnt_add_if_disabled.snap
@@ -1,0 +1,6 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env_root__doesnt_graph_if_deps_root_isnt_workspace_root.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env_root__doesnt_graph_if_deps_root_isnt_workspace_root.snap
@@ -1,0 +1,6 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env_root__doesnt_graph_if_tier1.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env_root__doesnt_graph_if_tier1.snap
@@ -1,0 +1,6 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env_root__doesnt_graph_if_unsupported.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env_root__doesnt_graph_if_unsupported.snap
@@ -1,0 +1,6 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+}

--- a/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env_root__graphs_if_deps_root_is_workspace_root.snap
+++ b/crates/action-graph/tests/snapshots/action_graph_builder_test__action_graph_builder__setup_env_root__graphs_if_deps_root_is_workspace_root.snap
@@ -1,0 +1,9 @@
+---
+source: crates/action-graph/tests/action_graph_builder_test.rs
+expression: graph.to_dot()
+---
+digraph {
+    0 [ label="SyncWorkspace"]
+    1 [ label="SetupEnvironment(tc-tier2-setup-env)"]
+    1 -> 0 [ label="required"]
+}

--- a/crates/app/src/commands/setup.rs
+++ b/crates/app/src/commands/setup.rs
@@ -1,7 +1,6 @@
 use crate::helpers::run_action_pipeline;
 use crate::session::{MoonSession, SessionResult};
 use iocraft::prelude::element;
-use moon_action::ActionStatus;
 use moon_action_graph::ActionGraphBuilderOptions;
 use moon_console::ui::{Container, Notice, StyledText, Variant};
 use tracing::instrument;
@@ -12,7 +11,7 @@ pub async fn setup(session: MoonSession) -> SessionResult {
         .build_action_graph_with_options(ActionGraphBuilderOptions {
             // Only enable toolchain setup for this command
             install_dependencies: false.into(),
-            setup_environment: false.into(),
+            setup_environment: true.into(),
             setup_toolchains: true.into(),
             sync_projects: false.into(),
             sync_project_dependencies: false,
@@ -28,11 +27,15 @@ pub async fn setup(session: MoonSession) -> SessionResult {
 
     for toolchain_id in session.toolchains_config.plugins.keys() {
         if let Some(spec) = action_graph_builder.get_workspace_spec(toolchain_id) {
-            action_graph_builder.setup_toolchain(&spec, None).await?;
+            let index = action_graph_builder.setup_toolchain(&spec, None).await?;
 
-            if !spec.is_system() {
+            if index.is_none() {
+                continue;
+            } else if !spec.is_system() {
                 toolchain_count += 1;
             }
+
+            action_graph_builder.setup_environment_root(&spec).await?;
         }
     }
 
@@ -68,31 +71,12 @@ pub async fn setup(session: MoonSession) -> SessionResult {
     let results = run_action_pipeline(&session, action_context, action_graph).await?;
 
     // Analyze results and provide feedback
-    let passed_count = results
-        .iter()
-        .filter(|action| matches!(action.status, ActionStatus::Passed))
-        .count();
-    let skipped_count = results
-        .iter()
-        .filter(|action| {
-            matches!(
-                action.status,
-                ActionStatus::Skipped | ActionStatus::Cached | ActionStatus::CachedFromRemote
-            )
-        })
-        .count();
     let failed_count = results.iter().filter(|action| action.has_failed()).count();
 
     let message = if failed_count > 0 {
-        format!(
-            "Setup toolchains with {passed_count} passed, {skipped_count} skipped, and {failed_count} failed"
-        )
-    } else if passed_count == 1 {
-        format!("Setup {passed_count} toolchain successfully!")
-    } else if passed_count > 0 {
-        format!("Setup {passed_count} toolchains successfully!")
+        "Failed to setup toolchains!".to_string()
     } else {
-        "All toolchains are already up to date!".to_string()
+        "Setup toolchains successfully!".to_string()
     };
 
     // Return error code if any setup failed

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780975129,
-        "narHash": "sha256-428T1pLXnbVeUgZx2wWEkbvl3ZORjras34ANZ3ACp5A=",
+        "lastModified": 1785388444,
+        "narHash": "sha256-6gtZiMMyfgr1CHA5g6fXoIYkTngQWMm1wtp3gNtuqJU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fe64e6b409dc513274d2941f8da13bbd0fdcf44e",
+        "rev": "c5b112f74bdbf91c5afd2d3779d12989818c9e8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Adds workspace root level `setup_environment` and `install_dependencies` support to the action graph, and wires environment setup into `moon setup`.

## Action graph builder

- New `install_dependencies_root(spec)` and `setup_environment_root(spec)` methods that are not associated with a project. They locate the dependencies root starting from the workspace root (workspace-level toolchain config only), and only insert actions when the located root **is** the workspace root — otherwise they insert nothing at all (no `SyncWorkspace`/`SetupToolchain` side effects) and return `None`. Nested dependency roots are expected to be handled by their owning projects.
- Nodes are created with no `project_id` and an empty root, so they dedupe with project-based installs that resolve to the workspace root.
- Refactored the project-based flows into shared `internal_install_dependencies` / `internal_setup_environment` methods, with a shared `locate_dependencies_root` helper covering both project and workspace starting points.
- The locate helper returns an empty output for toolchains without tier 2 support, so root methods degrade to `None` instead of failing on a missing plugin function.

## Setup command

- `moon setup` now also sets up each configured toolchain's environment via `setup_environment_root`, when its dependency root is the workspace root.
- Simplified the summary output.

## Tests

- New `setup_env`, `install_deps_root`, and `setup_env_root` test suites for the builder, covering the root-matching gate, deps workspace members, dedupe with the project-based flow, tier gating, and pipeline action switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)