### PR TITLE
fix: scope plugin commands to source toolchain

### DIFF
--- a/crates/actions/src/actions/install_dependencies.rs
+++ b/crates/actions/src/actions/install_dependencies.rs
@@ -184,6 +184,7 @@ pub async fn install_dependencies(
     let options = ExecCommandOptions {
         project,
         prefix: action.get_prefix().into(),
+        toolchain_id: Some(toolchain.id.clone()),
         working_dir: Some(deps_root),
         on_exec: Some(Arc::new(move |cmd, attempts| {
             handle_on_exec(&console, cmd, attempts)

--- a/crates/actions/src/actions/setup_environment.rs
+++ b/crates/actions/src/actions/setup_environment.rs
@@ -131,6 +131,7 @@ pub async fn setup_environment(
             ExecCommandOptions {
                 project,
                 prefix: action.get_prefix().into(),
+                toolchain_id: None,
                 working_dir: Some(node.root.to_logical_path(&app_context.workspace_root)),
                 on_exec: Some(Arc::new(move |cmd, attempts| {
                     handle_on_exec(&app_context.console, cmd, attempts)

--- a/crates/actions/src/plugins/commands.rs
+++ b/crates/actions/src/plugins/commands.rs
@@ -58,6 +58,7 @@ pub struct ExecCommandOptions {
     pub on_exec: Option<OnExecFn>,
     pub prefix: String,
     pub project: Option<Arc<Project>>,
+    pub toolchain_id: Option<Id>,
     pub working_dir: Option<PathBuf>,
 }
 
@@ -70,8 +71,18 @@ async fn internal_exec_plugin_command(
     let input = &command.command;
 
     let mut cmd = AugmentedCommand::from_input(&app_context, GlobalEnvBag::instance(), input);
-    cmd.inherit_from_plugins(options.project.as_deref(), None)
+
+    if let Some(toolchain_id) = &options.toolchain_id {
+        cmd.inherit_from_plugins_for_toolchains(
+            vec![toolchain_id.to_owned()],
+            options.project.as_deref(),
+            None,
+        )
         .await?;
+    } else {
+        cmd.inherit_from_plugins(options.project.as_deref(), None)
+            .await?;
+    }
 
     if let Some(cwd) = input.cwd.as_deref() {
         cmd.cwd(cwd);
@@ -231,8 +242,12 @@ pub async fn exec_plugin_commands(
     toolchain_id: &str,
     app_context: Arc<AppContext>,
     commands: Vec<ExecCommand>,
-    options: ExecCommandOptions,
+    mut options: ExecCommandOptions,
 ) -> miette::Result<Vec<Operation>> {
+    let toolchain_id = Id::new(toolchain_id)?;
+
+    options.toolchain_id = Some(toolchain_id.clone());
+
     let mut serial = vec![];
     let mut parallel = vec![];
     let mut ops = vec![];
@@ -269,7 +284,7 @@ pub async fn exec_plugin_commands(
 
     // Inherit toolchain ID
     for op in &mut ops {
-        op.plugin = Some(Id::new(toolchain_id)?);
+        op.plugin = Some(toolchain_id.clone());
     }
 
     Ok(ops)

--- a/crates/actions/tests/install_dependencies_test.rs
+++ b/crates/actions/tests/install_dependencies_test.rs
@@ -69,6 +69,25 @@ mod install_dependencies {
 
     #[serial_test::serial]
     #[tokio::test(flavor = "multi_thread")]
+    async fn does_not_augment_commands_with_unrelated_toolchains() {
+        let (_sandbox, ws) = create_workspace();
+        let ws = ws.update_toolchains_config(|config| {
+            config
+                .plugins
+                .get_mut(&Id::raw("tc-tier2-reqs"))
+                .unwrap()
+                .config
+                .insert("testExtendCommandFailure".into(), JsonValue::Bool(true));
+        });
+
+        let (action, status) = run_action(&ws).await;
+
+        assert_eq!(status, ActionStatus::Passed);
+        assert_eq!(count_execs(&action), 1);
+    }
+
+    #[serial_test::serial]
+    #[tokio::test(flavor = "multi_thread")]
     async fn does_not_dedupe_on_first_install() {
         let (_sandbox, ws) = create_workspace();
 

--- a/crates/app/src/commands/docker/prune.rs
+++ b/crates/app/src/commands/docker/prune.rs
@@ -202,6 +202,7 @@ impl PruneWorkflow {
                             &ExecCommandOptions {
                                 project: in_project,
                                 prefix: "prune-docker".into(),
+                                toolchain_id: Some(toolchain.id.clone()),
                                 working_dir: Some(workspace.output.root),
                                 on_exec: None,
                             },

--- a/crates/process-augment/src/augmented_command.rs
+++ b/crates/process-augment/src/augmented_command.rs
@@ -195,6 +195,23 @@ impl<'app> AugmentedCommand<'app> {
         task: Option<&Task>,
     ) -> miette::Result<()> {
         let toolchain_ids = self.get_toolchain_ids(project, task);
+
+        self.inherit_from_plugins_for_toolchains(toolchain_ids, project, task)
+            .await
+    }
+
+    /// Inherit command augmentations from an explicit set of toolchains.
+    ///
+    /// Plugin-generated commands may run at a shared dependencies workspace
+    /// root that is not owned by a single project. In this case, deriving the
+    /// toolchains from the project/task context would incorrectly select every
+    /// configured workspace toolchain.
+    pub async fn inherit_from_plugins_for_toolchains(
+        &mut self,
+        toolchain_ids: Vec<Id>,
+        project: Option<&Project>,
+        task: Option<&Task>,
+    ) -> miette::Result<()> {
         let current_dir = project
             .map(|p| &p.root)
             .unwrap_or(&self.context.working_dir);
@@ -315,7 +332,8 @@ impl<'app> AugmentedCommand<'app> {
             }
         }
 
-        self.inherit_from_toolchains(project, task).await?;
+        self.inherit_from_toolchains_with_ids(&toolchain_ids, project)
+            .await?;
 
         Ok(())
     }
@@ -326,6 +344,16 @@ impl<'app> AugmentedCommand<'app> {
         task: Option<&Task>,
     ) -> miette::Result<()> {
         let toolchain_ids = self.get_toolchain_ids(project, task);
+
+        self.inherit_from_toolchains_with_ids(&toolchain_ids, project)
+            .await
+    }
+
+    async fn inherit_from_toolchains_with_ids(
+        &mut self,
+        toolchain_ids: &[Id],
+        project: Option<&Project>,
+    ) -> miette::Result<()> {
         let mut map = FxHashMap::default();
 
         // First pass, gather workspace-level

--- a/wasm/tc-tier2-reqs/src/lib.rs
+++ b/wasm/tc-tier2-reqs/src/lib.rs
@@ -1,4 +1,5 @@
 use extism_pdk::*;
+use moon_pdk::plugin_err;
 use moon_pdk_api::*;
 
 pub use tc_tier2::*;
@@ -20,4 +21,22 @@ pub fn define_requirements(
             .and_then(|value| value.as_bool())
             .unwrap_or_default(),
     }))
+}
+
+#[plugin_fn]
+pub fn extend_command(
+    Json(input): Json<ExtendCommandInput>,
+) -> FnResult<Json<ExtendCommandOutput>> {
+    if input
+        .toolchain_config
+        .get("testExtendCommandFailure")
+        .and_then(|value| value.as_bool())
+        .unwrap_or_default()
+    {
+        return Err(plugin_err!(
+            "Unrelated toolchain extended a plugin-generated command (test)"
+        ));
+    }
+
+    Ok(Json(ExtendCommandOutput::default()))
 }

--- a/wasm/tc-tier2/src/lib.rs
+++ b/wasm/tc-tier2/src/lib.rs
@@ -1,5 +1,5 @@
 use extism_pdk::*;
-use moon_pdk::{get_plugin_id, VirtualPathExt};
+use moon_pdk::{VirtualPathExt, get_plugin_id};
 use moon_pdk_api::*;
 use std::fs;
 


### PR DESCRIPTION
might related to https://github.com/moonrepo/moon/issues/2691

## Summary

- preserve the originating toolchain when executing plugin-generated commands
- scope command hooks and executable-path augmentation to that toolchain
- add regression coverage proving unrelated toolchains are not invoked

## Root cause

Dependency install commands may run at a shared dependencies workspace root, so they do not always have a project or task context. Since Moon 2.5, `get_toolchain_ids(None, None)` returns every configured workspace toolchain for genuinely global commands.

The plugin command executor discarded the ID of the toolchain that generated a command and then inferred toolchains only from its project/task context. For a shared Go workspace command such as `go work sync`, both values were `None`, so Moon augmented it with Go, Node, Python, Rust, and every other configured toolchain. In a minimal Docker layer where only Go had been installed, resolving the unrelated Python command path failed before the Go command could run.

## Fix

Add the originating toolchain ID to `ExecCommandOptions` and pass it through the serial, parallel, cache, and retry execution paths. Plugin-generated commands use this explicit ID when applying toolchain hooks and executable paths. Commands without an explicit source retain the existing project/task/global inference behavior.

This preserves the all-toolchains behavior required by genuinely global commands while preventing a command generated by one toolchain from depending on unrelated toolchains. It also leaves toolchain setup parallelism unchanged.

## Validation

I replicate the issue locally and use patch moon which build successfully.
