### PR TITLE
fix: Strip trailing separators from command working directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed an issue where commands executed by toolchain plugins at the workspace root would receive a
+  `PWD` environment variable with a trailing slash (an artifact of virtual path conversion). Shells
+  that validate `PWD` on startup, like nushell, refused to run, failing the command (#2676).
+
 ## 2.5.1
 
 #### 🐞 Fixes

--- a/crates/process/src/command.rs
+++ b/crates/process/src/command.rs
@@ -251,7 +251,16 @@ impl Command {
     }
 
     pub fn cwd<P: AsRef<OsStr>>(&mut self, dir: P) -> &mut Self {
-        self.cwd = Some(dir.as_ref().to_os_string());
+        // Normalize away trailing separators (a `Path::join("")` artifact
+        // of virtual path conversion), as the value is passed to the child
+        // process as `PWD`, which shells like nushell refuse to inherit
+        // when it contains trailing slashes
+        self.cwd = Some(
+            Path::new(dir.as_ref())
+                .components()
+                .collect::<PathBuf>()
+                .into_os_string(),
+        );
         self
     }
 

--- a/crates/process/tests/command_test.rs
+++ b/crates/process/tests/command_test.rs
@@ -139,6 +139,30 @@ mod paths {
     }
 }
 
+mod cwd {
+    use super::*;
+
+    // Trailing separators must be stripped, as the value is exported
+    // as `PWD`, which nushell refuses to inherit with them present
+    #[cfg(unix)]
+    #[test]
+    fn strips_trailing_separators() {
+        let mut command = Command::new("git");
+        command.cwd("/tmp/dir/");
+
+        assert_eq!(command.cwd.as_deref(), Some(OsStr::new("/tmp/dir")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn strips_trailing_separators() {
+        let mut command = Command::new("git");
+        command.cwd("C:\\tmp\\dir\\");
+
+        assert_eq!(command.cwd.as_deref(), Some(OsStr::new("C:\\tmp\\dir")));
+    }
+}
+
 mod bin_name {
     use super::*;
 

--- a/crates/process/tests/exec_command_test.rs
+++ b/crates/process/tests/exec_command_test.rs
@@ -202,6 +202,20 @@ mod child_env {
     }
 
     #[tokio::test]
+    async fn strips_trailing_separators_from_pwd() {
+        let dir = std::env::temp_dir().canonicalize().unwrap();
+        let mut dir_with_sep = dir.clone().into_os_string();
+        dir_with_sep.push("/");
+
+        let mut command = create_command(r#"printf "$PWD""#);
+        command.cwd(dir_with_sep);
+
+        let output = command.exec_capture_output().await.unwrap();
+
+        assert_eq!(output.stdout, dir.as_os_str().as_encoded_bytes());
+    }
+
+    #[tokio::test]
     async fn prepends_lookup_paths() {
         let mut command = create_command(r#"printf "$PATH""#);
         command.prepend_paths(["/moon-test-fake-path"]);


### PR DESCRIPTION
Fixes #2676.

Commands executed by toolchain plugins with their `cwd` set to the workspace root receive a `PWD` environment variable with a trailing slash (`/Users/me/repo/`). The slash is an artifact of the virtual↔real path round-trip in warpgate: converting a path that is exactly a mapped prefix strips to an empty relative path, and `Path::join("")` appends a separator. Since moon wraps commands in the user's `$SHELL`, users on nushell get a hard failure — nu validates the inherited `$env.PWD` on startup and rejects trailing slashes, so e.g. `bun install` exits 1 before running.

### Changes

- `Command::cwd()` now normalizes the path via `Path::components()`, which drops trailing separators (and redundant ones). This is the single place `cwd` is set, so it covers the `PWD` env var, `current_dir`, and all other consumers, and protects against any plugin-supplied path regardless of the warpgate version in use.
- Added a unit test for the setter (unix and windows variants) and an end-to-end test asserting the child process observes `$PWD` without a trailing separator.
- Added a changelog entry.

The root cause is also fixed upstream in warpgate (moonrepo/proto#1085); this change stands on its own as a defensive guarantee at the process boundary.
