### PR TITLE
fix(config): accept multi-comparator versionConstraint ranges

### DIFF
--- a/crates/app/src/commands/upgrade.rs
+++ b/crates/app/src/commands/upgrade.rs
@@ -17,7 +17,7 @@ use starbase_utils::{fs, net};
 use std::env::{self, consts};
 use std::path::{Path, PathBuf};
 use tracing::{debug, instrument};
-use version_spec::{Requirement, Version};
+use version_spec::{Range, Version};
 
 pub fn is_musl() -> bool {
     match std::process::Command::new("ldd").arg("--version").output() {
@@ -287,7 +287,7 @@ fn update_constraint(session: &MoonSession, version: &Version) -> miette::Result
 
         let mut config: PartialWorkspaceConfig = read_config_based_on_extension(&file)?;
 
-        if let Ok(req) = Requirement::parse(format!("^{version}")) {
+        if let Ok(req) = Range::parse(format!("^{version}")) {
             config.version_constraint = Some(req);
 
             write_config_based_on_extension(&file, config)?;

--- a/crates/app/src/systems/analyze.rs
+++ b/crates/app/src/systems/analyze.rs
@@ -2,7 +2,7 @@ use crate::app_error::AppError;
 use moon_env_var::GlobalEnvBag;
 use moon_vcs::BoxedVcs;
 use tracing::instrument;
-use version_spec::{MatchesVersion, Requirement, Version};
+use version_spec::{MatchesVersion, Range, Version};
 
 #[instrument(skip_all)]
 pub async fn extract_repo_info(vcs: &BoxedVcs) -> miette::Result<()> {
@@ -19,10 +19,7 @@ pub async fn extract_repo_info(vcs: &BoxedVcs) -> miette::Result<()> {
 }
 
 #[instrument]
-pub fn validate_version_constraint(
-    constraint: &Requirement,
-    version: &Version,
-) -> miette::Result<()> {
+pub fn validate_version_constraint(constraint: &Range, version: &Version) -> miette::Result<()> {
     if !constraint.matches(version) {
         return Err(AppError::InvalidMoonVersion {
             actual: version.to_string(),

--- a/crates/cli/tests/misc_test.rs
+++ b/crates/cli/tests/misc_test.rs
@@ -1,5 +1,5 @@
 use moon_test_utils::{create_empty_moon_sandbox, create_moon_sandbox, predicates::prelude::*};
-use proto_core::Requirement;
+use proto_core::Range;
 use std::fs;
 
 mod cli {
@@ -10,7 +10,7 @@ mod cli {
         let sandbox = create_empty_moon_sandbox();
 
         sandbox.update_workspace_config(|config| {
-            config.version_constraint = Some(Requirement::parse(">=1000.0.0").unwrap());
+            config.version_constraint = Some(Range::parse(">=1000.0.0").unwrap());
         });
 
         sandbox

--- a/crates/config/src/workspace_config.rs
+++ b/crates/config/src/workspace_config.rs
@@ -4,7 +4,7 @@ use crate::{config_enum, config_struct, config_unit_enum};
 use moon_common::Id;
 use rustc_hash::FxHashMap;
 use schematic::{Config, ConfigEnum, PathSegment, ValidateError, env, validate};
-use version_spec::Requirement;
+use version_spec::Range;
 
 // We can't use serde based types in the enum below to handle validation,
 // as serde fails to parse correctly. So we must manually validate here.
@@ -199,6 +199,6 @@ config_struct!(
 
         /// Requires a specific version of the `moon` binary.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub version_constraint: Option<Requirement>,
+        pub version_constraint: Option<Range>,
     }
 );

--- a/crates/config/tests/workspace_config_test.rs
+++ b/crates/config/tests/workspace_config_test.rs
@@ -12,7 +12,7 @@ use schematic::ConfigLoader as BaseLoader;
 use starbase_sandbox::{create_empty_sandbox, create_sandbox};
 use std::path::Path;
 use utils::*;
-use version_spec::Version;
+use version_spec::{MatchesVersion, Version};
 
 const FILENAME: &str = ".moon/workspace.yml";
 
@@ -821,11 +821,66 @@ vcs:
         use super::*;
 
         #[test]
-        #[should_panic(expected = "Failed to parse a version requirement")]
+        #[should_panic(expected = "Failed to parse a version range")]
         fn errors_on_invalid_req() {
             test_load_config(FILENAME, "versionConstraint: '@1.0.0'", |path| {
                 load_config_from_root(path)
             });
+        }
+
+        #[test]
+        fn supports_multiple_comparators() {
+            let config = test_load_config(FILENAME, "versionConstraint: '>=2.4.6, <3'", |path| {
+                load_config_from_root(path)
+            });
+
+            let constraint = config.version_constraint.unwrap();
+
+            assert!(constraint.matches(&Version::parse("2.5.0").unwrap()));
+            assert!(!constraint.matches(&Version::parse("2.4.5").unwrap()));
+            assert!(!constraint.matches(&Version::parse("3.0.0").unwrap()));
+        }
+
+        #[test]
+        fn supports_range_syntax() {
+            for value in [
+                "1.2.3",
+                "=1.2.3",
+                ">=1.2.3",
+                "^1.2",
+                "~1",
+                "*",
+                ">=2.4.6, <3",
+                ">=2.4.6 <3",
+                ">=2.4.6 && <3",
+                "^1 || ^2",
+                "1.2.3 - 2.3.4",
+            ] {
+                let config = test_load_config(
+                    FILENAME,
+                    &format!("versionConstraint: '{value}'"),
+                    load_config_from_root,
+                );
+
+                assert!(
+                    config.version_constraint.is_some(),
+                    "expected `{value}` to be accepted"
+                );
+            }
+        }
+
+        #[test]
+        fn errors_on_invalid_range_syntax() {
+            for value in ["@1.0.0", ">=1.2.3, ", "1.2.3 ||", "><1.2.3"] {
+                let sandbox = create_empty_sandbox();
+
+                sandbox.create_file(FILENAME, format!("versionConstraint: '{value}'"));
+
+                assert!(
+                    load_config_from_root(sandbox.path()).is_err(),
+                    "expected `{value}` to be rejected"
+                );
+            }
         }
     }
 

--- a/packages/types/src/workspace-config.ts
+++ b/packages/types/src/workspace-config.ts
@@ -641,7 +641,7 @@ export interface VcsConfig {
 	sync?: boolean;
 }
 
-export type Requirement = string;
+export type Range = string;
 
 /**
  * Configures all aspects of the moon workspace.
@@ -729,7 +729,7 @@ export interface WorkspaceConfig {
 	 */
 	vcs: VcsConfig;
 	/** Requires a specific version of the `moon` binary. */
-	versionConstraint?: Requirement | null;
+	versionConstraint?: Range | null;
 }
 
 /** Configures aspects of the content-addressable storage (CAS) cache. */
@@ -1407,5 +1407,5 @@ export interface PartialWorkspaceConfig {
 	 */
 	vcs?: PartialVcsConfig | null;
 	/** Requires a specific version of the `moon` binary. */
-	versionConstraint?: Requirement | null;
+	versionConstraint?: Range | null;
 }


### PR DESCRIPTION
Type versionConstraint as version_spec::Range instead of version_spec::Requirement.

A Requirement holds one operator and one version, so a value such as ">=2.4.6, <3" fails to parse and blocks every command at config load. A Range holds a list of clauses and accepts ",", a space, " && ", " || ", and hyphenated bounds. Range is the version_spec equivalent of the semver::VersionReq that the field used before 2.5.0.

Range already implements MatchesVersion, Display, TryFrom<String>, and Schematic, so this is a type substitution. Invalid values such as "@1.0.0" are still rejected. The parse error for an invalid value now reads "Failed to parse a version range".