### PR TITLE
fix: prevent cache creation on completions

### DIFF
--- a/crates/app/src/session.rs
+++ b/crates/app/src/session.rs
@@ -502,10 +502,9 @@ impl AppSession for MoonSession {
         }
 
         // Ensure all in-flight storage tasks have finished
-        self.get_cache_engine()?
-            .storage
-            .wait_for_background_tasks()
-            .await?;
+        if let Some(engine) = self.cache_engine.get() {
+            engine.storage.wait_for_background_tasks().await?;
+        }
 
         // Ensure all child processes have finished
         ProcessRegistry::instance()

--- a/crates/cli/tests/completions_test.rs
+++ b/crates/cli/tests/completions_test.rs
@@ -1,0 +1,39 @@
+use moon_test_utils::create_empty_moon_sandbox;
+
+#[test]
+fn does_not_create_cache_directory() {
+    let sandbox = create_empty_moon_sandbox();
+    let cache_tag = sandbox.path().join(".moon/cache/CACHEDIR.TAG");
+
+    assert!(!cache_tag.exists());
+
+    sandbox
+        .run_bin(|cmd| {
+            cmd.arg("completions").arg("--shell").arg("bash");
+        })
+        .success();
+
+    assert!(
+        !cache_tag.exists(),
+        "moon completions must not create .moon/cache/CACHEDIR.TAG"
+    );
+}
+
+#[test]
+fn does_not_create_cache_directory_for_nushell() {
+    let sandbox = create_empty_moon_sandbox();
+    let cache_tag = sandbox.path().join(".moon/cache/CACHEDIR.TAG");
+
+    assert!(!cache_tag.exists());
+
+    sandbox
+        .run_bin(|cmd| {
+            cmd.arg("completions").arg("--shell").arg("nu");
+        })
+        .success();
+
+    assert!(
+        !cache_tag.exists(),
+        "moon completions nu must not create .moon/cache/CACHEDIR.TAG"
+    );
+}


### PR DESCRIPTION
.moon/cache was being created when generating completions